### PR TITLE
Fix cucumber 2.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ group :test do
   gem 'builder'
   # simplecov test formatter and uploader for Coveralls.io
   gem 'coveralls', require: false
+  # Test shared examples and matchers.  Used with aruba
+  gem 'cucumber', '~> 2.0'
   # for cleaning the database before suite in case previous run was aborted without clean up
   gem 'database_cleaner' 
   # Engine tasks are loaded using railtie

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,12 +20,8 @@ require 'aruba/jruby'
 if defined? SimpleCov
   Before do |scenario|
     command_name = case scenario
-                   when Cucumber::Ast::Scenario, Cucumber::Ast::ScenarioOutline
+                   when Cucumber::RunningTestCase::Scenario
                      "#{scenario.feature.title} #{scenario.name}"
-                   when Cucumber::Ast::OutlineTable::ExampleRow
-                     scenario_outline = scenario.scenario_outline
-
-                     "#{scenario_outline.feature.title} #{scenario_outline.name} #{scenario.name}"
                    else
                      raise TypeError, "Don't know how to extract command name from #{scenario.class}"
                    end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,7 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 62
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 1
+      PATCH = 2
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'cucumber-2'
 
       #
       # Module Methods


### PR DESCRIPTION
MSP-12547

Cucumber was not pinned, so when cucumber 2.0 came out, @egypt (and newer travis-ci build) installed cucumber 2.0.0, which has an incompatible API for the scenario passed to `Before` blocks.  Cucumber is now pinned to `~> 2.0` and `features/support/env.rb` uses the new scenario class, `Cucumber::RunningTestCase::Scenario`.

# Verification Steps

## Cucumber version
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] VERIFY cucumber >= 2.0.0 is installed.

## Cucumber
- [x] `rake cucumber`
- [x] VERIFY no errors about `Cucumber::Ast`.

## Test coverage
- [x] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 100% coverage

## Documentation coverage
- [x] `rake yard`
- [x] VERIFY no warnings
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [x] Edit `lib/metasploit/cache/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`
