### PR TITLE
Minimum coverage enforcement

### DIFF
--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -30,9 +30,11 @@ module Metasploit
       def self.full
         version = "#{MAJOR}.#{MINOR}.#{PATCH}"
 
+        # :nocov:
         if defined? PRERELEASE
           version = "#{version}-#{PRERELEASE}"
         end
+        # :nocov:
 
         version
       end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -12,6 +12,8 @@ module Metasploit
       MINOR = 61
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 4
+      # The pre-release version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'minimum-coverage-enforcement'
 
       #
       # Module Methods


### PR DESCRIPTION
MSP-12148

Instead of letting 'simplecov/defaults' at_exit handle the minimum_coverage check, manually do it in the 'coverage' task because the at_exit only works on unmerged results.

# Verification Steps

- [x] `bundle install`

## `rake spec coverage`
- [x] `rm -rf coverage`
- [x] `rake spec coverage`
- [x] `echo $?`  to print exit code
- [x] VERIFY no failures
- [x] VERIFY `Coverage (99.97%) is below the expected minimum coverage (100.00%).` is printed
- [x] VERIFY exit code is `2`

## `rake cucumber coverage`
- [x] `rm -rf coverage`
- [x] `rake cucumber coverage`
- [x] `echo $?`  to print exit code
- [x] VERIFY no failures
- [x] VERIFY `Coverage (99.39%) is below the expected minimum coverage (100.00%).` is printed
- [x] VERIFY exit code is `2`

## `rake cucumber spec coverage`
- [x] `rm -rf coverage`
- [x] `rake cucumber spec coverage`
- [x] `echo $?` to print exit code
- [x] VERIFY no failures.
- [x] VERIFY `Coverage (...) is below the expected minimum coverage (100.00%).` is NOT printed
- [x] VERIFY exit code is `0`

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/cache/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`
