### PR TITLE
Remove extra writer docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ cache: bundler
 env:
   matrix:
   - BUNDLER_INSTALL_WITHOUT="sqlite3" RAKE_TASKS="spec cucumber coverage"
-  - BUNDLER_INSTALL_WITHOUT="sqlite3" RAKE_TASKS="yard"
+  - BUNDLER_INSTALL_WITHOUT="sqlite3" RAKE_TASKS="yard:stats"
   - BUNDLER_INSTALL_WITHOUT="postgresql" RAKE_TASKS="spec cucumber coverage"
-  - BUNDLER_INSTALL_WITHOUT="postgresql" RAKE_TASKS="yard"
+  - BUNDLER_INSTALL_WITHOUT="postgresql" RAKE_TASKS="yard:stats"
   global:
     secure: cOCoUB1zTvnl274EftNxbbmkL8MIlXa9a2/NLXpJFfJaL39JLYLCvrj85ndLO75fl8W5j7Xnx1w3kyNCL0FUumWzrIfcJFwTADv20EggrmrrJaEJDdqi3+oxFA8/AHQK7GUXws2AEhbs1ujXO7wA44qeQmO1daWdbXmN5t2qoxc=
 language: ruby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 99.73% coverage.
+3. Verify there was 99.72% coverage.
 
 ##### Documentation
 1. `rake yard:stats`
@@ -90,7 +90,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 99.73% coverage
+- [ ] VERIFY 99.72% coverage
 
 ### Documentation Coverage
 - [ ] `rake yard:stats`
@@ -105,7 +105,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 99.69% coverage
+- [ ] VERIFY 99.68% coverage
 
 ### Documentation coverage
 - [ ] `rake yard:stats`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,11 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 100% coverage.
+3. Verify there was 99.72% coverage.
 
 ##### Documentation
-1. `rake yard`
-2. Verify there were no warnings.
+1. `rake yard:stats`
+2. Verify only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support. 
 2. Verify there were no undocumented objects.
 
 #### Sqlite3
@@ -66,8 +66,8 @@ Make your changes or however many commits you like, committing each with `git co
 3. Verify there was 100% coverage.
 
 ##### Documentation
-1. `rake yard`
-2. Verify there were no warnings.
+1. `rake yard:stats`
+2. Verify only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
 2. Verify there were no undocumented objects.
 
 ### Push
@@ -90,11 +90,11 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] VERIFY 99.72% coverage
 
 ### Documentation Coverage
-- [ ] `rake yard`
-- [ ] VERIFY no warnings
+- [ ] `rake yard:stats`
+- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
 - [ ] VERIFY no undocumented objects
 
 ## Sqlite3
@@ -105,11 +105,11 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] VERIFY 99.68% coverage
 
 ### Documentation coverage
-- [ ] `rake yard`
-- [ ] VERIFY no warnings
+- [ ] `rake yard:stats`
+- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
 - [ ] VERIFY no undocumented objects
 ```
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,10 @@ group :content do
   gem 'metasploit_data_models', '0.23.0'
 end
 
+group :development do
+  gem 'metasploit-yard', github: 'rapid7/metasploit-yard', ref: '3ca321c47cba178d298f347d6006995b28c76226'
+end
+
 # used by dummy application
 group :development, :test do
   # Templates for Metasploit Modules

--- a/app/models/metasploit/cache/actionable/action.rb
+++ b/app/models/metasploit/cache/actionable/action.rb
@@ -35,15 +35,5 @@ class Metasploit::Cache::Actionable::Action < ActiveRecord::Base
                 unless: :batched?
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] the name of this action.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/architecture.rb
+++ b/app/models/metasploit/cache/architecture.rb
@@ -215,58 +215,5 @@ class Metasploit::Cache::Architecture < ActiveRecord::Base
     end
   end
 
-  #
-  # Instance Methods
-  #
-
-  # @!method abbreviation=(abbreviation)
-  #   Sets {#abbreviation}.
-  #
-  #   @param abbreviation [String] Abbreviation used for the architecture.  Will match ARCH constants in
-  #     metasploit-framework.
-  #   @return [void]
-
-  # @!method bits=(bits)
-  #   Sets {#bits}.
-  #
-  #   @param bits [32, 64, nil] Number of bits supported by this architecture: `32` if 32-bit; `64` if 64-bit; `nil` if
-  #     bits aren't applicable, such as for non-CPU architectures like ruby, etc.
-  #   @return [void]
-
-  # @!method endianness=(endianness)
-  #   Sets {#endianness}.
-  #
-  #   @param endianness ['big', 'little', nil] `'big'` if big-endian; `'little'` if little-endian; `nil` if endianness
-  #     is not applicable, such as for software architectures like tty.
-  #   @return [void]
-
-  # @!method family=(family)
-  #   Sets {#family}.
-  #
-  #   @param family [String, nil] The CPU architecture family. `String` if a CPU architecture; `nil` if not a CPU
-  #     architecture.
-  #   @return [void]
-
-  # @!method summary=(summary)
-  #   Sets {#summary}.
-  #
-  #   @param summary [String] Sentence length summary of architecture.  Usually an expansion of the abbreviation or
-  #     initialism in the {#abbreviation} and the {#bits} and {#endianness} in prose.
-  #   @return [void]
-
-  # @!method module_architectures=(module_architectures)
-  #   Sets {#module_architectures}.
-  #
-  #   @param module_architectures [Enumerable<Metasploit::Cache::Module::Architecture>, nil] Join models between this
-  #     {Metasploit::Cache::Architecture} and {Metasploit::Cache::Module::Instance}.
-  #   @return [void]
-
-  # @!method target_architectures=(target_architectures)
-  #   Sets {#target_architectures}.
-  #
-  #   @param target_architectures [Enumerable<Metasploit::Cache::Target::Architecture>, nil] Join models between this
-  #     and {Metasploit::Cache::Module::Target}.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/author.rb
+++ b/app/models/metasploit/cache/author.rb
@@ -54,22 +54,5 @@ class Metasploit::Cache::Author < ActiveRecord::Base
                 unless: :batched?
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method module_authors=(module_authors)
-  #   Sets {#module_authors}.
-  #
-  #   @param module_authors [Enumerable<Metasploit::Cache::Module::Author>] Joins this to {#email_addresses} and
-  #     {#module_instances}.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Set the {#name}.
-  #
-  #   @param name [String] Full name (First + Last name) or handle of author.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/authority.rb
+++ b/app/models/metasploit/cache/authority.rb
@@ -54,7 +54,7 @@ class Metasploit::Cache::Authority < ActiveRecord::Base
   #   Whether this authority is obsolete and no longer exists on the internet.
   #
   #   @return [false]
-  #   @return [true] {#url} may be `nil` because authory no longer has a web site.
+  #   @return [true] {#url} may be `nil` because authority no longer has a web site.
 
   # @!attribute summary
   #   An expansion of the {#abbreviation}.
@@ -105,20 +105,6 @@ class Metasploit::Cache::Authority < ActiveRecord::Base
   # Instance Methods
   #
 
-  # @!method abbreviation=(abbreviation)
-  #   Sets {#abbreviation}.
-  #
-  #   @param abbreviation [String] Abbreviation or initialism for authority, such as CVE for
-  #     'Common Vulnerability and Exposures'.
-  #   @return [void]
-
-  # @!method obsolete=(obsolete)
-  #   Sets {#obsolete}.
-  #
-  #   @param obsolete [Boolean] `true` if this authority is obsolete and no longer exists on the internet; otherwise
-  #     `false`.
-  #   @return [void]
-
   # Returns the {Metasploit::Cache::Reference#url URL} for a {Metasploit::Cache::Reference#designation designation}.
   #
   # @param designation [String] {Metasploit::Cache::Reference#designation}.
@@ -162,25 +148,6 @@ class Metasploit::Cache::Authority < ActiveRecord::Base
 
     extension_name
   end
-
-  # @!method references=(references)
-  #   Sets {#references}.
-  #
-  #   @param references [Array<Metasploit::Cache::Reference>] {Metasploit::Cache::Reference References} that use this
-  #     authority's scheme for their {Metasploit::Cache::Reference#authority}.
-  #   @return [void]
-
-  # @!method summary=(summary)
-  #   Sets {#summary}.
-  #
-  #   @param summary [String] An expansion of the {#abbreviation}.
-  #   @return [void]
-
-  # @!method url=(url)
-  #   Sets {#url}.
-  #
-  #   @param url [String]  URL to the authority's home page or root URL for their {#references} database.
-  #   @return [void]
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/auxiliary/instance.rb
+++ b/app/models/metasploit/cache/auxiliary/instance.rb
@@ -92,34 +92,6 @@ class Metasploit::Cache::Auxiliary::Instance < ActiveRecord::Base
   # Instance Methods
   #
 
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this auxiliary Metasploit Module.
-  #   @return [void]
-
-  # @!method disclosed_on=(disclosed_on)
-  #   Sets {#disclosed_on}.
-  #
-  #   @param disclosed_on [Date, nil] The date when the bug this Metasploit Module exercises was disclosed publicly
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human-readable name of this auxiliary Metasploit Module.  This can be thought of as the
-  #     title or summary of the Metasploit Module.
-  #   @return [void]
-
-  # @!method stance=(stance)
-  #   Sets {#stance}.
-  #
-  #   @param stance ['aggressive', 'passive'] Use ``'aggressive'` when this Metasploit Module connects to a remote
-  #     server, so the Metasploit Module is a client exploiting a server.  Use `'passive'` when this Metasploit Module
-  #     waits for remote clients to connect to it, so the Metasploit Module is a server exploiting clients.
-  #   @return [void]
-
-
   private
 
   # Validates that {#default_action}, when it is set, is in {#actions}.

--- a/app/models/metasploit/cache/email_address.rb
+++ b/app/models/metasploit/cache/email_address.rb
@@ -123,30 +123,5 @@ class Metasploit::Cache::EmailAddress < ActiveRecord::Base
     local
   end
 
-  # @!method domain=(domain)
-  #   Sets {#domain}.
-  #
-  #   @param domain [String] The domain part of the email address after the `'@'`.
-  #   @return [void]
-
-  # @!method full=(full)
-  #   Sets {#full}.
-  #
-  #   @param full [String] <{#local}>@<{#domain}>
-  #   @return [void]
-
-  # @!method local=(local)
-  #   Sets {#local}.
-  #
-  #   @param local [String] The local part of the email address before the `'@'`.
-  #   @return [void]
-
-  # @!method module_authors=(module_authors)
-  #   Sets {#module_authors}.
-  #
-  #   @param module_authors [Array<Metasploit::Cache::Module::Authors>] Credits where {#authors} used this email address
-  #     for {#module_instances modules}.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/encoder/instance.rb
+++ b/app/models/metasploit/cache/encoder/instance.rb
@@ -37,22 +37,5 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   validates :name,
             presence: true
 
-  #
-  # Instance Methods
-  #
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this encoder Metasploit Module.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human-readable name of this encoder Metasploit Module.  This can be thought of as the
-  #     title or summary of the Metasploit Module.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -96,48 +96,5 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
                 in: Metasploit::Cache::Module::Stance::ALL
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this encoder Metasploit Module.
-  #   @return [void]
-
-  # @!method disclosed_on=(disclosed_on)
-  #   Sets {#disclosed_on}.
-  #
-  #   @param disclosed_on [Date] The date this exploit was disclosed to the public.
-  #   @return [void]
-
-  # @!method exploit_class_id=(exploit_class_id)
-  #   Sets {#exploit_class_id} and causes cache of {#exploit_class} to be invalidated and reloaded on next access.
-  #
-  #   @param exploit_class_id [Integer]
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human-readable name of this exploit Metasploit Module.  This can be thought of as the
-  #     title or summary of the Metasploit Module.
-  #   @return [void]
-
-  # @!method privileged=(privileged)
-  #   Sets {#privileged}.
-  #
-  #   @param priviliged [Boolean] `true` if privileged access is granted; `false` if privileged access is not granted.
-  #   @return [void]
-
-  # @!method stance=(stance)
-  #   Sets {#stance}.
-  #
-  #   @param stance ['aggressive', 'passive'] `'aggressive'` if this Metasploit Module connects to a remote server, so
-  #     the Metasploit Module is a client exploiting a server. `'passive'` if this Metasploit Module waits for remote
-  #     clients to connect to it, so the Metasploit Module is a server exploiting clients.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -45,22 +45,5 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
                 scope: :exploit_instance_id
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method index=(index)
-  #   Sets {#index}
-  #
-  #   @param index [Integer] The index of this target in the array of targets as declared on the
-  #     {#exploit_instance exploit Metasploit Module} source.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] name of this target.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/module/action.rb
+++ b/app/models/metasploit/cache/module/action.rb
@@ -48,21 +48,5 @@ class Metasploit::Cache::Module::Action < ActiveRecord::Base
                 unless: :batched?
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method module_instance=(module_instance)
-  #   Sets {#module_instance}.
-  #
-  #   @param module_instance [Module::Cache::Module::Instance] Module that has this action.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] Name of this action.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/module/ancestor.rb
+++ b/app/models/metasploit/cache/module/ancestor.rb
@@ -419,27 +419,6 @@ class Metasploit::Cache::Module::Ancestor < ActiveRecord::Base
     derived
   end
 
-  # @!method real_path_modified_at=(real_path_modified_at)
-  #   Sets {#real_path_modified_at}.
-  #
-  #   @param real_path_modified_at [String] The modification time of the module {#real_pathname file on-disk}.
-  #   @return [void]
-
-  # @!method real_path_sha1_hex_digest=(real_path_sha1_hex_digest)
-  #   Sets {#real_path_sha1_hex_digest}.
-  #
-  #   @param real_path_sha1_hex_digest [String] The SHA1 hexadecimal digest of contents of the file at {#real_pathname}.
-  #   @return [void]
-
-  # @!method relationships=(relationships)
-  #   Sets {#relationships}.
-  #
-  #   @param relationships [Enumerable<Metasploit::Cache::Model::Relationship>] Relates this
-  #     {Metasploit::Cache::Module::Ancestor} to the
-  #     {Metasploit::Cache::Module::Class Metasploit::Cache::Module::Classes} that
-  #     {Metasploit::Cache::Module::Relationship#descendant descend} from the {Metasploit::Cache::Module::Ancestor}.
-  #   @return [void]
-
   # File names on {#relative_pathname}.
   #
   # @return [Enumerator<String>]
@@ -454,13 +433,6 @@ class Metasploit::Cache::Module::Ancestor < ActiveRecord::Base
     end
   end
 
-  # @!method relative_path=(relative_path)
-  #   Sets the relative path under `#parent_path` {Metasploit::Cache::Module::Path#real_path} where te module file
-  #   exists on-disk.
-  #
-  #   @param relative_path [String] a relative path
-  #   @return [void]
-
   # {#relative_path} as a `Pathname`.
   #
   # @return [Pathname] unless {#relative_path} is `nil`.
@@ -470,12 +442,6 @@ class Metasploit::Cache::Module::Ancestor < ActiveRecord::Base
       Pathname.new(relative_path)
     end
   end
-
-  # @!method reference_name=(reference_name)
-  #   Sets {#reference_name}.
-  #
-  #   @param reference_name [String] The name of the module under its {#module_type type}.
-  #   @return [void]
 
   # The path relative to the {#module_type_directory} under the {Metasploit::Cache::Module::Path
   # parent_path.real_path}, including the file {EXTENSION extension}.

--- a/app/models/metasploit/cache/module/class.rb
+++ b/app/models/metasploit/cache/module/class.rb
@@ -267,13 +267,6 @@ class Metasploit::Cache::Module::Class < ActiveRecord::Base
     derived
   end
 
-  # @!method module_instance=(module_instance)
-  #   Sets {#module_instance}.
-  #
-  #   @param module_instance [Metasploit::Cache::Module::Instance, nil]
-  #     Instance-derived metadata to go along with the class-derived metadata from this model.
-  #   @return [void]
-
   # Returns whether this represents a Class<Msf::Payload>.
   #
   # @return [true] if {#module_type} == 'payload'
@@ -285,17 +278,6 @@ class Metasploit::Cache::Module::Class < ActiveRecord::Base
       false
     end
   end
-
-  # @!method relationships=(relationships)
-  #   Sets {#relationships}.
-  #
-  #   @param relationships [Enumerable<Metasploit::Cache::Module::Relationship>, nil] Join model between
-  #     {Metasploit::Cache::Module::Class} and {Metasploit::Cache::Module::Ancestor} that represents that the Class or
-  #     Module in {Metasploit::Cache::Module::Ancestor#real_path} is an ancestor of the Class represented by this
-  #     {Metasploit::Cache::Module::Class}.
-  #   @return [void]
-
-  # Comment break before private so above comment will be parsed correctly by YARD
 
   private
 
@@ -364,46 +346,6 @@ class Metasploit::Cache::Module::Class < ActiveRecord::Base
 
     derived
   end
-
-  # @!method full_name=(full_name)
-  #   Sets {#full_name}.
-  #
-  #   @param full_name [String] The full name (type + reference) for the Class<Msf::Module>.  This is merely a
-  #     denormalized cache of `"#{{#module_type}}/#{{#reference_name}}"` as full_name is used in numerous queries and
-  #     reports.
-  #   @return [void]
-
-  # @!method module_type=(module_type)
-  #   Sets {#module_type}.
-  #
-  #   @param module_type [String] A denormalized cache of the
-  #     {Metasploit::Cache::Module::Class#module_type ancestors' module_types}, which must all be the same.  This cache
-  #     exists so that queries for modules of a given type don't need include the {#ancestors}.
-  #   @return [void]
-
-
-  # @!method payload_type=(payload_type)
-  #   Sets {#payload_type}.
-  #
-  #   @param payload_type ['single', 'staged', nil] the payload type when {#payload?} `true`; otherwise `nil`.
-  #   @return [void]
-
-  # @!method rank=(rank)
-  #   Sets {#rank}.
-  #
-  #   @param rank [Metasploit::Cache::Module::Rank] The reliability of the module and likelyhood that the module won't
-  #     knock over the service or host being exploited.  Bigger values is better.
-  #   @return [void]
-
-  # @!method reference_name=(reference_name)
-  #   Sets {#reference_name}.
-  #
-  #   @param reference_name [String] The reference name for the Class<Msf::Module>. For non-payloads, this will just be
-  #     {Metasploit::Cache::Module::Ancestor#reference_name} for the only element in {#ancestors}.  For payloads
-  #     composed of a stage and stager, the reference name will be derived from the
-  #     {Metasploit::Cache::Module::Ancestor#reference_name} of each element {#ancestors} or an alias defined in those
-  #     Modules.
-  #   @return [void]
 
   # switch back to public for load hooks
   public

--- a/app/models/metasploit/cache/module/instance.rb
+++ b/app/models/metasploit/cache/module/instance.rb
@@ -720,13 +720,6 @@ class Metasploit::Cache::Module::Instance < ActiveRecord::Base
   # Instance Methods
   #
 
-  # @!method actions=(actions)
-  #   Sets {#actions}.
-  #
-  #   @param actions [Array<Metasploit::Cache::Module::Action>] Auxiliary actions to perform when this running this
-  #     module.
-  #   @return [void]
-
   # Whether the given `attribute` is allowed to have elements.
   #
   # @param attribute [Symbol] name of attribute to check if {#module_type} allows it to have one or more
@@ -743,31 +736,6 @@ class Metasploit::Cache::Module::Instance < ActiveRecord::Base
       false
     end
   end
-
-  # @!method default_action=(default_action)
-  #   Sets {#default_action}.
-  #
-  #   @param default_action [Metasploit::Cache::Module::Action] The default action in {#actions}.
-  #   @return [void]
-
-  # @!method default_target=(default_target)
-  #   Sets {#default_target}.
-  #
-  #   @param default_target [Metasploit::Cache::Module::Target] the default target in {#targets}.
-  #   @return [void]
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] A long, paragraph description of what the module does.
-  #   @return [void]
-
-  # @!method disclosed_on=(disclosed_on)
-  #   Sets {#disclosed_on}.
-  #
-  #   @param disclosed_on [Date, nil] the date the vulnerability exploited by this module was disclosed to the
-  #     public.
-  #   @return [void]
 
   # The dynamic length valdiations, such as `:is` and `:minimum` for the given attribute for the current
   # {#module_type}.
@@ -786,45 +754,6 @@ class Metasploit::Cache::Module::Instance < ActiveRecord::Base
     end
   end
 
-  # @!method license=(license)
-  #   Sets {#license}.
-  #
-  #   @param license [String] The name of the software license for the module's code.
-  #   @return [void]
-
-  # @!method module_architectures=(module_architectures)
-  #   Sets {#module_architectures}.
-  #
-  #   @param module_architectures [Array<Metasploit::Cache::Module::Architecture>] Joins this with {#architectures}.
-  #   @return [void]
-
-  # @!method module_authors=(module_authors)
-  #   Sets {#module_authors}.
-  #
-  #   @param module_authors [Array<Metasploit::Cache::Module::Author>] Joins this with {#authors} and {#email_addresses}
-  #     to model the name and email address used for an author entry in the module metadata.
-  #   @return [void]
-
-  # @!method module_class=(module_class)
-  #   Sets {#module_class}.
-  #
-  #   @param module_class [Metasploit::Cache::Module::Class] Class-derived metadata to go along with the
-  #     instance-derived metadata in this model.
-  #   @return [void]
-
-  # @!method module_platforms=(module_platforms)
-  #   Sets {#module_platforms}.
-  #
-  #   @param module_platforms [Enumerable<Metasploit::Cache::Module::Platform>] joins this with {#platforms}.
-  #   @return [void]
-
-  # @!method module_references=(module_references)
-  #   Sets {#module_references}.
-  #
-  #   @param module_references [Enumerable<Metasploit::Cache::Module::Reference>, nil] Joins {#references} to this
-  #     {Metasploit::Cache::Module::Instance}.
-  #   @return [void]
-
   # @!method module_type
   #   The {Metasploit::Cache::Module::Class#module_type} of the {#module_class}.
   #
@@ -833,27 +762,6 @@ class Metasploit::Cache::Module::Instance < ActiveRecord::Base
            allow_nil: true,
            to: :module_class
 
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human readable name of the module.  It is unrelated to
-  #     {Metasploit::Cache::Module::Class#full_name} or {Metasploit::Cache::Module::Class#reference_name} and is better
-  #     thought of as a short summary of the {#description}.
-  #   @return [void]
-
-  # @!method privileged=(privileged)
-  #   Sets {#priviledged}.
-  #
-  #   @param priviledged [Boolean] Whether this module requires privileged access to run.
-  #   @return [void]
-
-  # @!method stance=(stance)
-  #   Sets {#stance}.
-  #
-  #   @param stance ['active', 'passive', nil] Whether the module is active or passive; `nil` if the {#module_type} is
-  #     not {#stanced?}.
-  #   @return [void]
-
   # Whether {#module_type} requires {#stance} to be set or to be `nil`.
   #
   # @return (see Metasploit::Cache::Module::Instance::ClassMethods#stanced?)
@@ -861,15 +769,6 @@ class Metasploit::Cache::Module::Instance < ActiveRecord::Base
   def stanced?
     self.class.stanced?(module_type)
   end
-
-  # @!method targets=(targets)
-  #   Sets {#targets}.
-  #
-  #   @param targets [Array<Metasploit::Cache::Module::Target>] Targets with different configurations that can be
-  #     exploited by this module.
-  #   @return [void]
-
-  # Comment break to make {#targets=} docs work above `private`
 
   private
 

--- a/app/models/metasploit/cache/module/path.rb
+++ b/app/models/metasploit/cache/module/path.rb
@@ -174,16 +174,6 @@ class Metasploit::Cache::Module::Path < ActiveRecord::Base
     directory
   end
 
-  # @!method gem=(gem)
-  #   Sets {#gem}.
-  #
-  #   @param gem [String] The name of the gem that is adding this module path to metasploit-framework.  For paths
-  #     normally added by metasploit-framework itself, this would be `'metasploit-framework'`, while for Metasploit Pro
-  #     this would be `'metasploit-pro'`.  The name used for `gem` does not have to be a gem on rubygems, it just
-  #     functions as a namespace for {#name} so that projects using metasploit-framework do not need to worry about
-  #     collisions on {#name} which could disrupt the cache behavior.
-  #   @return [void]
-
   # @note This path should be validated before calling {#name_collision} so that {#gem} and {#name} is normalized.
   #
   # Returns path with the same {#gem} and {#name}.
@@ -201,14 +191,6 @@ class Metasploit::Cache::Module::Path < ActiveRecord::Base
 
     collision
   end
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The name of the module path scoped to {#gem}.  {#gem} and {#name} uniquely identify this
-  #     path, so that if {#real_path} changes, the entire cache does not need to be invalidated because the change in
-  #     {#real_path} will still be tied to the same ({#gem}, {#name}) tuple.
-  #   @return [void]
 
   # Returns whether is a named path.
   #
@@ -248,14 +230,6 @@ class Metasploit::Cache::Module::Path < ActiveRecord::Base
 
     was_named
   end
-
-  # @!method real_path=(real_path)
-  #   Sets {#real_path}.
-  #
-  #   @param real_path [String] The real (absolute) path to module path.
-  #   @return [void]
-
-  # Comment break to make {#real_path=} docs work above `private`
 
   private
 

--- a/app/models/metasploit/cache/module/platform.rb
+++ b/app/models/metasploit/cache/module/platform.rb
@@ -39,17 +39,5 @@ class Metasploit::Cache::Module::Platform < ActiveRecord::Base
   # Instance Methods
   #
 
-  # @!method module_instance=(module_instance)
-  #   Sets {#module_instance}.
-  #
-  #   @param module_instance [Metasploit::Cache::Module::Instance] Module that supports {#platform}.
-  #   @return [void]
-
-  # @!method platform=(platform)
-  #   Sets {#platform}.
-  #
-  #   @param platform [Metasploit::Cache::Platform] platform supported by {#module_instance}.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/module/rank.rb
+++ b/app/models/metasploit/cache/module/rank.rb
@@ -137,21 +137,5 @@ class Metasploit::Cache::Module::Rank < ActiveRecord::Base
             },
             uniqueness: true
 
-  #
-  # Instance Methods
-  #
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] the name of the rank.
-  #   @return [void]
-
-  # @!method number=(number)
-  #   Sets {#number}.
-  #
-  #   @param number [Integer] the numerical value of teh rank.  Higher numbers are better.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/module/reference.rb
+++ b/app/models/metasploit/cache/module/reference.rb
@@ -37,23 +37,5 @@ class Metasploit::Cache::Module::Reference < ActiveRecord::Base
                 unless: :batched?
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method module_instance=(module_instance)
-  #   Sets {#module_instance}.
-  #
-  #   @param module_instance [Metasploit::Cache::Module::Instance] {Metasploit::Cache::Module::Instance Module} with
-  #     {#reference}.
-  #   @return [void]
-
-  # @!method reference=(reference)
-  #   Sets {#reference}.
-  #
-  #   @param reference [Metasploit::Cache::Reference] {Metasploit::Cache::Reference reference} to exploit or
-  #     proof-of-concept (PoC) code for module_instance.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/module/target.rb
+++ b/app/models/metasploit/cache/module/target.rb
@@ -87,35 +87,5 @@ class Metasploit::Cache::Module::Target < ActiveRecord::Base
   search_attribute :name,
                    type: :string
 
-  #
-  # Instance Methods
-  #
-
-  # @!method module_instance=(module_instance)
-  #   Sets {#module_instance}.
-  #
-  #   @param module_instance [Metasploit::Cache::Module::Instance] module where this target was declared.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] name of this target.
-  #   @return [void]
-
-  # @!method target_architectures=(target_architectures)
-  #   Sets {#target_architectures}.
-  #
-  #   @param target_architectures [Array<Metasploit::Cache::Module::Target::Architecture>] joins this target ot its
-  #     {#architectures}.
-  #   @return [void]
-
-  # @!method target_platforms=(target_platforms)
-  #   Sets {#target_platforms}.
-  #
-  #   @param target_platforms [Array<Metasploit::Cache::Module::Target::Platform>] joins this target to its
-  #     {#platforms}.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/module/target/architecture.rb
+++ b/app/models/metasploit/cache/module/target/architecture.rb
@@ -36,21 +36,5 @@ class Metasploit::Cache::Module::Target::Architecture < ActiveRecord::Base
   validates :module_target,
             presence: true
 
-  #
-  # Instance Methods
-  #
-
-  # @!method architecture=(architecture)
-  #   Sets {#architecture}.
-  #
-  #   @param architecture [Metasploit::Cache::Architecture] an architecture supported by {#module_target}.
-  #   @return [void]
-
-  # @!method module_target=(module_target)
-  #   Sets {#module_target}.
-  #
-  #   @param module_target [Metasploit::Cache::Module::Target] the module target that supports {#architecture}.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/module/target/platform.rb
+++ b/app/models/metasploit/cache/module/target/platform.rb
@@ -36,21 +36,5 @@ class Metasploit::Cache::Module::Target::Platform < ActiveRecord::Base
                 unless: :batched?
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method module_target=(module_target)
-  #   Sets {#module_target}.
-  #
-  #   @param module_target [Metasploit::Cache::Module::Target] the module target that supports {#platform}.
-  #   @return [void]
-
-  # @!method platform=(platform)
-  #   Sets {#platform}.
-  #
-  #   @param platform [Metasploit::Cache::Platform] the platform supported by the {#module_target}.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/nop/instance.rb
+++ b/app/models/metasploit/cache/nop/instance.rb
@@ -42,28 +42,5 @@ class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
   validates :nop_class_id,
             uniqueness: true
 
-  #
-  # Instance Methods
-  #
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this encoder Metasploit Module.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human-readable name of this exploit Metasploit Module.  This can be thought of as the
-  #     title or summary of the Metasploit Module.
-  #   @return [void]
-
-  # @!method nop_class_id=(nop_class_id)
-  #   Sets {#nop_class_id} and causes cache of {#nop_class} to be invalidated and reloaded on next access.
-  #
-  #   @param nop_class_id [Integer]
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/payload/handler.rb
+++ b/app/models/metasploit/cache/payload/handler.rb
@@ -48,21 +48,5 @@ class Metasploit::Cache::Payload::Handler < ActiveRecord::Base
             presence: true,
             uniqueness: true
 
-  #
-  # Instance Methods
-  #
-
-  # @!method general_handler_type=(general_handler_type)
-  #   Sets {#general_handler_type}.
-  #
-  #   @param general_handler_type [String] the general handler type
-  #   @return [void]
-
-  # @!method handler_type=(handler_type)
-  #   Sets {#handler_type}.
-  #
-  #   @param handler_type [String] the specific handler type
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -63,35 +63,5 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
                 ]
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this single payload Metasploit Module.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human-readable name of this single payload Metasploit Module.  This can be thought of as
-  #     the title or summary of the Metasploit Module.
-  #   @return [void]
-
-  # @!method payload_single_class_id=(payload_single_class_id)
-  #   Sets {#payload_single_class_id} and causes cache of {#payload_single_class} to be invalidated and reloaded on next
-  #   access.
-  #
-  #   @param payload_single_class_id [Integer]
-  #   @return [void]
-
-  # @!method privileged=(privileged)
-  #   Sets {#privileged}.
-  #
-  #   @param priviliged [Boolean] `true` if privileged access is required; `false` if privileged access is not required.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -48,35 +48,5 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   validates :payload_stage_class_id,
             uniqueness: true
 
-  #
-  # Instance Methods
-  #
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this stage payload Metasploit Module.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human-readable name of this stage payload Metasploit Module.  This can be thought of as
-  #     the title or summary of the Metasploit Module.
-  #   @return [void]
-
-  # @!method payload_stage_class_id=(payload_stage_class_id)
-  #   Sets {#payload_stage_class_id} and causes cache of {#payload_stage_class} to be invalidated and reloaded on next
-  #   access.
-  #
-  #   @param payload_stage_class_id [Integer]
-  #   @return [void]
-
-  # @!method privileged=(privileged)
-  #   Sets {#privileged}.
-  #
-  #   @param priviliged [Boolean] `true` if privileged access is required; `false` if privileged access is not required.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/payload/stager/instance.rb
+++ b/app/models/metasploit/cache/payload/stager/instance.rb
@@ -61,42 +61,5 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   validates :payload_stager_class_id,
             uniqueness: true
 
-  #
-  # Instance Methods
-  #
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this stager payload Metasploit Module.
-  #   @return [void]
-
-  # @!attribute handler_type_alias=(handler_type_alias)
-  #   Sets {#handler_type_alias}.
-  #
-  #   @param handler_type_alias [String, nil] Alternate name for the handler_type to prevent naming collisions in staged
-  #     payload Metasploit Modules that use this stager payload Metasploit Module.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   @param name [String] The human-readable name of this stager payload Metasploit Module.  This can be thought of as
-  #     the title or summary of the Metasploit Module.
-  #   @return [void]
-
-  # @!method payload_stager_class_id=(payload_stager_class_id)
-  #   Sets {#payload_stager_class_id} and causes cache of {#payload_stager_class} to be invalidated and reloaded on next
-  #   access.
-  #
-  #   @param payload_stager_class_id [Integer]
-  #   @return [void]
-
-  # @!method privileged=(privileged)
-  #   Sets {#privileged}.
-  #
-  #   @param priviliged [Boolean] `true` if privileged access is required; `false` if privileged access is not required.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/platform.rb
+++ b/app/models/metasploit/cache/platform.rb
@@ -144,39 +144,5 @@ class Metasploit::Cache::Platform < ActiveRecord::Base
     end
   end
 
-  # @!method fully_qualified_name=(fully_qualified_name)
-  #   Sets {#fully_qualified_name}.
-  #
-  #   @param full_qualified_name [String] The fully qualified name of this platform, as would be used in the platform
-  #     list in a metasploit-framework module.
-  #   @return [void]
-
-  # @!method module_platforms=(module_platforms)
-  #   Sets {#module_platforms}.
-  #
-  #   @param module_platforms [Enumerable<Metasploit::Cache::Module::Platform>, nil] Joins this
-  #     {Metasploit::Cache::Platform} to {Metasploit::Cache::Module::Instance modules} that support the platform.
-  #   @return [void]
-
-  # @!method parent=(parent)
-  #   Sets {#parent}.
-  #
-  #   @param parent [Metasploit::Cache::Platform, nil]  The parent platform of this platform; `nil` if this is a
-  #     top-level platform.
-  #   @return [void]
-
-  # @!method relative_name=(relative_name)
-  #   Sets {#relative_name}.
-  #
-  #   @param relative_name [String] name of this platform relative to the {#fully_qualified_name} of {#parent}.
-  #   @return [void]
-
-  # @!method target_platforms=(target_platforms)
-  #   Sets {#target_platforms}.
-  #
-  #   @param target_platforms [Enumerable<Metasploit::Cache::Target::Platform>, nil] Joins this to
-  #     {Metasploit::Cache::Module::Target targets} that support this platform.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -62,41 +62,5 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
                 ]
             }
 
-  #
-  # Instance Methods
-  #
-
-  # @!method description=(description)
-  #   Sets {#description}.
-  #
-  #   @param description [String] The long-form human-readable description of this post Metasploit Module.
-  #   @return [void]
-
-  # @!method disclosed_on=(disclosed_on)
-  #   Sets {#disclosed_on}.
-  #
-  #   @param disclosed_on [Date] The date the exploit exercised by this post Metasploit Module was disclosed to the
-  #     public.
-  #   @return [void]
-
-  # @!method name=(name)
-  #   Sets {#name}.
-  #
-  #   name [String] The human-readable name of this post Metasploit Module.  This can be thought of as the
-  #     title or summary of the Metasploit Module.
-  #   @return [void]
-
-  # @!method post_class_id=(post_class_id)
-  #   Sets {#post_class_id} and causes cached of {#post_class} to be invalided and reloaded on next access.
-  #
-  #   @param post_class_id [Integer]
-  #   @return [void]
-
-  # @!method privileged=(privileged)
-  #   Sets {#privileged}.
-  #
-  #   @param priviliged [Boolean] `true` if privileged access is required; `false` if privileged access is not required.
-  #   @return [void]
-
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/reference.rb
+++ b/app/models/metasploit/cache/reference.rb
@@ -89,12 +89,6 @@ class Metasploit::Cache::Reference < ActiveRecord::Base
   # Instance Methods
   #
 
-  # @!method authority=(authority)
-  #   Sets {#authority}.
-  #
-  #   @param authority [Metasploit::Cache::Authority, nil]  The {Metasploit::Cache::Authority authority} that assigned
-  #     {#designation}.  `nil` if only a {#url} reference and not from an {Metasploit::Cache::Authority authority}.
-
   # Returns whether {#authority} is not `nil`.
   #
   # @return [true] unless {#authority} is `nil`.
@@ -115,27 +109,6 @@ class Metasploit::Cache::Reference < ActiveRecord::Base
 
     derived
   end
-
-  # @!method designation=(designation)
-  #   Sets {#designation}.
-  #
-  #   @param designation [String, nil] a designation (usually a string of numbers and dashes) assigned by {#authority};
-  #     `nil` if a {#url} only reference.
-  #   @return [void]
-
-  # @!method module_references=(module_references)
-  #   Sets {#module_references}.
-  #
-  #   @param module_references [Enumerable<Metasploit::Cache::Module::Reference>, nil] Joins this
-  #     {Metasploit::Cache::Reference} to {#module_instances}.
-  #   @return [void]
-
-  # @!method url=(url)
-  #   Sets {#url}.
-  #
-  #   @param url [String, nil] URL to web page with information about referenced exploit. Should only be `nil` if
-  #     {#authority} {Metasploit::Cache::Authority#obsolete} is `true`.
-  #   @return [void]
 
   Metasploit::Concern.run(self)
 end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,7 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 27
+      PATCH = 28
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'extra-writer-docs'
 
       #
       # Module Methods

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -12,6 +12,8 @@ module Metasploit
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 31
+      # Remove on master
+      PRERELEASE = 'extra-writer-docs'
 
       #
       # Module Methods

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -12,8 +12,6 @@ module Metasploit
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 31
-      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-      PRERELEASE = 'extra-writer-docs'
 
       #
       # Module Methods


### PR DESCRIPTION
MSP-12717

Remove unneeded writer docs for attributes by using [metasploit-yard that ignores undocumented attribute writers](https://github.com/rapid7/metasploit-yard/pull/6)

# Pre-verification Steps
- [x] Release https://github.com/rapid7/metasploit-yard/pull/6 as metasploit-yard 1.0.3

# Verification Steps

## Without metasploit-yard 0.1.2
- [ ] `git checkout c269ced`
- [ ] `rm Gemfile.lock`
- [ ] `gem uninstall metasploit-yard`
- [ ] `gem install metasploit-yard --version '1.0.2'`
- [ ] `bundle`
- [ ] `rake yard:stats`
- [ ] VERIFY writer (`<foo>=`) methods are shown as undocumented

## With metasploit-yard 0.1.3
- [x] `git checkout bug/MSP-12717/extra-writer-docs`
- [x] `rm Gemfile.lock`
- [x] `bundle`

### Postgresql
- [x] `rm Gemfile.lock`
- [x] `bundle install --without sqlite3`
- [x] `rake db:drop db:create db:migrate`

#### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.72% coverage

#### Documentation Coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [x] VERIFY no undocumented objects

### Sqlite3
- [x] `rm Gemfile.lock`
- [x] `bundle install --without postgresql`
- [x] `rake db:drop db:create db:migrate`

#### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.68% coverage

### Documentation coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.s
- [x] VERIFY no undocumented objects