### PR TITLE
Metasploit::Cache::License

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 
 ### Documentation Coverage
 - [ ] `rake yard`
-- [ ] VERIFY no warnings
+- [ ] VERIFY no `[warn]`ings. (Rails ERD "invalid model" Warnings are OK.)
 - [ ] VERIFY no undocumented objects
 
 ## Sqlite3
@@ -109,7 +109,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 
 ### Documentation coverage
 - [ ] `rake yard`
-- [ ] VERIFY no warnings
+- [ ] VERIFY no `[warn]`ings. (Rails ERD "invalid model" Warnings are OKrm Gemfile.lock.)
 - [ ] VERIFY no undocumented objects
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 100% coverage.
+3. Verify there was 99.72% coverage.
 
 ##### Documentation
 1. `rake yard`
@@ -63,7 +63,7 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 100% coverage.
+3. Verify there was 99.69% coverage.
 
 ##### Documentation
 1. `rake yard`
@@ -90,7 +90,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] VERIFY 99.72% coverage
 
 ### Documentation Coverage
 - [ ] `rake yard`
@@ -105,7 +105,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] VERIFY 99.69% coverage
 
 ### Documentation coverage
 - [ ] `rake yard`

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ task :coverage do
   # and its specs.
   minimum_coverage_by_adapter = {
       'postgresql' => 99.72,
-      'sqlite3' => 99.68
+      'sqlite3' => 99.69
   }
 
   SimpleCov.configure do

--- a/app/models/metasploit/cache/license.rb
+++ b/app/models/metasploit/cache/license.rb
@@ -1,7 +1,5 @@
-# Represents licenses like BSD, MIT, etc used to provide license information for {Metasploit::Cache::Module::Instance modules}
+# Represents licenses like BSD, MIT, etc used to provide license information for Metasploit modules
 class Metasploit::Cache::License < ActiveRecord::Base
-  extend ActiveSupport::Autoload
-
   #
   # Attributes
   #

--- a/app/models/metasploit/cache/license.rb
+++ b/app/models/metasploit/cache/license.rb
@@ -7,7 +7,7 @@ class Metasploit::Cache::License < ActiveRecord::Base
   #
 
   # @!attribute abbreviation
-  #   Abbreviated license name
+  #   Short name of this license, e.g. "BSD-2"
   #
   #   @return [String]
 
@@ -37,6 +37,25 @@ class Metasploit::Cache::License < ActiveRecord::Base
   validates :url,
             uniqueness: true,
             presence: true
+
+
+  # @!method abbreviation=(abbreviation)
+  #   Sets {#abbreviation}.
+  #
+  #   @param abbreviation [String] short name of this license, e.g. "BSD-2"
+  #   @return [void]
+
+  # @!method summary=(summary)
+  #   Sets {#summary}.
+  #
+  #   @param summary [String] summary of the license text
+  #   @return [void]
+
+  # @!method url=(url)
+  #   Sets {#url}.
+  #
+  #   @param url [String] URL to the location of the full license text
+  #   @return [void]
 
 
   Metasploit::Concern.run(self)

--- a/app/models/metasploit/cache/license.rb
+++ b/app/models/metasploit/cache/license.rb
@@ -1,0 +1,23 @@
+# License of one or more {#module_instances modules}.
+class Metasploit::Cache::License < ActiveRecord::Base
+
+  #
+  # Attributes
+  #
+
+  # @!attribute abbreviation
+  #   Abbreviated license name
+  #
+  #   @return [String]
+
+  # @!attribute summary
+  #   Summary of the license text
+  #
+  #   @return [String]
+
+  # @!attribute url
+  #   URL of the full license text
+  #
+  #   @return [String]
+
+end

--- a/app/models/metasploit/cache/license.rb
+++ b/app/models/metasploit/cache/license.rb
@@ -1,5 +1,6 @@
-# License of one or more {#module_instances modules}.
+# Represents licenses like BSD, MIT, etc used to provide license information for {Metasploit::Cache::Module::Instance modules}
 class Metasploit::Cache::License < ActiveRecord::Base
+  extend ActiveSupport::Autoload
 
   #
   # Attributes
@@ -20,4 +21,24 @@ class Metasploit::Cache::License < ActiveRecord::Base
   #
   #   @return [String]
 
+
+  #
+  # Validations
+  #
+
+  validates :abbreviation,
+            uniqueness: true,
+            presence: true
+
+  validates :summary,
+            uniqueness: true,
+            presence: true
+
+  validates :url,
+            uniqueness: true,
+            presence: true
+
+
+  Metasploit::Concern.run(self)
 end
+

--- a/db/migrate/20150515163602_create_mc_licenses.rb
+++ b/db/migrate/20150515163602_create_mc_licenses.rb
@@ -1,0 +1,23 @@
+class CreateMcLicenses < ActiveRecord::Migration
+
+  TABLE_NAME = :mc_licenses
+
+  # Drops `mc_licenses`
+  #
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+
+  # Creates `mc_licenses`
+  #
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      t.string :abbreviation
+      t.text :summary
+      t.string :url
+    end
+  end
+
+end

--- a/db/migrate/20150515163602_create_mc_licenses.rb
+++ b/db/migrate/20150515163602_create_mc_licenses.rb
@@ -14,9 +14,15 @@ class CreateMcLicenses < ActiveRecord::Migration
   # @return [void]
   def up
     create_table TABLE_NAME do |t|
-      t.string :abbreviation, null: false, unique: true
-      t.text :summary, null: false, unique: true
-      t.string :url, null: false, unique: true
+      t.string :abbreviation, null: false
+      t.text :summary, null: false
+      t.string :url, null: false
+    end
+
+    change_table TABLE_NAME do |t|
+      t.index :abbreviation, unique: true
+      t.index :summary, unique: true
+      t.index :url, unique: true
     end
   end
 

--- a/db/migrate/20150515163602_create_mc_licenses.rb
+++ b/db/migrate/20150515163602_create_mc_licenses.rb
@@ -14,9 +14,9 @@ class CreateMcLicenses < ActiveRecord::Migration
   # @return [void]
   def up
     create_table TABLE_NAME do |t|
-      t.string :abbreviation
-      t.text :summary
-      t.string :url
+      t.string :abbreviation, null: false, unique: true
+      t.text :summary, null: false, unique: true
+      t.string :url, null: false, unique: true
     end
   end
 

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -41,6 +41,7 @@ module Metasploit
     autoload :Exploit
     autoload :File
     autoload :Invalid
+    autoload :License
     autoload :Login
     autoload :Module
     autoload :NilifyBlanks

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -12,6 +12,8 @@ module Metasploit
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 27
+      # Remove on master
+      PRERELEASE = 'license-model'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/license_spec.rb
+++ b/spec/app/models/metasploit/cache/license_spec.rb
@@ -1,15 +1,34 @@
 RSpec.describe Metasploit::Cache::License do
-  context "associations" do
-    
-  end
-
-  context "database" do
-    context "columns" do
-      
-    end
-
-    context "indices" do
-      
+  context 'database' do
+    context 'columns' do
+      it { is_expected.to have_db_column(:abbreviation).of_type(:string).with_options(null: false, unique: true) }
+      it { is_expected.to have_db_column(:summary).of_type(:text).with_options(null: false, unique: true) }
+      it { is_expected.to have_db_column(:url).of_type(:string).with_options(null: false, unique: true) }
     end
   end
+
+  context 'factories' do
+    context :metasploit_cache_license do
+      subject(:metasploit_cache_license) { FactoryGirl.build(:metasploit_cache_license) }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  context "validations" do
+    context "presence" do
+      it { is_expected.to validate_presence_of :abbreviation }
+      it { is_expected.to validate_presence_of :summary }
+      it { is_expected.to validate_presence_of :url }
+    end
+
+    context "uniqueness" do
+      subject(:metasploit_cache_license) { FactoryGirl.build(:metasploit_cache_license) }
+
+      it { is_expected.to validate_uniqueness_of :abbreviation }
+      it { is_expected.to validate_uniqueness_of :summary }
+      it { is_expected.to validate_uniqueness_of :url }
+    end
+  end
+
 end

--- a/spec/app/models/metasploit/cache/license_spec.rb
+++ b/spec/app/models/metasploit/cache/license_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Metasploit::Cache::License do
+  context "associations" do
+    
+  end
+
+  context "database" do
+    context "columns" do
+      
+    end
+
+    context "indices" do
+      
+    end
+  end
+end

--- a/spec/app/models/metasploit/cache/license_spec.rb
+++ b/spec/app/models/metasploit/cache/license_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Metasploit::Cache::License do
       it { is_expected.to have_db_column(:summary).of_type(:text).with_options(null: false, unique: true) }
       it { is_expected.to have_db_column(:url).of_type(:string).with_options(null: false, unique: true) }
     end
+
+    context "indices" do
+      it {is_expected.to have_db_index(:abbreviation).unique(true)}
+      it {is_expected.to have_db_index(:summary).unique(true)}
+      it {is_expected.to have_db_index(:url).unique(true)}
+    end
   end
 
   context 'factories' do

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150507130708) do
+ActiveRecord::Schema.define(:version => 20150515163602) do
 
   create_table "mc_actionable_actions", :force => true do |t|
     t.string  "name",            :null => false
@@ -109,6 +109,12 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
   add_index "mc_exploit_targets", ["exploit_instance_id", "index"], :name => "index_mc_exploit_targets_on_exploit_instance_id_and_index", :unique => true
   add_index "mc_exploit_targets", ["exploit_instance_id", "name"], :name => "index_mc_exploit_targets_on_exploit_instance_id_and_name", :unique => true
   add_index "mc_exploit_targets", ["exploit_instance_id"], :name => "index_mc_exploit_targets_on_exploit_instance_id"
+
+  create_table "mc_licenses", :force => true do |t|
+    t.string "abbreviation", :null => false
+    t.text   "summary",      :null => false
+    t.string "url",          :null => false
+  end
 
   create_table "mc_module_actions", :force => true do |t|
     t.integer "module_instance_id", :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -116,6 +116,10 @@ ActiveRecord::Schema.define(:version => 20150515163602) do
     t.string "url",          :null => false
   end
 
+  add_index "mc_licenses", ["abbreviation"], :name => "index_mc_licenses_on_abbreviation", :unique => true
+  add_index "mc_licenses", ["summary"], :name => "index_mc_licenses_on_summary", :unique => true
+  add_index "mc_licenses", ["url"], :name => "index_mc_licenses_on_url", :unique => true
+
   create_table "mc_module_actions", :force => true do |t|
     t.integer "module_instance_id", :null => false
     t.text    "name",               :null => false

--- a/spec/factories/metasploit/cache/licenses.rb
+++ b/spec/factories/metasploit/cache/licenses.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :metasploit_cache_license, class: Metasploit::Cache::License do
+    abbreviation "BSD-2"
+    summary(
+      <<EOS
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+EOS
+    )
+    url "http://opensource.org/licenses/BSD-2-Clause"
+  end
+end


### PR DESCRIPTION
**Note:** due to PRERELEASE enforcement, please merge this locally on the command line

# Verification Steps

## Postgresql
- [x] `rm Gemfile.lock`
- [x] `bundle install --without sqlite3`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.72% coverage

### Documentation Coverage
- [ ] `rake yard`
- [ ] VERIFY no warnings
- [ ] VERIFY no undocumented objects

## Sqlite3
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without postgresql`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.69% coverage

### Documentation coverage
- [ ] `rake yard`
- [ ] VERIFY no warnings
- [ ] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [ ] Edit `lib/metasploit/cache/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`