### PR TITLE
Metasploit::Cache::Post::Instance

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,8 +44,8 @@ task :coverage do
   # coverage differs by adapter because different adapters have different handling in Metasploit::Cache::Batched::Root
   # and its specs.
   minimum_coverage_by_adapter = {
-      'postgresql' => '99.68',
-      'sqlite3' => '99.64'
+      'postgresql' => 99.7,
+      'sqlite3' => 99.65
   }
 
   SimpleCov.configure do

--- a/app/models/metasploit/cache/post/class.rb
+++ b/app/models/metasploit/cache/post/class.rb
@@ -9,6 +9,12 @@ class Metasploit::Cache::Post::Class < Metasploit::Cache::Direct::Class
              class_name: 'Metasploit::Cache::Post::Ancestor',
              inverse_of: :post_class
 
+  # Instance level metadata for this post Metasploit Module
+  has_one :post_instance,
+          class_name: 'Metasploit::Cache::Post::Instance',
+          dependent: :destroy,
+          inverse_of: :post_class
+
   # Reliability of Metasploit Module.
   belongs_to :rank,
              class_name: 'Metasploit::Cache::Module::Rank',

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -23,6 +23,23 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #
   #   @return [Date]
 
+  # @!attribute name
+  #   The human-readable name of this post Metasploit Module.  This can be thought of as the title or summary of the
+  #   Metasploit Module.
+  #
+  #   @return [String]
+
+  # @!attribute post_class_id
+  #   The foreign key for the {#post_class} association.
+  #
+  #   @return [Integer]
+
+  # @!attribute privileged
+  #   Whether this post Metasploit Module requires privileged access on the remote machine.
+  #
+  #   @return [true] privileged access is required.
+  #   @return [false] privileged access is NOT required.
+
   #
   # Validations
   #
@@ -60,6 +77,25 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #
   #   @param disclosed_on [Date] The date the exploit exercised by this post Metasploit Module was disclosed to the
   #     public.
+  #   @return [void]
+
+  # @!method name=(name)
+  #   Sets {#name}.
+  #
+  #   name [String] The human-readable name of this post Metasploit Module.  This can be thought of as the
+  #     title or summary of the Metasploit Module.
+  #   @return [void]
+
+  # @!method post_class_id=(post_class_id)
+  #   Sets {#post_class_id} and causes cached of {#post_class} to be invalided and reloaded on next access.
+  #
+  #   @param post_class_id [Integer]
+  #   @return [void]
+
+  # @!method privileged=(privileged)
+  #   Sets {#privileged}.
+  #
+  #   @param priviliged [Boolean] `true` if privileged access is required; `false` if privileged access is not required.
   #   @return [void]
 
   Metasploit::Concern.run(self)

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -9,11 +9,18 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #
   #   @return [String]
 
+  # @!attribute disclosed_on
+  #   The public disclosure date of the exploit exercised by this post Metasploit Module.
+  #
+  #   @return [Date]
+
   #
   # Validations
   #
 
   validates :description,
+            presence: true
+  validates :disclosed_on,
             presence: true
 
   #
@@ -24,6 +31,13 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #   Sets {#description}.
   #
   #   @param description [String] The long-form human-readable description of this post Metasploit Module.
+  #   @return [void]
+
+  # @!method disclosed_on=(disclosed_on)
+  #   Sets {#disclosed_on}.
+  #
+  #   @param disclosed_on [Date] The date the exploit exercised by this post Metasploit Module was disclosed to the
+  #     public.
   #   @return [void]
 
   Metasploit::Concern.run(self)

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -37,6 +37,13 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
             presence: true
   validates :post_class_id,
             uniqueness: true
+  validates :privileged,
+            inclusion: {
+                in: [
+                    false,
+                    true
+                ]
+            }
 
   #
   # Instance Methods

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -1,6 +1,15 @@
 # Instance-level metadata for a post Metasploit Module.
 class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #
+  # Associations
+  #
+
+  # The class level metadata for this post Metasploit Module
+  belongs_to :post_class,
+             class_name: 'Metasploit::Cache::Post::Class',
+             inverse_of: :post_instance
+
+  #
   # Attributes
   #
 
@@ -24,6 +33,10 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
             presence: true
   validates :name,
             presence: true
+  validates :post_class,
+            presence: true
+  validates :post_class_id,
+            uniqueness: true
 
   #
   # Instance Methods

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -1,3 +1,4 @@
 # Instance-level metadata for a post Metasploit Module.
 class Metasploit::Cache::Post::Instance
+  Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -22,6 +22,8 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
             presence: true
   validates :disclosed_on,
             presence: true
+  validates :name,
+            presence: true
 
   #
   # Instance Methods

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -1,0 +1,3 @@
+# Instance-level metadata for a post Metasploit Module.
+class Metasploit::Cache::Post::Instance
+end

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -1,4 +1,30 @@
 # Instance-level metadata for a post Metasploit Module.
-class Metasploit::Cache::Post::Instance
+class Metasploit::Cache::Post::Instance < ActiveRecord::Base
+  #
+  # Attributes
+  #
+
+  # @!attribute description
+  #   The long-form human-readable description of this post Metasploit Module.
+  #
+  #   @return [String]
+
+  #
+  # Validations
+  #
+
+  validates :description,
+            presence: true
+
+  #
+  # Instance Methods
+  #
+
+  # @!method description=(description)
+  #   Sets {#description}.
+  #
+  #   @param description [String] The long-form human-readable description of this post Metasploit Module.
+  #   @return [void]
+
   Metasploit::Concern.run(self)
 end

--- a/db/migrate/20150428142801_create_mc_post_instances.rb
+++ b/db/migrate/20150428142801_create_mc_post_instances.rb
@@ -23,6 +23,8 @@ class CreateMcPostInstances < ActiveRecord::Migration
     create_table TABLE_NAME do |t|
       t.text :description,
              null: false
+      t.date :disclosed_on,
+             null: false
     end
   end
 end

--- a/db/migrate/20150428142801_create_mc_post_instances.rb
+++ b/db/migrate/20150428142801_create_mc_post_instances.rb
@@ -27,6 +27,18 @@ class CreateMcPostInstances < ActiveRecord::Migration
              null: false
       t.string :name,
                null: false
+
+      #
+      # References
+      #
+
+      t.references :post_class,
+                   null: false
+    end
+
+    change_table TABLE_NAME do |t|
+      t.index :post_class_id,
+              unique: true
     end
   end
 end

--- a/db/migrate/20150428142801_create_mc_post_instances.rb
+++ b/db/migrate/20150428142801_create_mc_post_instances.rb
@@ -25,6 +25,8 @@ class CreateMcPostInstances < ActiveRecord::Migration
              null: false
       t.date :disclosed_on,
              null: false
+      t.string :name,
+               null: false
     end
   end
 end

--- a/db/migrate/20150428142801_create_mc_post_instances.rb
+++ b/db/migrate/20150428142801_create_mc_post_instances.rb
@@ -27,6 +27,8 @@ class CreateMcPostInstances < ActiveRecord::Migration
              null: false
       t.string :name,
                null: false
+      t.boolean :privileged,
+                null: false
 
       #
       # References

--- a/db/migrate/20150428142801_create_mc_post_instances.rb
+++ b/db/migrate/20150428142801_create_mc_post_instances.rb
@@ -1,0 +1,28 @@
+class CreateMcPostInstances < ActiveRecord::Migration
+  #
+  # CONSTANTS
+  #
+  # Name of the table being created
+  TABLE_NAME = :mc_post_instances
+
+  #
+  # Instance Methods
+  #
+
+  # Drop {TABLE_NAME}.
+  #
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+
+  # Create {TABLE_NAME}.
+  #
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      t.text :description,
+             null: false
+    end
+  end
+end

--- a/lib/metasploit/cache/post.rb
+++ b/lib/metasploit/cache/post.rb
@@ -7,4 +7,15 @@ module Metasploit::Cache::Post
   autoload :Ancestor
   autoload :Class
   autoload :Instance
+
+  #
+  # Module Methods
+  #
+
+  # The prefix for ActiveRecord::Base subclass table names in this namespace.
+  #
+  # @return [String]
+  def self.table_name_prefix
+    "#{parent.table_name_prefix}post_"
+  end
 end

--- a/lib/metasploit/cache/post.rb
+++ b/lib/metasploit/cache/post.rb
@@ -1,8 +1,10 @@
 # Namespace for post Metasploit Module cache metadata, including from
-# {Metasploit::Cache::Post::Ancestor ancestors} and {Metasploit::Cache::Post::Class classes}.
+# {Metasploit::Cache::Post::Ancestor ancestors}, {Metasploit::Cache::Post::Class classes}, and
+# {Metasploit::Cache::Post::Instance instances}.
 module Metasploit::Cache::Post
   extend ActiveSupport::Autoload
 
   autoload :Ancestor
   autoload :Class
+  autoload :Instance
 end

--- a/lib/metasploit/cache/spec.rb
+++ b/lib/metasploit/cache/spec.rb
@@ -4,4 +4,20 @@ module Metasploit::Cache::Spec
 
   autoload :Matcher
   autoload :Template
+
+  #
+  # Module Methods
+  #
+
+  # A stream of samples of the given population.
+  #
+  # @param population [Array] array of objects to sample
+  # @return [Enumerator] returns a sample each time it is iterated
+  def self.sample_stream(population)
+    Enumerator.new do |yielder|
+      loop do
+        yielder.yield population.sample
+      end
+    end
+  end
 end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,7 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 12
+      PATCH = 13
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'post-instance'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/post/class_spec.rb
+++ b/spec/app/models/metasploit/cache/post/class_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Metasploit::Cache::Post::Class do
 
   context 'associations' do
     it { is_expected.to belong_to(:ancestor).class_name('Metasploit::Cache::Post::Ancestor') }
+    it { is_expected.to have_one(:post_instance).class_name('Metasploit::Cache::Post::Instance').dependent(:destroy).inverse_of(:post_class) }
     it { is_expected.to belong_to(:rank).class_name('Metasploit::Cache::Module::Rank') }
   end
 

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe Metasploit::Cache::Post::Instance do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
       it { is_expected.to have_db_column(:disclosed_on).of_type(:date).with_options(null: false) }
       it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
+      it { is_expected.to have_db_column(:post_class_id).of_type(:integer).with_options(null: false) }
+    end
+
+    context 'indices' do
+      it { is_expected.to have_db_index(:post_class_id).unique(true) }
+    end
+  end
+
+  context 'associations' do
+    it { is_expected.to belong_to(:post_class).class_name('Metasploit::Cache::Post::Class').inverse_of(:post_instance) }
+  end
+
+  context 'factories' do
+    context 'metasploit_cache_post_instance' do
+      subject(:metasploit_cache_post_instance) {
+        FactoryGirl.build(:metasploit_cache_post_instance)
+      }
+
+      it { is_expected.to be_valid }
     end
   end
 
@@ -13,5 +32,18 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :disclosed_on }
     it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :post_class }
+
+    # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
+    # constraints exist for other fields.
+    context 'with existing record' do
+      let!(:existing_post_instance) {
+        FactoryGirl.create(
+            :metasploit_cache_post_instance
+        )
+      }
+
+      it { is_expected.to validate_uniqueness_of :post_class_id }
+    end
   end
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe Metasploit::Cache::Post::Instance do
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
+      it { is_expected.to have_db_column(:disclosed_on).of_type(:date).with_options(null: false) }
     end
   end
 
   context 'validations' do
     it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :disclosed_on }
   end
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -1,3 +1,13 @@
 RSpec.describe Metasploit::Cache::Post::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
+
+  context 'database' do
+    context 'columns' do
+      it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
+    end
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of :description }
+  end
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Metasploit::Cache::Post::Instance do
+end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Metasploit::Cache::Post::Instance do
       it { is_expected.to have_db_column(:disclosed_on).of_type(:date).with_options(null: false) }
       it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
       it { is_expected.to have_db_column(:post_class_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:privileged).of_type(:boolean).with_options(null: false) }
     end
 
     context 'indices' do
@@ -33,6 +34,7 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     it { is_expected.to validate_presence_of :disclosed_on }
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :post_class }
+    it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -1,2 +1,3 @@
 RSpec.describe Metasploit::Cache::Post::Instance do
+  it_should_behave_like 'Metasploit::Concern.run'
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
       it { is_expected.to have_db_column(:disclosed_on).of_type(:date).with_options(null: false) }
+      it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
     end
   end
 
   context 'validations' do
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :disclosed_on }
+    it { is_expected.to validate_presence_of :name }
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -217,7 +217,8 @@ ActiveRecord::Schema.define(:version => 20150428142801) do
   add_index "mc_platforms", ["parent_id", "relative_name"], :name => "index_mc_platforms_on_parent_id_and_relative_name", :unique => true
 
   create_table "mc_post_instances", :force => true do |t|
-    t.text "description", :null => false
+    t.text "description",  :null => false
+    t.date "disclosed_on", :null => false
   end
 
   create_table "mc_references", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -217,8 +217,9 @@ ActiveRecord::Schema.define(:version => 20150428142801) do
   add_index "mc_platforms", ["parent_id", "relative_name"], :name => "index_mc_platforms_on_parent_id_and_relative_name", :unique => true
 
   create_table "mc_post_instances", :force => true do |t|
-    t.text "description",  :null => false
-    t.date "disclosed_on", :null => false
+    t.text   "description",  :null => false
+    t.date   "disclosed_on", :null => false
+    t.string "name",         :null => false
   end
 
   create_table "mc_references", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150409155014) do
+ActiveRecord::Schema.define(:version => 20150428142801) do
 
   create_table "mc_architectures", :force => true do |t|
     t.integer "bits"
@@ -59,6 +59,17 @@ ActiveRecord::Schema.define(:version => 20150409155014) do
   add_index "mc_email_addresses", ["domain"], :name => "index_mc_email_addresses_on_domain"
   add_index "mc_email_addresses", ["full"], :name => "index_mc_email_addresses_on_full", :unique => true
   add_index "mc_email_addresses", ["local"], :name => "index_mc_email_addresses_on_local"
+
+  create_table "mc_exploit_instances", :force => true do |t|
+    t.text    "description",      :null => false
+    t.date    "disclosed_on",     :null => false
+    t.string  "name",             :null => false
+    t.boolean "privileged",       :null => false
+    t.string  "stance",           :null => false
+    t.integer "exploit_class_id", :null => false
+  end
+
+  add_index "mc_exploit_instances", ["exploit_class_id"], :name => "index_mc_exploit_instances_on_exploit_class_id", :unique => true
 
   create_table "mc_module_actions", :force => true do |t|
     t.integer "module_instance_id", :null => false
@@ -204,6 +215,10 @@ ActiveRecord::Schema.define(:version => 20150409155014) do
 
   add_index "mc_platforms", ["fully_qualified_name"], :name => "index_mc_platforms_on_fully_qualified_name", :unique => true
   add_index "mc_platforms", ["parent_id", "relative_name"], :name => "index_mc_platforms_on_parent_id_and_relative_name", :unique => true
+
+  create_table "mc_post_instances", :force => true do |t|
+    t.text "description", :null => false
+  end
 
   create_table "mc_references", :force => true do |t|
     t.string  "designation"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -220,6 +220,7 @@ ActiveRecord::Schema.define(:version => 20150428142801) do
     t.text    "description",   :null => false
     t.date    "disclosed_on",  :null => false
     t.string  "name",          :null => false
+    t.boolean "privileged",    :null => false
     t.integer "post_class_id", :null => false
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -217,10 +217,13 @@ ActiveRecord::Schema.define(:version => 20150428142801) do
   add_index "mc_platforms", ["parent_id", "relative_name"], :name => "index_mc_platforms_on_parent_id_and_relative_name", :unique => true
 
   create_table "mc_post_instances", :force => true do |t|
-    t.text   "description",  :null => false
-    t.date   "disclosed_on", :null => false
-    t.string "name",         :null => false
+    t.text    "description",   :null => false
+    t.date    "disclosed_on",  :null => false
+    t.string  "name",          :null => false
+    t.integer "post_class_id", :null => false
   end
+
+  add_index "mc_post_instances", ["post_class_id"], :name => "index_mc_post_instances_on_post_class_id", :unique => true
 
   create_table "mc_references", :force => true do |t|
     t.string  "designation"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -60,17 +60,6 @@ ActiveRecord::Schema.define(:version => 20150428142801) do
   add_index "mc_email_addresses", ["full"], :name => "index_mc_email_addresses_on_full", :unique => true
   add_index "mc_email_addresses", ["local"], :name => "index_mc_email_addresses_on_local"
 
-  create_table "mc_exploit_instances", :force => true do |t|
-    t.text    "description",      :null => false
-    t.date    "disclosed_on",     :null => false
-    t.string  "name",             :null => false
-    t.boolean "privileged",       :null => false
-    t.string  "stance",           :null => false
-    t.integer "exploit_class_id", :null => false
-  end
-
-  add_index "mc_exploit_instances", ["exploit_class_id"], :name => "index_mc_exploit_instances_on_exploit_class_id", :unique => true
-
   create_table "mc_module_actions", :force => true do |t|
     t.integer "module_instance_id", :null => false
     t.text    "name",               :null => false

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -1,0 +1,26 @@
+FactoryGirl.define do
+  factory :metasploit_cache_post_instance,
+          class: Metasploit::Cache::Post::Instance do
+    description { generate :metasploit_cache_post_instance_description }
+    disclosed_on { generate :metasploit_cache_post_instance_disclosed_on }
+    name { generate :metasploit_cache_post_instance_name }
+
+    association :post_class, factory: :metasploit_cache_post_class
+  end
+
+  #
+  # Sequences
+  #
+
+  sequence :metasploit_cache_post_instance_description do |n|
+    "Metasploit::Cache::Post::Instance#description #{n}"
+  end
+
+  sequence :metasploit_cache_post_instance_disclosed_on do |n|
+    n.days.ago
+  end
+
+  sequence :metasploit_cache_post_instance_name do |n|
+    "Metasploit::Cache::Post::Instance"
+  end
+end

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     description { generate :metasploit_cache_post_instance_description }
     disclosed_on { generate :metasploit_cache_post_instance_disclosed_on }
     name { generate :metasploit_cache_post_instance_name }
+    privileged { generate :metasploit_cache_post_instance_privileged }
 
     association :post_class, factory: :metasploit_cache_post_class
   end
@@ -23,4 +24,6 @@ FactoryGirl.define do
   sequence :metasploit_cache_post_instance_name do |n|
     "Metasploit::Cache::Post::Instance"
   end
+
+  sequence :metasploit_cache_post_instance_privileged, Metasploit::Cache::Spec.sample_stream([false, true])
 end


### PR DESCRIPTION
MSP-12427

# Verification Steps

## Postgres
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without sqlite3`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.7% coverage

### Documentation Coverage
- [ ] `rake yard`
- [ ] VERIFY no warnings
- [ ] VERIFY no undocumented objects

## Sqlite3
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without postgres`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.65% coverage

### Documentation coverage
- [ ] `rake yard`
- [ ] VERIFY no warnings
- [ ] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [ ] Edit `lib/metasploit/cache/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`