### PR TITLE
Metasploit::Cache::Exploit::Target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Make your changes or however many commits you like, committing each with `git co
 
 ### Pre-Pull Request Steps
 
-#### Postgres
+#### Postgresql
 1. `rm Gemfile.lock`
 2. `bundle install --without sqlite3`
 3. `rake db:drop db:create db:migrate`
@@ -57,7 +57,7 @@ Make your changes or however many commits you like, committing each with `git co
 
 #### Sqlite3
 1. `rm Gemfile.lock`
-2. `bundle install --without postgres`
+2. `bundle install --without postgresql`
 3. `rake db:drop db:create db:migrate`
 
 ##### Testing
@@ -82,7 +82,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ```
 # Verification Steps
 
-## Postgres
+## Postgresql
 - [ ] `rm Gemfile.lock`
 - [ ] `bundle install --without sqlite3`
 - [ ] `rake db:drop db:create db:migrate`
@@ -99,7 +99,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 
 ## Sqlite3
 - [ ] `rm Gemfile.lock`
-- [ ] `bundle install --without postgres`
+- [ ] `bundle install --without postgresql`
 - [ ] `rake db:drop db:create db:migrate`
 
 ### Test coverage

--- a/Rakefile
+++ b/Rakefile
@@ -44,8 +44,8 @@ task :coverage do
   # coverage differs by adapter because different adapters have different handling in Metasploit::Cache::Batched::Root
   # and its specs.
   minimum_coverage_by_adapter = {
-      'postgresql' => 99.7,
-      'sqlite3' => 99.65
+      'postgresql' => 99.72,
+      'sqlite3' => 99.68
   }
 
   SimpleCov.configure do

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -4,6 +4,11 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
   # Associations
   #
 
+  # The default {#exploit_targets exploit target}.
+  belongs_to :default_exploit_target,
+             class_name: 'Metasploit::Cache::Exploit::Target',
+             inverse_of: :exploit_instance
+
   # The class level metadata for this exploit Metasploit Module
   belongs_to :exploit_class,
              class_name: 'Metasploit::Cache::Exploit::Class',
@@ -58,6 +63,13 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
   # Validations
   #
 
+  validates :default_exploit_target,
+            inclusion: {
+                allow_nil: true,
+                in: ->(exploit_instance){
+                  exploit_instance.exploit_targets
+                }
+            }
   validates :description,
             presence: true
   validates :disclosed_on,

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -9,6 +9,12 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Exploit::Class',
              inverse_of: :exploit_instance
 
+  # The targets that specialize this exploit for a given set of architectures and platforms.
+  has_many :exploit_targets,
+           class_name: 'Metasploit::Cache::Exploit::Target',
+           dependent: :destroy,
+           inverse_of: :exploit_instance
+
   #
   # Attributes
   #
@@ -60,6 +66,10 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
             presence: true
   validates :exploit_class_id,
             uniqueness: true
+  validates :exploit_targets,
+            length: {
+                minimum: 1
+            }
   validates :name,
             presence: true
   validates :privileged,

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -34,6 +34,11 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
             uniqueness: {
                 scope: :exploit_instance_id
             }
+  validates :name,
+            presence: true,
+            uniqueness: {
+                scope: :exploit_instance_id
+            }
 
   #
   # Instance Methods

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -11,11 +11,40 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
              inverse_of: :exploit_targets
 
   #
+  # Attributes
+  #
+
+  # @!attribute index
+  #   @note Does not imply that this is the index of this target in
+  #     {Metasploit::Cache::Exploit::Instance#exploit_targets}.
+  #
+  #   The index of this target in the array of targets as declared on the {#exploit_instance exploit Metasploit Module}
+  #   source.
+  #
+  #   @return [Integer]
+
+  #
   # Validations
   #
 
   validates :exploit_instance,
             presence: true
+  validates :index,
+            presence: true,
+            uniqueness: {
+                scope: :exploit_instance_id
+            }
+
+  #
+  # Instance Methods
+  #
+
+  # @!method index=(index)
+  #   Sets {#index}
+  #
+  #   @param index [Integer] The index of this target in the array of targets as declared on the
+  #     {#exploit_instance exploit Metasploit Module} source.
+  #   @return [void]
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -23,6 +23,11 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
   #
   #   @return [Integer]
 
+  # @!attribute name
+  #   The name of this target.
+  #
+  #   @return [String]
+
   #
   # Validations
   #
@@ -49,6 +54,12 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
   #
   #   @param index [Integer] The index of this target in the array of targets as declared on the
   #     {#exploit_instance exploit Metasploit Module} source.
+  #   @return [void]
+
+  # @!method name=(name)
+  #   Sets {#name}.
+  #
+  #   @param name [String] name of this target.
   #   @return [void]
 
   Metasploit::Concern.run(self)

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -1,0 +1,4 @@
+# Target of an {Metasploit::Cache::Exploit::Instance exploit Metasploit Module}.  Targets have specific architectures
+# and platforms that customize the behavior of the exploit Metasploit Module.
+class Metasploit::Cache::Exploit::Target
+end

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -1,5 +1,21 @@
 # Target of an {Metasploit::Cache::Exploit::Instance exploit Metasploit Module}.  Targets have specific architectures
 # and platforms that customize the behavior of the exploit Metasploit Module.
-class Metasploit::Cache::Exploit::Target
+class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
+  #
+  # Associations
+  #
+
+  # {Metasploit::Cache::Exploit::Instance Exploit Metasploit Module} on which this is a target.
+  belongs_to :exploit_instance,
+             class_name: 'Metasploit::Cache::Exploit::Instance',
+             inverse_of: :exploit_targets
+
+  #
+  # Validations
+  #
+
+  validates :exploit_instance,
+            presence: true
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -1,4 +1,5 @@
 # Target of an {Metasploit::Cache::Exploit::Instance exploit Metasploit Module}.  Targets have specific architectures
 # and platforms that customize the behavior of the exploit Metasploit Module.
 class Metasploit::Cache::Exploit::Target
+  Metasploit::Concern.run(self)
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,10 @@ en:
             actions:
               does_not_contain_default_action: "does not contain default action"
               too_short: "has too few actions (minimum is %{count} action)"
+        metasploit/cache/exploit/instance:
+          attributes:
+            exploit_targets:
+              too_short: "has too few exploit targets (minimum is %{count} exploit target)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,8 @@ en:
               too_short: "has too few actions (minimum is %{count} action)"
         metasploit/cache/exploit/instance:
           attributes:
+            default_exploit_target:
+              inclusion: "is not included in exploit targets"
             exploit_targets:
               too_short: "has too few exploit targets (minimum is %{count} exploit target)"
   metasploit:

--- a/db/migrate/20150330203014_create_mc_exploit_instances.rb
+++ b/db/migrate/20150330203014_create_mc_exploit_instances.rb
@@ -36,11 +36,15 @@ class CreateMcExploitInstances < ActiveRecord::Migration
       # References
       #
 
+      t.references :default_exploit_target,
+                   null: true
       t.references :exploit_class,
                    null: false
     end
 
     change_table TABLE_NAME do |t|
+      t.index :default_exploit_target_id,
+              unique: true
       t.index :exploit_class_id,
               unique: true
     end

--- a/db/migrate/20150507130708_create_mc_exploit_targets.rb
+++ b/db/migrate/20150507130708_create_mc_exploit_targets.rb
@@ -1,0 +1,37 @@
+class CreateMcExploitTargets < ActiveRecord::Migration
+  #
+  # CONSTANTS
+  #
+  # Name of the table being created
+  TABLE_NAME = :mc_exploit_targets
+
+  #
+  # Instance Methods
+  #
+
+  # Drop {TABLE_NAME}.
+  #
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+
+  # Create {TABLE_NAME}.
+  #
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      #
+      # References
+      #
+
+      t.references :exploit_instance,
+                   null: false
+    end
+
+    change_table TABLE_NAME do |t|
+      t.index :exploit_instance_id,
+              unique: false
+    end
+  end
+end

--- a/db/migrate/20150507130708_create_mc_exploit_targets.rb
+++ b/db/migrate/20150507130708_create_mc_exploit_targets.rb
@@ -23,6 +23,8 @@ class CreateMcExploitTargets < ActiveRecord::Migration
     create_table TABLE_NAME do |t|
       t.integer :index,
                 null: false
+      t.string :name,
+               null: false
 
       #
       # References
@@ -36,6 +38,8 @@ class CreateMcExploitTargets < ActiveRecord::Migration
       t.index :exploit_instance_id,
               unique: false
       t.index [:exploit_instance_id, :index],
+              unique: true
+      t.index [:exploit_instance_id, :name],
               unique: true
     end
   end

--- a/db/migrate/20150507130708_create_mc_exploit_targets.rb
+++ b/db/migrate/20150507130708_create_mc_exploit_targets.rb
@@ -21,6 +21,9 @@ class CreateMcExploitTargets < ActiveRecord::Migration
   # @return [void]
   def up
     create_table TABLE_NAME do |t|
+      t.integer :index,
+                null: false
+
       #
       # References
       #
@@ -32,6 +35,8 @@ class CreateMcExploitTargets < ActiveRecord::Migration
     change_table TABLE_NAME do |t|
       t.index :exploit_instance_id,
               unique: false
+      t.index [:exploit_instance_id, :index],
+              unique: true
     end
   end
 end

--- a/lib/metasploit/cache/exploit.rb
+++ b/lib/metasploit/cache/exploit.rb
@@ -7,6 +7,7 @@ module Metasploit::Cache::Exploit
   autoload :Ancestor
   autoload :Class
   autoload :Instance
+  autoload :Target
 
   #
   # Module Methods

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,7 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 26
+      PATCH = 27
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'exploit-target'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
 
   context 'database' do
     context 'columns' do
+      it { is_expected.to have_db_column(:default_exploit_target_id).of_type(:integer).with_options(null: true) }
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
       it { is_expected.to have_db_column(:disclosed_on).of_type(:date).with_options(null: false) }
       it { is_expected.to have_db_column(:exploit_class_id).of_type(:integer).with_options(null: false) }
@@ -12,11 +13,13 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
     end
 
     context 'indices' do
+      it { is_expected.to have_db_index(:default_exploit_target_id).unique(true) }
       it { is_expected.to have_db_index(:exploit_class_id).unique(true) }
     end
   end
 
   context 'associations' do
+    it { is_expected.to belong_to(:default_exploit_target).class_name('Metasploit::Cache::Exploit::Target').inverse_of(:exploit_instance) }
     it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance) }
     it { is_expected.to have_many(:exploit_targets).class_name('Metasploit::Cache::Exploit::Target').dependent(:destroy).inverse_of(:exploit_instance) }
   end
@@ -38,6 +41,66 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
     it { is_expected.to validate_inclusion_of(:stance).in_array(Metasploit::Cache::Module::Stance::ALL) }
+
+    context 'validates inclusion of #default_exploit_target in #exploit_targets' do
+      subject(:default_exploit_target_errors) {
+        exploit_instance.errors[:default_exploit_target]
+      }
+
+      let(:error) {
+        I18n.translate!('activerecord.errors.models.metasploit/cache/exploit/instance.attributes.default_exploit_target.inclusion')
+      }
+
+      let(:exploit_instance) {
+        described_class.new
+      }
+
+      context 'without #default_exploit_target' do
+        before(:each) do
+          exploit_instance.default_exploit_target = nil
+        end
+
+        it { is_expected.not_to include(error) }
+      end
+
+      context 'with #default_exploit_target' do
+        #
+        # lets
+        #
+
+        let(:default_exploit_target) {
+          Metasploit::Cache::Exploit::Target.new
+        }
+
+        #
+        # Callbacks
+        #
+
+        before(:each) do
+          exploit_instance.default_exploit_target = default_exploit_target
+        end
+
+        context 'in #exploit_targets' do
+          before(:each) do
+            exploit_instance.exploit_targets = [
+                default_exploit_target
+            ]
+            exploit_instance.valid?
+          end
+
+          it { is_expected.not_to include(error) }
+        end
+
+        context 'not in #exploit_targets' do
+          before(:each) do
+            exploit_instance.exploit_targets = []
+            exploit_instance.valid?
+          end
+
+          it { is_expected.to include(error) }
+        end
+      end
+    end
 
     # validate_length_of cannot test minimum length on exploit_targets because it tries to tests with a String
     context 'validates length of #exploit_targets is at least 1' do

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance) }
+    it { is_expected.to have_many(:exploit_targets).class_name('Metasploit::Cache::Exploit::Target').dependent(:destroy).inverse_of(:exploit_instance) }
   end
 
   context 'factory' do
@@ -37,6 +38,39 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
     it { is_expected.to validate_inclusion_of(:stance).in_array(Metasploit::Cache::Module::Stance::ALL) }
+
+    # validate_length_of cannot test minimum length on exploit_targets because it tries to tests with a String
+    context 'validates length of #exploit_targets is at least 1' do
+      subject(:exploit_targets_errors) {
+        exploit_instance.errors[:exploit_targets]
+      }
+
+      let(:exploit_instance) {
+        described_class.new
+      }
+
+      let(:error) {
+        I18n.translate!('activerecord.errors.models.metasploit/cache/exploit/instance.attributes.exploit_targets.too_short', count: 1)
+      }
+
+      context 'with no exploit targets' do
+        before(:each) do
+          exploit_instance.exploit_targets = []
+          exploit_instance.valid?
+        end
+
+        it { is_expected.to include(error) }
+      end
+
+      context 'with one exploit target' do
+        before(:each) do
+          exploit_instance.exploit_targets << Metasploit::Cache::Exploit::Target.new
+          exploit_instance.valid?
+        end
+
+        it { is_expected.not_to include(error) }
+      end
+    end
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:exploit_instance_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:index).of_type(:integer).with_options(null: false) }
     end
 
     context 'indices' do
       it { is_expected.to have_db_index(:exploit_instance_id).unique(false) }
+      it { is_expected.to have_db_index([:exploit_instance_id, :index]).unique(true) }
     end
   end
 
@@ -27,5 +29,16 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
 
   context 'validations' do
     it { is_expected.to validate_presence_of :exploit_instance }
+    it { is_expected.to validate_presence_of :index }
+
+    # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
+    # constraints exist for other fields.
+    context 'with existing record' do
+      let!(:existing_exploit_target) {
+        FactoryGirl.create(:metasploit_cache_exploit_target)
+      }
+
+      it { is_expected.to validate_uniqueness_of(:index).scoped_to(:exploit_instance_id) }
+    end
   end
 end

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
     context 'columns' do
       it { is_expected.to have_db_column(:exploit_instance_id).of_type(:integer).with_options(null: false) }
       it { is_expected.to have_db_column(:index).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
     end
 
     context 'indices' do
       it { is_expected.to have_db_index(:exploit_instance_id).unique(false) }
       it { is_expected.to have_db_index([:exploit_instance_id, :index]).unique(true) }
+      it { is_expected.to have_db_index([:exploit_instance_id, :name]).unique(true) }
     end
   end
 
@@ -30,6 +32,7 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
   context 'validations' do
     it { is_expected.to validate_presence_of :exploit_instance }
     it { is_expected.to validate_presence_of :index }
+    it { is_expected.to validate_presence_of :name }
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
@@ -39,6 +42,7 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
       }
 
       it { is_expected.to validate_uniqueness_of(:index).scoped_to(:exploit_instance_id) }
+      it { is_expected.to validate_uniqueness_of(:name).scoped_to(:exploit_instance_id) }
     end
   end
 end

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Metasploit::Cache::Exploit::Target do
+end

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -1,3 +1,31 @@
 RSpec.describe Metasploit::Cache::Exploit::Target do
   it_should_behave_like 'Metasploit::Concern.run'
+
+  context 'associations' do
+    it { is_expected.to belong_to(:exploit_instance).class_name('Metasploit::Cache::Exploit::Instance').inverse_of(:exploit_targets) }
+  end
+
+  context 'database' do
+    context 'columns' do
+      it { is_expected.to have_db_column(:exploit_instance_id).of_type(:integer).with_options(null: false) }
+    end
+
+    context 'indices' do
+      it { is_expected.to have_db_index(:exploit_instance_id).unique(false) }
+    end
+  end
+
+  context 'factories' do
+    context 'metasploit_cache_exploit_target' do
+      subject(:metasploit_cache_exploit_target) {
+        FactoryGirl.build(:metasploit_cache_exploit_target)
+      }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of :exploit_instance }
+  end
 end

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -1,2 +1,3 @@
 RSpec.describe Metasploit::Cache::Exploit::Target do
+  it_should_behave_like 'Metasploit::Concern.run'
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -88,14 +88,16 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
   add_index "mc_encoder_instances", ["encoder_class_id"], :name => "index_mc_encoder_instances_on_encoder_class_id", :unique => true
 
   create_table "mc_exploit_instances", :force => true do |t|
-    t.text    "description",      :null => false
-    t.date    "disclosed_on",     :null => false
-    t.string  "name",             :null => false
-    t.boolean "privileged",       :null => false
-    t.string  "stance",           :null => false
-    t.integer "exploit_class_id", :null => false
+    t.text    "description",               :null => false
+    t.date    "disclosed_on",              :null => false
+    t.string  "name",                      :null => false
+    t.boolean "privileged",                :null => false
+    t.string  "stance",                    :null => false
+    t.integer "default_exploit_target_id"
+    t.integer "exploit_class_id",          :null => false
   end
 
+  add_index "mc_exploit_instances", ["default_exploit_target_id"], :name => "index_mc_exploit_instances_on_default_exploit_target_id", :unique => true
   add_index "mc_exploit_instances", ["exploit_class_id"], :name => "index_mc_exploit_instances_on_exploit_class_id", :unique => true
 
   create_table "mc_exploit_targets", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -100,10 +100,12 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
 
   create_table "mc_exploit_targets", :force => true do |t|
     t.integer "index",               :null => false
+    t.string  "name",                :null => false
     t.integer "exploit_instance_id", :null => false
   end
 
   add_index "mc_exploit_targets", ["exploit_instance_id", "index"], :name => "index_mc_exploit_targets_on_exploit_instance_id_and_index", :unique => true
+  add_index "mc_exploit_targets", ["exploit_instance_id", "name"], :name => "index_mc_exploit_targets_on_exploit_instance_id_and_name", :unique => true
   add_index "mc_exploit_targets", ["exploit_instance_id"], :name => "index_mc_exploit_targets_on_exploit_instance_id"
 
   create_table "mc_module_actions", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150429155157) do
+ActiveRecord::Schema.define(:version => 20150507130708) do
 
   create_table "mc_actionable_actions", :force => true do |t|
     t.string  "name",            :null => false
@@ -97,6 +97,12 @@ ActiveRecord::Schema.define(:version => 20150429155157) do
   end
 
   add_index "mc_exploit_instances", ["exploit_class_id"], :name => "index_mc_exploit_instances_on_exploit_class_id", :unique => true
+
+  create_table "mc_exploit_targets", :force => true do |t|
+    t.integer "exploit_instance_id", :null => false
+  end
+
+  add_index "mc_exploit_targets", ["exploit_instance_id"], :name => "index_mc_exploit_targets_on_exploit_instance_id"
 
   create_table "mc_module_actions", :force => true do |t|
     t.integer "module_instance_id", :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -99,9 +99,11 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
   add_index "mc_exploit_instances", ["exploit_class_id"], :name => "index_mc_exploit_instances_on_exploit_class_id", :unique => true
 
   create_table "mc_exploit_targets", :force => true do |t|
+    t.integer "index",               :null => false
     t.integer "exploit_instance_id", :null => false
   end
 
+  add_index "mc_exploit_targets", ["exploit_instance_id", "index"], :name => "index_mc_exploit_targets_on_exploit_instance_id_and_index", :unique => true
   add_index "mc_exploit_targets", ["exploit_instance_id"], :name => "index_mc_exploit_targets_on_exploit_instance_id"
 
   create_table "mc_module_actions", :force => true do |t|

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_exploit_instance,
           class: Metasploit::Cache::Exploit::Instance do
+    transient do
+      exploit_target_count 1
+    end
+
     description { generate :metasploit_cache_exploit_instance_description }
     disclosed_on { generate :metasploit_cache_exploit_instance_disclosed_on }
     name { generate :metasploit_cache_exploit_instance_name }
@@ -8,6 +12,18 @@ FactoryGirl.define do
     stance { generate :metasploit_cache_module_stance }
 
     association :exploit_class, factory: :metasploit_cache_exploit_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) { |exploit_instance, evaluator|
+      exploit_instance.exploit_targets = build_list(
+          :metasploit_cache_exploit_target,
+          evaluator.exploit_target_count,
+          exploit_instance: exploit_instance
+      )
+    }
   end
 
   #

--- a/spec/factories/metasploit/cache/exploit/targets.rb
+++ b/spec/factories/metasploit/cache/exploit/targets.rb
@@ -1,6 +1,12 @@
 FactoryGirl.define do
   factory :metasploit_cache_exploit_target,
           class: Metasploit::Cache::Exploit::Target do
+    index { generate :metasploit_cache_exploit_target_index }
+
     association :exploit_instance, factory: :metasploit_cache_exploit_instance
+  end
+
+  sequence :metasploit_cache_exploit_target_index do |n|
+    n
   end
 end

--- a/spec/factories/metasploit/cache/exploit/targets.rb
+++ b/spec/factories/metasploit/cache/exploit/targets.rb
@@ -2,11 +2,16 @@ FactoryGirl.define do
   factory :metasploit_cache_exploit_target,
           class: Metasploit::Cache::Exploit::Target do
     index { generate :metasploit_cache_exploit_target_index }
+    name { generate :metasploit_cache_exploit_target_name }
 
     association :exploit_instance, factory: :metasploit_cache_exploit_instance
   end
 
   sequence :metasploit_cache_exploit_target_index do |n|
     n
+  end
+
+  sequence :metasploit_cache_exploit_target_name do |n|
+    "Metasploit::Cache::Exploit::Target#name #{n}"
   end
 end

--- a/spec/factories/metasploit/cache/exploit/targets.rb
+++ b/spec/factories/metasploit/cache/exploit/targets.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :metasploit_cache_exploit_target,
+          class: Metasploit::Cache::Exploit::Target do
+    association :exploit_instance, factory: :metasploit_cache_exploit_instance
+  end
+end


### PR DESCRIPTION
MSP-12438

# Verification Steps

## Design translation
- [x] `open doc/images/metasploit-cache.png`
- [x] VERIFY links between `Metasploit::Cache::Exploit::Instance` and `Metasploit::Cache::Exploit::Target` are implemented.
- [x] VERIFY links between `Metasploit::Cache::Exploit::Target` and `Metasploit::Cache::Architecturable::Architecture` are NOT implemented yet.
- [x] VERIFY links between `Metasploit::Cache::Exploit::Target` and `Metasploit::Cache::Platformable::Platform` are NOT implemented yet.

## Postgres
- [x] `rm Gemfile.lock`
- [x] `bundle install --without sqlite3`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.72% coverage

### Documentation Coverage
- [ ] `rake yard`
- [ ] VERIFY no warnings
- [ ] VERIFY no undocumented objects

## Sqlite3
- [x] `rm Gemfile.lock`
- [x] `bundle install --without postgresql`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.68% coverage

### Documentation coverage
- [x] `rake yard`
- [x] VERIFY no warnings
- [x] VERIFY no undocumented objects