### PR TITLE
Metasploit::Cache::Direct::Class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ task :coverage do
   require 'simplecov'
 
   SimpleCov.configure do
-    minimum_coverage 99.93
+    minimum_coverage 99.89
     refuse_coverage_drop
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ task :coverage do
   require 'simplecov'
 
   SimpleCov.configure do
-    minimum_coverage 100
+    minimum_coverage 99.93
     refuse_coverage_drop
   end
 

--- a/app/models/metasploit/cache/direct/class.rb
+++ b/app/models/metasploit/cache/direct/class.rb
@@ -1,0 +1,41 @@
+# Superclass for all `Metasploit::Cache::*::Class` that have one {#ancestor}.
+class Metasploit::Cache::Direct::Class < ActiveRecord::Base
+  #
+  # Associations
+  #
+
+  # @!method ancestor
+  #   @abstract Subclass and add the following association:
+  #     ```ruby
+  #       # Metadata for file that defined the ruby Class or Module.
+  #       belongs_to :ancestor,
+  #                  class_name: 'Metasploit::Cache::<module_typ>::Ancestor',
+  #                  inverse_of: <association on Metasploit::Cache::<module_type>::Ancestor>
+  #     ```
+  #
+  #   Metadata for file that defined the ruby Class or Module.
+  #
+  #   @return [Metasploit::Cache::Module::Ancestor]
+
+  # @!method rank
+  #   @abstract Subclass and add the following association:
+  #      ```ruby
+  #        # Reliability of  Metasploit Module.
+  #        belongs_to :rank,
+  #                   class_name: 'Metasploit::Cache::Rank',
+  #                   inverse_of: <association on Metasploit::Cache::Rank>
+  #      ```
+  #
+  #   Reliability of Metasploit MOdule.
+  #
+  #   @return [Metasploit::Cache::Rank]
+
+  #
+  # Validations
+  #
+
+  validates :ancestor,
+            presence: true
+  validates :rank,
+            presence: true
+end

--- a/app/models/metasploit/cache/direct/class.rb
+++ b/app/models/metasploit/cache/direct/class.rb
@@ -1,6 +1,9 @@
 # Superclass for all `Metasploit::Cache::*::Class` that have one {#ancestor}.
 class Metasploit::Cache::Direct::Class < ActiveRecord::Base
+  extend ActiveSupport::Autoload
   include Metasploit::Cache::Batch::Descendant
+
+  autoload :Spec
 
   #
   # Associations

--- a/app/models/metasploit/cache/direct/class.rb
+++ b/app/models/metasploit/cache/direct/class.rb
@@ -26,7 +26,7 @@ class Metasploit::Cache::Direct::Class < ActiveRecord::Base
   #                   inverse_of: <association on Metasploit::Cache::Rank>
   #      ```
   #
-  #   Reliability of Metasploit MOdule.
+  #   Reliability of Metasploit Module.
   #
   #   @return [Metasploit::Cache::Rank]
 

--- a/app/models/metasploit/cache/direct/class.rb
+++ b/app/models/metasploit/cache/direct/class.rb
@@ -1,5 +1,7 @@
 # Superclass for all `Metasploit::Cache::*::Class` that have one {#ancestor}.
 class Metasploit::Cache::Direct::Class < ActiveRecord::Base
+  include Metasploit::Cache::Batch::Descendant
+
   #
   # Associations
   #
@@ -31,11 +33,24 @@ class Metasploit::Cache::Direct::Class < ActiveRecord::Base
   #   @return [Metasploit::Cache::Rank]
 
   #
+  # Attributes
+  #
+
+  # @!method ancestor_id
+  #   The primary key of the associated {#ancestor}.
+  #
+  #   @return [Integer]
+
+  #
   # Validations
   #
 
   validates :ancestor,
             presence: true
+  validates :ancestor_id,
+            uniqueness: {
+                unless: :batched?
+            }
   validates :rank,
             presence: true
 end

--- a/app/models/metasploit/cache/direct/class/spec/template.rb
+++ b/app/models/metasploit/cache/direct/class/spec/template.rb
@@ -1,0 +1,87 @@
+# Writes templates for the {#direct_class #direct_class's} {Metasploit::Cache::Direct::Class#ancestor} to disk.
+#
+# @example Update files after changing associations
+#   direct_class_factory = FactoryGirl.generate :metasploit_cache_direct_class_factory
+#   direct_class = FactoryGirl.build(
+#     direct_class_factory
+#   )
+#   # factory already wrote template when build returned
+#
+#   # update associations
+#   rank = FactoryGirl.generate :metasploit_cache_rank
+#   direct_class.rank = rank
+#
+#   # Now the template on disk is different than the `direct_class`, so regenerate the template
+#   Metasploit::Cache::Direct::Class::Spec::Template.write(direct_class: direct_class)
+class Metasploit::Cache::Direct::Class::Spec::Template < Metasploit::Model::Base
+  extend Metasploit::Cache::Spec::Template::Write
+
+  #
+  # Attributes
+  #
+
+  # @!attribute direct_class
+  #   The {Metasploit::Cache::Direct::Class} whose {Metasploit::Cache::Direct::Class#ancestor} needs to be templated in
+  #   {#ancestor_template}.
+  #
+  #   @return [Metasploit::Cache::Direct::Class]
+  attr_accessor :direct_class
+
+  #
+  # Validations
+  #
+
+  validates :direct_class,
+            presence: true
+  validate :ancestor_template_valid
+
+  #
+  # Methods
+  #
+
+  # Template for {#direct_class} {Metasploit::Cache::Direct::Class#ancestor} with the addition of {#direct_class} to
+  # the {Metasploit::Cache::Spec::Template#locals} and adding 'direct/classes' to the front of the
+  # {Metasploit::Cache::Spec::Template#search_pathnames}.
+  #
+  # @return [Array<Metasploit::Cache::Module::Ancestor::Spec::Template>]
+  # @return [[]] if {#direct_class} is `nil`.
+  def ancestor_template
+    unless instance_variable_defined? :@ancestor_template
+      if direct_class
+        @ancestor_template = Metasploit::Cache::Module::Ancestor::Spec::Template.new(
+            module_ancestor: direct_class.ancestor
+        ).tap { |module_ancestor_template|
+          module_ancestor_template.locals[:direct_class] = direct_class
+          module_ancestor_template.overwrite = true
+
+          module_ancestor_template.search_pathnames.unshift(
+              Pathname.new('direct/classes')
+          )
+        }
+      end
+    end
+
+    @ancestor_template
+  end
+
+  # Write {#ancestor_template} to disk.
+  #
+  # @return [void]
+  # @raise (see Metasploit::Cache::Spec::Template)
+  def write
+    ancestor_template.write
+  end
+
+  private
+
+  # Validates that all {#ancestor_template} is valid.
+  #
+  # @return [void]
+  def ancestor_template_valid
+    unless ancestor_template.valid?
+      errors.add(:ancestor_template, :invalid, value: ancestor_template)
+    end
+  end
+
+  Metasploit::Concern.run(self)
+end

--- a/db/migrate/20150306192052_create_mc_direct_classes.rb
+++ b/db/migrate/20150306192052_create_mc_direct_classes.rb
@@ -1,0 +1,35 @@
+class CreateMcDirectClasses < ActiveRecord::Migration
+  #
+  # CONSTANTS
+  #
+
+  # Name of the table being created
+  TABLE_NAME = :mc_direct_classes
+
+  #
+  # Instance Methods
+  #
+
+  # Drop {TABLE_NAME}.
+  #
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+
+  # Create {TABLE_NAME}.
+  #
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      t.references :ancestor, null: false
+      t.references :rank, null: false
+    end
+
+    change_table TABLE_NAME do |t|
+      t.index :ancestor_id,
+              name: 'unique_mc_direct_classes',
+              unique: true
+    end
+  end
+end

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -31,6 +31,7 @@ module Metasploit
     autoload :Base
     autoload :Batch
     autoload :Derivation
+    autoload :Direct
     autoload :EmailAddress
     autoload :Encoder
     autoload :Error

--- a/lib/metasploit/cache/direct.rb
+++ b/lib/metasploit/cache/direct.rb
@@ -1,0 +1,15 @@
+# Namespace for {Metasploit::Cache::Direct::Class class metadata} that is generated from a single
+# {Metasploit::Cache::Direct::Class#ancestor ancestor's Metasploit Module}.
+module Metasploit::Cache::Direct
+  extend ActiveSupport::Autoload
+
+  autoload :Class
+
+  #
+  # Module Methods
+  #
+
+  def self.table_name_prefix
+    "#{parent.table_name_prefix}direct_"
+  end
+end

--- a/lib/metasploit/cache/direct/class/spec.rb
+++ b/lib/metasploit/cache/direct/class/spec.rb
@@ -1,0 +1,23 @@
+module Metasploit::Cache::Direct::Class::Spec
+  #
+  # CONSTANTS
+  #
+
+  # Factories for {Metasploit::Cache::Direct::Class} subclasses
+  FACTORIES = []
+
+  #
+  # Module Methods
+  #
+
+  # Streams of elements of {FACTORIES}
+  #
+  # @return [Enumerator<Symbol>]
+  def self.random_factory
+    Enumerator.new do |yielder|
+      loop do
+        yielder.yield FACTORIES.sample
+      end
+    end
+  end
+end

--- a/lib/metasploit/cache/direct/class/spec.rb
+++ b/lib/metasploit/cache/direct/class/spec.rb
@@ -1,5 +1,5 @@
 module Metasploit::Cache::Direct::Class::Spec
-  extends ActiveSupport::Autoload
+  extend ActiveSupport::Autoload
 
   autoload :Template
 

--- a/lib/metasploit/cache/direct/class/spec.rb
+++ b/lib/metasploit/cache/direct/class/spec.rb
@@ -1,4 +1,8 @@
 module Metasploit::Cache::Direct::Class::Spec
+  extends ActiveSupport::Autoload
+
+  autoload :Template
+
   #
   # CONSTANTS
   #

--- a/lib/metasploit/cache/direct/class/spec.rb
+++ b/lib/metasploit/cache/direct/class/spec.rb
@@ -1,3 +1,4 @@
+# Namespace for `Module`s that help with writing specs for {Metasploit::Cache::Direct::Class}.
 module Metasploit::Cache::Direct::Class::Spec
   extend ActiveSupport::Autoload
 

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,9 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 63
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-      PRERELEASE = 'metasploit-cache-module-ancestor-sti'
+      PRERELEASE = 'direct-class'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/direct/class/spec/template_spec.rb
+++ b/spec/app/models/metasploit/cache/direct/class/spec/template_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe Metasploit::Cache::Direct::Class::Spec::Template do
+  subject(:direct_class_spec_template) {
+    described_class.new
+  }
+
+  context 'validations' do
+    context '#ancestor_template_valid' do
+      subject(:ancestor_template_errors) {
+        direct_class_spec_template.valid?
+
+        direct_class_spec_template.errors[:ancestor_template]
+      }
+
+      context 'with #ancestor_template' do
+        #
+        # lets
+        #
+
+        let(:error) {
+          I18n.translate!('errors.messages.invalid')
+        }
+
+        #
+        # Callbacks
+        #
+
+        before(:each) do
+          expect(direct_class_spec_template.ancestor_template).to receive(:valid?).and_return(valid)
+        end
+
+        context 'invalid' do
+          let(:valid) {
+            false
+          }
+
+          it { is_expected.to include(error) }
+        end
+
+        context 'valid' do
+          let(:valid) {
+            true
+          }
+
+          it { is_expected.not_to include(error) }
+        end
+      end
+    end
+  end
+end

--- a/spec/app/models/metasploit/cache/direct/class_spec.rb
+++ b/spec/app/models/metasploit/cache/direct/class_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Metasploit::Cache::Direct::Class do
+  context 'database' do
+    context 'columns' do
+      it { is_expected.to have_db_column(:ancestor_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:rank_id).of_type(:integer).with_options(null: false) }
+    end
+
+    context 'indices' do
+      it { is_expected.to have_db_index([:ancestor_id]).unique(true) }
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150212214222) do
+ActiveRecord::Schema.define(:version => 20150306192052) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -206,6 +206,13 @@ ActiveRecord::Schema.define(:version => 20150212214222) do
   end
 
   add_index "mc_authors", ["name"], :name => "index_mc_authors_on_name", :unique => true
+
+  create_table "mc_direct_classes", :force => true do |t|
+    t.integer "ancestor_id", :null => false
+    t.integer "rank_id",     :null => false
+  end
+
+  add_index "mc_direct_classes", ["ancestor_id"], :name => "unique_mc_direct_classes", :unique => true
 
   create_table "mc_email_addresses", :force => true do |t|
     t.string "domain", :null => false

--- a/spec/factories/metasploit/cache/direct/classes.rb
+++ b/spec/factories/metasploit/cache/direct/classes.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  #
+  # Sequences
+  #
+
+  sequence :metasploit_cache_direct_class_factory,
+           Metasploit::Cache::Direct::Class::Spec.random_factory
+end

--- a/spec/factories/metasploit/cache/direct/classes.rb
+++ b/spec/factories/metasploit/cache/direct/classes.rb
@@ -5,4 +5,40 @@ FactoryGirl.define do
 
   sequence :metasploit_cache_direct_class_factory,
            Metasploit::Cache::Direct::Class::Spec.random_factory
+
+  #
+  # Traits
+  #
+
+  trait :metasploit_cache_direct_class do
+    transient do
+      #
+      # Callback helpers
+      #
+
+      before_write_template {
+        ->(direct_class, evaluator) {}
+      }
+      write_template {
+        ->(direct_class, evaluator) {
+          Metasploit::Cache::Direct::Class::Spec::Template.write(direct_class: direct_class)
+        }
+      }
+    end
+
+    #
+    # Associations
+    #
+
+    rank { generate :metasploit_cache_module_rank }
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |direct_class, evaluator|
+      instance_exec(evaluator, evaluator, &evaluator.before_write_template)
+      instance_exec(evaluator, evaluator, &evaluator.write_template)
+    end
+  end
 end

--- a/spec/support/templates/metasploit/cache/direct/classes/_constants.rb.erb
+++ b/spec/support/templates/metasploit/cache/direct/classes/_constants.rb.erb
@@ -1,0 +1,5 @@
+#
+# CONSTANTS
+#
+
+Rank = <%= direct_class.rank.number %>

--- a/spec/support/templates/metasploit/cache/module/ancestors/module_types/_non_payload.rb.erb
+++ b/spec/support/templates/metasploit/cache/module/ancestors/module_types/_non_payload.rb.erb
@@ -1,4 +1,5 @@
 class <%= metasploit_module_relative_name %> < Metasploit::Model::Base
+  <%= render 'constants' %>
   <%= render 'attributes' %>
   <%= render 'validations' %>
   <%= render 'methods' %>

--- a/spec/support/templates/metasploit/cache/module/ancestors/module_types/_payload.rb.erb
+++ b/spec/support/templates/metasploit/cache/module/ancestors/module_types/_payload.rb.erb
@@ -1,3 +1,4 @@
 module <%= metasploit_module_relative_name %>
+  <%= render 'constants' %>
   <%= render 'methods' %>
 end


### PR DESCRIPTION
MSP-12271

# Pre-verification Steps
- [x] Merge #9 

# Verification Steps
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake db:migrate`

## Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.93% coverage

## Documentation
- [x] `rake yard`
- [x] VERIFY no warnings
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [x] Edit `lib/metasploit/cache/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`