### PR TITLE
Update Contributing Guidlines with better steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,17 @@ PRERELEASE = '<SUMMARY>'
 
 Make your changes or however many commits you like, committing each with `git commit`.
 
-### Pre-Pull Request Testing
+### Pre-Pull Request Steps
 
-1. Run specs one last time before opening the Pull Request: `rake spec`
-2. Verify there was no failures.
+#### Testing
+1. `rake cucumber spec coverage`
+2. Verify there were no failures.
+3. Verify there was 100% coverage.
+
+#### Documentation
+1. `rake yard`
+2. Verify there were no warnings.
+2. Verify there were no undocumented objects.
 
 ### Push
 
@@ -54,13 +61,18 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 
 ```
 # Verification Steps
-
+- [ ] `rm Gemfile.lock`
 - [ ] `bundle install`
 
-## `rake spec`
-- [ ] `rake spec`
+## Test coverage
+- [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-```
+- [ ] VERIFY 100% coverage
+
+## Documentation coverage
+- [ ] `rake yard`
+- [ ] VERIFY no warnings
+- [ ] VERIFY no undocumented objects
 
 You should also include at least one scenario to manually check the changes outside of specs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ When merging to `master`:
 ```
 # Post-merge Steps
 
-Perform these steps prior to pushing to master or the build will be broke on master.
+Perform these steps prior to pushing to master or the build will be broken on master.
 
 ## Version
 - [ ] Edit `lib/metasploit/cache/version.rb`
@@ -111,7 +111,7 @@ When merging to DESTINATION other than `master`:
 ```
 # Post-merge Steps
 
-Perform these steps prior to pushing to DESTINATION or the build will be broke on DESTINATION.
+Perform these steps prior to pushing to DESTINATION or the build will be broken on DESTINATION.
 
 ## Version
 - [ ] Edit `lib/metasploit/cache/version.rb`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 
 You should also include at least one scenario to manually check the changes outside of specs.
 
-* Add a Post-merge Steps comment
+* Add Post-merge Steps to the description comment
 
 The 'Post-merge Steps' are a reminder to the reviewer of the Pull Request of how to update the [`PRERELEASE`](lib/metasploit/cache/version.rb) so that [version_spec.rb](spec/lib/metasploit/cache/version.rb_spec.rb) passes on the target branch after the merge.
 

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,9 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 61
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 3
+      PATCH = 4
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-      PRERELEASE = 'full-coverage'
+      PRERELEASE = 'update-contributing'
 
       #
       # Module Methods


### PR DESCRIPTION
MSP-12186

Change Verification Steps to include `cucumber` and `coverage` for testing and `yard` for documentation.  Change wording so that all steps get added to the description comment and are trackable from referencing PRs and issues.

# Verification Steps
- [x] Read `CONTRIBUTING.md`
- [x] VERIFY no typos, grammatical errors, or unclear steps.

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/cache/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`