### PR TITLE
Metasploit::Cache::Architecturable::Architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,10 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 100% coverage.
+3. Verify there was 99.73% coverage.
 
 ##### Documentation
-1. `rake yard`
+1. `rake yard:stats`
 2. Verify there were no warnings.
 2. Verify there were no undocumented objects.
 
@@ -63,10 +63,10 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 100% coverage.
+3. Verify there was 99.69% coverage.
 
 ##### Documentation
-1. `rake yard`
+1. `rake yard:stats`
 2. Verify there were no warnings.
 2. Verify there were no undocumented objects.
 
@@ -90,11 +90,11 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] VERIFY 99.73% coverage
 
 ### Documentation Coverage
-- [ ] `rake yard`
-- [ ] VERIFY no warnings
+- [ ] `rake yard:stats`
+- [ ] VERIFY only `[warn]`ings are for scope parameters
 - [ ] VERIFY no undocumented objects
 
 ## Sqlite3
@@ -105,11 +105,11 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] VERIFY 99.69% coverage
 
 ### Documentation coverage
-- [ ] `rake yard`
-- [ ] VERIFY no warnings
+- [ ] `rake yard:stats`
+- [ ] VERIFY only `[warn]`ings are for scope parameters
 - [ ] VERIFY no undocumented objects
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -44,8 +44,8 @@ task :coverage do
   # coverage differs by adapter because different adapters have different handling in Metasploit::Cache::Batched::Root
   # and its specs.
   minimum_coverage_by_adapter = {
-      'postgresql' => 99.72,
-      'sqlite3' => 99.68
+      'postgresql' => 99.73,
+      'sqlite3' => 99.69
   }
 
   SimpleCov.configure do

--- a/app/models/metasploit/cache/architecturable/architecture.rb
+++ b/app/models/metasploit/cache/architecturable/architecture.rb
@@ -1,0 +1,2 @@
+class Metasploit::Cache::Architecturable::Architecture
+end

--- a/app/models/metasploit/cache/architecturable/architecture.rb
+++ b/app/models/metasploit/cache/architecturable/architecture.rb
@@ -1,3 +1,8 @@
+# Polymorphic join model between {#architecture architectures} and ({Metasploit::Cache::Encoder::Instance encoder},
+# {Metasploit::Cache::Nop::Instance nop}, {Metasploit::Cache::Payload::Single::Instance single payload},
+# {Metasploit::Cache::Payload::Stage::Instance stage payload},
+# {Metasploit::Cache::Payload::Stager::Instance stager payload}, or {Metasploit::Cache::Post::Instance post}) Metasploit
+# Modules or {Metasploit::Cache::Exploit::Target exploit Metasploit Module targets}.
 class Metasploit::Cache::Architecturable::Architecture < ActiveRecord::Base
   #
   # Associations
@@ -14,6 +19,15 @@ class Metasploit::Cache::Architecturable::Architecture < ActiveRecord::Base
              inverse_of: :architecturable_architectures
 
   #
+  # Attributes
+  #
+
+  # @!attribute architecture_id
+  #   The foreign key for {#architecture}.
+  #
+  #   @return [Integer]
+
+  #
   # Validations
   #
 
@@ -28,6 +42,16 @@ class Metasploit::Cache::Architecturable::Architecture < ActiveRecord::Base
                     :architecturable_id
                 ]
             }
+
+  #
+  # Instance Methods
+  #
+
+  # @!method architecture_id=(architecture_id)
+  #   Sets {#architecture_id} and invalidates cached {#architecture} so it is reloaded on next access.
+  #
+  #   @param architecture_id [Integer] Primary key of {#architecture}.
+  #   @return [void]
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/architecturable/architecture.rb
+++ b/app/models/metasploit/cache/architecturable/architecture.rb
@@ -1,3 +1,19 @@
-class Metasploit::Cache::Architecturable::Architecture
+class Metasploit::Cache::Architecturable::Architecture < ActiveRecord::Base
+  #
+  # Associations
+  #
+
+  # The architecture supported by the `#architecturable`.
+  belongs_to :architecture,
+             class_name: 'Metasploit::Cache::Architecture',
+             inverse_of: :architecturable_architectures
+
+  #
+  # Validations
+  #
+
+  validates :architecture,
+            presence: true
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/architecturable/architecture.rb
+++ b/app/models/metasploit/cache/architecturable/architecture.rb
@@ -3,7 +3,12 @@ class Metasploit::Cache::Architecturable::Architecture < ActiveRecord::Base
   # Associations
   #
 
-  # The architecture supported by the `#architecturable`.
+  # The thing that supports {#architecture}.
+  belongs_to :architecturable,
+             inverse_of: :architecturable_architectures,
+             polymorphic: true
+
+  # The architecture supported by the {#architecturable}.
   belongs_to :architecture,
              class_name: 'Metasploit::Cache::Architecture',
              inverse_of: :architecturable_architectures
@@ -12,8 +17,17 @@ class Metasploit::Cache::Architecturable::Architecture < ActiveRecord::Base
   # Validations
   #
 
+  validates :architecturable,
+            presence: true
   validates :architecture,
             presence: true
+  validates :architecture_id,
+            uniqueness: {
+                scope: [
+                    :architecturable_type,
+                    :architecturable_id
+                ]
+            }
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/architecturable/architecture.rb
+++ b/app/models/metasploit/cache/architecturable/architecture.rb
@@ -1,2 +1,3 @@
 class Metasploit::Cache::Architecturable::Architecture
+  Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/architecture.rb
+++ b/app/models/metasploit/cache/architecture.rb
@@ -62,6 +62,13 @@ class Metasploit::Cache::Architecture < ActiveRecord::Base
   #
   #
 
+  # Join model between this {Metasploit::Cache::Architecture} and Metasploit Module instances or
+  # {Metasploit::Cache::Exploit::Target exploit Metasploit Module targets}
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecture
+
   # Join models between this {Metasploit::Cache::Architecture} and {Metasploit::Cache::Module::Instance}.
   has_many :module_architectures,
            class_name: 'Metasploit::Cache::Module::Architecture',

--- a/app/models/metasploit/cache/encoder/instance.rb
+++ b/app/models/metasploit/cache/encoder/instance.rb
@@ -45,6 +45,10 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   # Validations
   #
 
+  validates :architecturable_architectures,
+            length: {
+                minimum: 1
+            }
   validates :description,
             presence: true
   validates :encoder_class,

--- a/app/models/metasploit/cache/encoder/instance.rb
+++ b/app/models/metasploit/cache/encoder/instance.rb
@@ -4,12 +4,27 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   # Associations
   #
 
+  # Joins {#architectures} to this encoder Metasploit Module.
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecturable
+
   # The class-level metadata for this instance metadata.
   #
   # @return [Metasploit::Cache::Encoder::Class]
   belongs_to :encoder_class,
              class_name: 'Metasploit::Cache::Encoder::Class',
              inverse_of: :encoder_instance
+
+  #
+  # through: :architecturable_architectures
+  #
+
+  # Architectures this encoder Metasploit Modules works on.
+  has_many :architectures,
+           class_name: 'Metasploit::Cache::Architecture',
+           through: :architecturable_architectures
 
   #
   # Attributes

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -47,6 +47,10 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
   # Validations
   #
 
+  validates :architecturable_architectures,
+            length: {
+                minimum: 1
+            }
   validates :exploit_instance,
             presence: true
   validates :index,

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -5,10 +5,25 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
   # Associations
   #
 
+  # Joins {#architectures} to this target.
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecturable
+
   # {Metasploit::Cache::Exploit::Instance Exploit Metasploit Module} on which this is a target.
   belongs_to :exploit_instance,
              class_name: 'Metasploit::Cache::Exploit::Instance',
              inverse_of: :exploit_targets
+
+  #
+  # through: :architecturable_architectures
+  #
+
+  # The architectures targeted by this target.
+  has_many :architectures,
+           class_name: 'Metasploit::Cache::Architecture',
+           through: :architecturable_architectures
 
   #
   # Attributes

--- a/app/models/metasploit/cache/nop/instance.rb
+++ b/app/models/metasploit/cache/nop/instance.rb
@@ -50,6 +50,10 @@ class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
   # Validations
   #
 
+  validates :architecturable_architectures,
+            length: {
+                minimum: 1
+            }
   validates :description,
             presence: true
   validates :name,

--- a/app/models/metasploit/cache/nop/instance.rb
+++ b/app/models/metasploit/cache/nop/instance.rb
@@ -1,13 +1,30 @@
 # Instance-level metadata for a nop Metasploit Module
 class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
+  #
+
+  # Joins {#architectures} to this nop Metasploit Module.
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecturable
 
   # The class level metadata for this nop Metasploit Module.
   belongs_to :nop_class,
              class_name: 'Metasploit::Cache::Nop::Class',
              inverse_of: :nop_instance
+
+  #
+  # through: :architecturable_architectures
+  #
+
+  # Architectures on which this Metasploit Module can generate NOPs.
+  has_many :architectures,
+           class_name: 'Metasploit::Cache::Architecture',
+           through: :architecturable_architectures
 
   #
   # Attributes

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -62,6 +62,10 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   # Validations
   #
 
+  validates :architecturable_architectures,
+            length: {
+                minimum: 1
+            }
   validates :description,
             presence: true
   validates :handler,

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -1,8 +1,16 @@
 # Instance-level metadata for single payload Metasploit Modules
 class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
+  #
+
+  # Joins {#architectures} to this single payload Metasploit Module.
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecturable
 
   # The connection handler
   belongs_to :handler,
@@ -13,6 +21,15 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   belongs_to :payload_single_class,
              class_name: 'Metasploit::Cache::Payload::Single::Class',
              inverse_of: :payload_single_instance
+
+  #
+  # through: architecturable_architectures
+  #
+
+  # Architectures on which this payload can run.
+  has_many :architectures,
+           class_name: 'Metasploit::Cache::Architecture',
+           through: :architecturable_architectures
 
   #
   # Attributes

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -12,7 +12,6 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
            dependent: :destroy,
            inverse_of: :architecturable
 
-
   # The class-level metadata for this stage payload Metasploit Module.
   belongs_to :payload_stage_class,
              class_name: 'Metasploit::Cache::Payload::Stage::Class',

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -1,14 +1,32 @@
 # Instance-level metadata for stage payload Metasploit Module
 class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
+  #
+
+  # Joins {#architectures} to this stage payload Metasploit Module.
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecturable
+
 
   # The class-level metadata for this stage payload Metasploit Module.
   belongs_to :payload_stage_class,
              class_name: 'Metasploit::Cache::Payload::Stage::Class',
              inverse_of: :payload_stage_instance
-  
+
+  #
+  # through: architecturable_architectures
+  #
+
+  # Architectures on which this payload can run.
+  has_many :architectures,
+           class_name: 'Metasploit::Cache::Architecture',
+           through: :architecturable_architectures
+
   #
   # Attributes
   #

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -56,6 +56,10 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   # Validations
   #
 
+  validates :architecturable_architectures,
+            length: {
+                minimum: 1
+            }
   validates :description,
             presence: true
   validates :name,

--- a/app/models/metasploit/cache/payload/stager/instance.rb
+++ b/app/models/metasploit/cache/payload/stager/instance.rb
@@ -1,8 +1,16 @@
 # Instance-level metadata for stager payload Metasploit Module
 class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
+  #
+
+  # Joins {#architectures} to this stager payload Metasploit Module.
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecturable
 
   # The connection handler
   belongs_to :handler,
@@ -13,6 +21,15 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   belongs_to :payload_stager_class,
              class_name: 'Metasploit::Cache::Payload::Stager::Class',
              inverse_of: :payload_stager_instance
+
+  #
+  # through: :architecturable_architectures
+  #
+
+  # Architectures on which this payload can run.
+  has_many :architectures,
+           class_name: 'Metasploit::Cache::Architecture',
+           through: :architecturable_architectures
 
   #
   # Attributes

--- a/app/models/metasploit/cache/payload/stager/instance.rb
+++ b/app/models/metasploit/cache/payload/stager/instance.rb
@@ -67,6 +67,10 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   # Validations
   #
 
+  validates :architecturable_architectures,
+            length: {
+                minimum: 1
+            }
   validates :description,
             presence: true
   validates :handler,

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -1,13 +1,30 @@
 # Instance-level metadata for a post Metasploit Module.
 class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
+  #
+
+  # Joins {#architectures} to this post Metasploit Module.
+  has_many :architecturable_architectures,
+           class_name: 'Metasploit::Cache::Architecturable::Architecture',
+           dependent: :destroy,
+           inverse_of: :architecturable
 
   # The class level metadata for this post Metasploit Module
   belongs_to :post_class,
              class_name: 'Metasploit::Cache::Post::Class',
              inverse_of: :post_instance
+
+  #
+  # through: :architecturable_architectures
+  #
+
+  # Architectures on which this Metasploit Module can run.
+  has_many :architectures,
+           class_name: 'Metasploit::Cache::Architecture',
+           through: :architecturable_architectures
 
   #
   # Attributes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
           attributes:
             architecturable_architectures:
               too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
+        metasploit/cache/payload/stage/instance:
+          attributes:
+            architecturable_architectures:
+              too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,10 @@ en:
           attributes:
             architecturable_architectures:
               too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
+        metasploit/cache/nop/instance:
+          attributes:
+            architecturable_architectures:
+              too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,10 @@ en:
               inclusion: "is not included in exploit targets"
             exploit_targets:
               too_short: "has too few exploit targets (minimum is %{count} exploit target)"
+        metasploit/cache/exploit/target:
+          attributes:
+            architecturable_architectures:
+              too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,10 @@ en:
             actions:
               does_not_contain_default_action: "does not contain default action"
               too_short: "has too few actions (minimum is %{count} action)"
+        metasploit/cache/encoder/instance:
+          attributes:
+            architecturable_architectures:
+              too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
         metasploit/cache/exploit/instance:
           attributes:
             default_exploit_target:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,10 @@ en:
           attributes:
             architecturable_architectures:
               too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
+        metasploit/cache/payload/stager/instance:
+          attributes:
+            architecturable_architectures:
+              too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,10 @@ en:
           attributes:
             architecturable_architectures:
               too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
+        metasploit/cache/payload/single/instance:
+          attributes:
+            architecturable_architectures:
+              too_short: "has too few architecturable architectures (minimum is %{count} architecturable architecture)"
   metasploit:
     model:
       ancestors:

--- a/db/migrate/20150519134624_create_mc_architecturable_architecture.rb
+++ b/db/migrate/20150519134624_create_mc_architecturable_architecture.rb
@@ -25,11 +25,20 @@ class CreateMcArchitecturableArchitecture < ActiveRecord::Migration
       # References
       #
 
+      t.references :architecturable,
+                   null: false,
+                   polymorphic: true
       t.references :architecture,
                    null: false
     end
 
     change_table TABLE_NAME do |t|
+      t.index [:architecturable_type, :architecturable_id],
+              name: 'mc_architecturable_architechurables',
+              unique: false
+      t.index [:architecturable_type, :architecturable_id, :architecture_id],
+              name: 'unique_mc_architecturable_architectures',
+              unique: true
       t.index :architecture_id,
               unique: false
     end

--- a/db/migrate/20150519134624_create_mc_architecturable_architecture.rb
+++ b/db/migrate/20150519134624_create_mc_architecturable_architecture.rb
@@ -1,0 +1,37 @@
+class CreateMcArchitecturableArchitecture < ActiveRecord::Migration
+  #
+  # CONSTANTS
+  #
+  # Name of the table being created
+  TABLE_NAME = :mc_architecturable_architectures
+
+  #
+  # Instance Methods
+  #
+
+  # Drop {TABLE_NAME}.
+  #
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+
+  # Create {TABLE_NAME}.
+  #
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      #
+      # References
+      #
+
+      t.references :architecture,
+                   null: false
+    end
+
+    change_table TABLE_NAME do |t|
+      t.index :architecture_id,
+              unique: false
+    end
+  end
+end

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -25,6 +25,7 @@ module Metasploit
 
     autoload :Actionable
     autoload :Architecture
+    autoload :Architecturable
     autoload :Association
     autoload :Author
     autoload :Authority

--- a/lib/metasploit/cache/architecturable.rb
+++ b/lib/metasploit/cache/architecturable.rb
@@ -1,0 +1,6 @@
+# Polymorphic namespace for `ActiveRecord::Base` subclasses that support architectures.
+module Metasploit::Cache::Architecturable
+  extend ActiveSupport::Autoload
+
+  autoload :Architecture
+end

--- a/lib/metasploit/cache/architecturable.rb
+++ b/lib/metasploit/cache/architecturable.rb
@@ -3,4 +3,15 @@ module Metasploit::Cache::Architecturable
   extend ActiveSupport::Autoload
 
   autoload :Architecture
+
+  #
+  # Module Methods
+  #
+
+  # The prefix for ActiveRecord::Base subclass table names in this namespace.
+  #
+  # @return [String]
+  def self.table_name_prefix
+    "#{parent.table_name_prefix}architecturable_"
+  end
 end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,7 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 27
+      PATCH = 28
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'architecturable-architecture'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe Metasploit::Cache::Architecturable::Architecture do
       it { is_expected.to be_valid }
     end
 
-    context 'metasploit_cache_payload_post_architecture' do
-      subject(:metasploit_cache_payload_post_architecture) {
-        FactoryGirl.build(:metasploit_cache_payload_post_architecture)
+    context 'metasploit_cache_post_architecture' do
+      subject(:metasploit_cache_post_architecture) {
+        FactoryGirl.build(:metasploit_cache_post_architecture)
       }
 
       it { is_expected.to be_valid }

--- a/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Metasploit::Cache::Architecturable::Architecture do
+end

--- a/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
@@ -1,2 +1,3 @@
 RSpec.describe Metasploit::Cache::Architecturable::Architecture do
+  it_should_behave_like 'Metasploit::Concern.run'
 end

--- a/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
@@ -1,20 +1,92 @@
 RSpec.describe Metasploit::Cache::Architecturable::Architecture do
   context 'associations' do
     it { is_expected.to belong_to(:architecture).class_name('Metasploit::Cache::Architecture').inverse_of(:architecturable_architectures) }
+    it { is_expected.to belong_to(:architecturable) }
   end
 
   context 'database' do
     context 'columns' do
+      it { is_expected.to have_db_column(:architecturable_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:architecturable_type).of_type(:string).with_options(null: false) }
       it { is_expected.to have_db_column(:architecture_id).of_type(:integer).with_options(null: false) }
     end
 
     context 'indices' do
-      it { is_expected.to have_db_index(:architecture_id) }
+      it { is_expected.to have_db_index([:architecturable_type, :architecturable_id]).unique(false) }
+      it { is_expected.to have_db_index([:architecturable_type, :architecturable_id, :architecture_id]).unique(true) }
+      it { is_expected.to have_db_index(:architecture_id).unique(false) }
+    end
+  end
+
+  context 'factories' do
+    context 'metasploit_cache_encoder_architecture' do
+      subject(:metasploit_cache_encoder_architecture) {
+        FactoryGirl.build(:metasploit_cache_encoder_architecture)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_exploit_target_architecture' do
+      subject(:metasploit_cache_exploit_target_architecture) {
+        FactoryGirl.build(:metasploit_cache_exploit_target_architecture)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_nop_architecture' do
+      subject(:metasploit_cache_nop_architecture) {
+        FactoryGirl.build(:metasploit_cache_nop_architecture)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_payload_single_architecture' do
+      subject(:metasploit_cache_payload_single_architecture) {
+        FactoryGirl.build(:metasploit_cache_payload_single_architecture)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_payload_stage_architecture' do
+      subject(:metasploit_cache_payload_stage_architecture) {
+        FactoryGirl.build(:metasploit_cache_payload_stage_architecture)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_payload_stager_architecture' do
+      subject(:metasploit_cache_payload_stager_architecture) {
+        FactoryGirl.build(:metasploit_cache_payload_stager_architecture)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_payload_post_architecture' do
+      subject(:metasploit_cache_payload_post_architecture) {
+        FactoryGirl.build(:metasploit_cache_payload_post_architecture)
+      }
+
+      it { is_expected.to be_valid }
     end
   end
 
   context 'validations' do
+    it { is_expected.to validate_presence_of :architecturable }
     it { is_expected.to validate_presence_of :architecture }
+
+    context 'with pre-existing record' do
+      let!(:existing_architecturable_architecture) {
+        FactoryGirl.create(:metasploit_cache_encoder_architecture)
+      }
+
+      it { is_expected.to validate_uniqueness_of(:architecture_id).scoped_to(:architecturable_type, :architecturable_id) }
+    end
   end
 
   it_should_behave_like 'Metasploit::Concern.run'

--- a/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
@@ -1,3 +1,21 @@
 RSpec.describe Metasploit::Cache::Architecturable::Architecture do
+  context 'associations' do
+    it { is_expected.to belong_to(:architecture).class_name('Metasploit::Cache::Architecture').inverse_of(:architecturable_architectures) }
+  end
+
+  context 'database' do
+    context 'columns' do
+      it { is_expected.to have_db_column(:architecture_id).of_type(:integer).with_options(null: false) }
+    end
+
+    context 'indices' do
+      it { is_expected.to have_db_index(:architecture_id) }
+    end
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of :architecture }
+  end
+
   it_should_behave_like 'Metasploit::Concern.run'
 end

--- a/spec/app/models/metasploit/cache/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecture_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe Metasploit::Cache::Architecture do
   end
 
   context 'associations' do
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecture) }
     it { should have_many(:module_architectures).class_name('Metasploit::Cache::Module::Architecture').dependent(:destroy) }
     it { should have_many(:module_instances).class_name('Metasploit::Cache::Module::Instance').through(:module_architectures) }
     it { should have_many(:target_architectures).class_name('Metasploit::Cache::Module::Target::Architecture').dependent(:destroy) }

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -35,45 +35,9 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
   context 'validations' do
     it { is_expected.to validate_presence_of(:auxiliary_class) }
 
-    # validate_lenght_of from shoulda-matchers assumes attribute is String and doesn't work on associations
-    context 'validates length of actions is at least 1' do
-      let(:error) {
-        I18n.translate!(
-          'activerecord.errors.models.metasploit/cache/auxiliary/instance.attributes.actions.too_short',
-           count: 1
-        )
-      }
-
-      context 'without actions' do
-        subject(:auxiliary_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_auxiliary_instance,
-              actions_count: 0
-          )
-        }
-
-        it 'adds error on #actions' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:actions]).to include(error)
-        end
-      end
-
-      context 'with actions' do
-        subject(:auxiliary_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_auxiliary_instance,
-              actions_count: 1
-          )
-        }
-
-        it 'does not adds error on #actions' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:actions]).not_to include(error)
-        end
-      end
-    end
+    it_should_behave_like 'validates at least one associated',
+                          :actions,
+                          factory: :metasploit_cache_auxiliary_instance
 
     context 'actions_contains_default_action' do
       let(:error) {
@@ -88,7 +52,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
             subject(:auxiliary_instance) {
               FactoryGirl.build(
                              :metasploit_cache_auxiliary_instance,
-                             actions_count: 1
+                             action_count: 1
               ).tap { |auxiliary_instance|
                 auxiliary_instance.default_action = auxiliary_instance.actions.first
               }
@@ -117,7 +81,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
             subject(:auxiliary_instance) {
               FactoryGirl.build(
                              :metasploit_cache_auxiliary_instance,
-                             actions_count: 1
+                             action_count: 1
               ).tap { |auxiliary_instance|
                 auxiliary_instance.default_action = FactoryGirl.build(
                     :metasploit_cache_auxiliary_action,
@@ -150,7 +114,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 1
+                action_count: 1
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = nil
             }
@@ -177,7 +141,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 0
+                action_count: 0
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = FactoryGirl.build(
                   :metasploit_cache_auxiliary_action,
@@ -205,7 +169,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 0
+                action_count: 0
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = nil
             }

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -33,44 +33,8 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
     it { is_expected.to validate_presence_of :encoder_class }
     it { is_expected.to validate_presence_of :name }
 
-    # validate_length_of from shoulda-matchers assumes attribute is String and doesn't work on associations
-    context 'validates length of architecturable_architectures is at least 1' do
-      let(:error) {
-        I18n.translate!(
-          'activerecord.errors.models.metasploit/cache/encoder/instance.attributes.architecturable_architectures.too_short',
-           count: 1
-        )
-      }
-
-      context 'without architecturable_architectures' do
-        subject(:encoder_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_encoder_instance,
-              architecturable_architecture_count: 0
-          )
-        }
-
-        it 'adds error on #architecturable_architectures' do
-          encoder_instance.valid?
-
-          expect(encoder_instance.errors[:architecturable_architectures]).to include(error)
-        end
-      end
-
-      context 'with architecturable_architectures' do
-        subject(:encoder_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_encoder_instance,
-              architecturable_architecture_count: 1
-          )
-        }
-
-        it 'does not adds error on #architcturable_architectures' do
-          encoder_instance.valid?
-
-          expect(encoder_instance.errors[:architecturable_architectures]).not_to include(error)
-        end
-      end
-    end
+    it_should_behave_like 'validates at least one associated',
+                          :architecturable_architectures,
+                          factory: :metasploit_cache_encoder_instance
   end
 end

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -32,5 +32,45 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :encoder_class }
     it { is_expected.to validate_presence_of :name }
+
+    # validate_length_of from shoulda-matchers assumes attribute is String and doesn't work on associations
+    context 'validates length of architecturable_architectures is at least 1' do
+      let(:error) {
+        I18n.translate!(
+          'activerecord.errors.models.metasploit/cache/encoder/instance.attributes.architecturable_architectures.too_short',
+           count: 1
+        )
+      }
+
+      context 'without architecturable_architectures' do
+        subject(:encoder_instance) {
+          FactoryGirl.build(
+              :metasploit_cache_encoder_instance,
+              architecturable_architecture_count: 0
+          )
+        }
+
+        it 'adds error on #architecturable_architectures' do
+          encoder_instance.valid?
+
+          expect(encoder_instance.errors[:architecturable_architectures]).to include(error)
+        end
+      end
+
+      context 'with architecturable_architectures' do
+        subject(:encoder_instance) {
+          FactoryGirl.build(
+              :metasploit_cache_encoder_instance,
+              architecturable_architecture_count: 1
+          )
+        }
+
+        it 'does not adds error on #architcturable_architectures' do
+          encoder_instance.valid?
+
+          expect(encoder_instance.errors[:architecturable_architectures]).not_to include(error)
+        end
+      end
+    end
   end
 end

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:architectures).class_name('Metasploit::Cache::Architecture') }
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
     it { is_expected.to belong_to(:encoder_class).class_name('Metasploit::Cache::Encoder::Class').inverse_of(:encoder_instance) }
   end
 

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
     it { is_expected.to validate_presence_of :index }
     it { is_expected.to validate_presence_of :name }
 
+    it_should_behave_like 'validates at least one associated',
+                          :architecturable_architectures,
+                          factory: :metasploit_cache_exploit_target
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:architectures).class_name('Metasploit::Cache::Architecture') }
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
     it { is_expected.to belong_to(:exploit_instance).class_name('Metasploit::Cache::Exploit::Instance').inverse_of(:exploit_targets) }
   end
 

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Metasploit::Cache::Nop::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to have_many(:architectures).class_name('Metasploit::Cache::Architecture') }
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
+    it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
@@ -21,10 +27,6 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
 
       it { is_expected.to be_valid }
     end
-  end
-
-  context 'associations' do
-    it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
   end
 
   context 'validations' do

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :nop_class }
 
+    it_should_behave_like 'validates at least one associated',
+                          :architecturable_architectures,
+                          factory: :metasploit_cache_nop_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
     it { is_expected.to validate_presence_of :payload_single_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
+    it_should_behave_like 'validates at least one associated',
+                          :architecturable_architectures,
+                          factory: :metasploit_cache_payload_single_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:architectures).class_name('Metasploit::Cache::Architecture') }
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
   end
 

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to belong_to(:payload_stage_class).class_name('Metasploit::Cache::Payload::Stage::Class').inverse_of(:payload_stage_instance) }
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:architectures).class_name('Metasploit::Cache::Architecture') }
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
     it { is_expected.to belong_to(:payload_stage_class).class_name('Metasploit::Cache::Payload::Stage::Class').inverse_of(:payload_stage_instance) }
   end
 

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
     it { is_expected.to validate_presence_of :payload_stage_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
+    it_should_behave_like 'validates at least one associated',
+                          :architecturable_architectures,
+                          factory: :metasploit_cache_payload_stage_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_stager_instances) }
+    it { is_expected.to belong_to(:payload_stager_class).class_name('Metasploit::Cache::Payload::Stager::Class').inverse_of(:payload_stager_instance) }
   end
 
   context 'database' do

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:architectures).class_name('Metasploit::Cache::Architecture') }
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_stager_instances) }
     it { is_expected.to belong_to(:payload_stager_class).class_name('Metasploit::Cache::Payload::Stager::Class').inverse_of(:payload_stager_instance) }
   end

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
     it { is_expected.to validate_presence_of :payload_stager_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
+    it_should_behave_like 'validates at least one associated',
+                          :architecturable_architectures,
+                          factory: :metasploit_cache_payload_stage_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Metasploit::Cache::Post::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to have_many(:architectures).class_name('Metasploit::Cache::Architecture') }
+    it { is_expected.to have_many(:architecturable_architectures).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
+    it { is_expected.to belong_to(:post_class).class_name('Metasploit::Cache::Post::Class').inverse_of(:post_instance) }
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
@@ -13,10 +19,6 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     context 'indices' do
       it { is_expected.to have_db_index(:post_class_id).unique(true) }
     end
-  end
-
-  context 'associations' do
-    it { is_expected.to belong_to(:post_class).class_name('Metasploit::Cache::Post::Class').inverse_of(:post_instance) }
   end
 
   context 'factories' do

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -305,15 +305,13 @@ ActiveRecord::Schema.define(:version => 20150519134624) do
   add_index "mc_platforms", ["parent_id", "relative_name"], :name => "index_mc_platforms_on_parent_id_and_relative_name", :unique => true
 
   create_table "mc_post_instances", :force => true do |t|
-    t.text    "description",       :null => false
-    t.date    "disclosed_on",      :null => false
-    t.string  "name",              :null => false
-    t.boolean "privileged",        :null => false
-    t.integer "default_action_id"
-    t.integer "post_class_id",     :null => false
+    t.text    "description",   :null => false
+    t.date    "disclosed_on",  :null => false
+    t.string  "name",          :null => false
+    t.boolean "privileged",    :null => false
+    t.integer "post_class_id", :null => false
   end
 
-  add_index "mc_post_instances", ["default_action_id"], :name => "index_mc_post_instances_on_default_action_id", :unique => true
   add_index "mc_post_instances", ["post_class_id"], :name => "index_mc_post_instances_on_post_class_id", :unique => true
 
   create_table "mc_references", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150507130708) do
+ActiveRecord::Schema.define(:version => 20150519134624) do
 
   create_table "mc_actionable_actions", :force => true do |t|
     t.string  "name",            :null => false
@@ -20,6 +20,12 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
   end
 
   add_index "mc_actionable_actions", ["actionable_type", "actionable_id", "name"], :name => "unique_mc_actionable_actions", :unique => true
+
+  create_table "mc_architecturable_architectures", :force => true do |t|
+    t.integer "architecture_id", :null => false
+  end
+
+  add_index "mc_architecturable_architectures", ["architecture_id"], :name => "index_mc_architecturable_architectures_on_architecture_id"
 
   create_table "mc_architectures", :force => true do |t|
     t.integer "bits"
@@ -295,13 +301,15 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
   add_index "mc_platforms", ["parent_id", "relative_name"], :name => "index_mc_platforms_on_parent_id_and_relative_name", :unique => true
 
   create_table "mc_post_instances", :force => true do |t|
-    t.text    "description",   :null => false
-    t.date    "disclosed_on",  :null => false
-    t.string  "name",          :null => false
-    t.boolean "privileged",    :null => false
-    t.integer "post_class_id", :null => false
+    t.text    "description",       :null => false
+    t.date    "disclosed_on",      :null => false
+    t.string  "name",              :null => false
+    t.boolean "privileged",        :null => false
+    t.integer "default_action_id"
+    t.integer "post_class_id",     :null => false
   end
 
+  add_index "mc_post_instances", ["default_action_id"], :name => "index_mc_post_instances_on_default_action_id", :unique => true
   add_index "mc_post_instances", ["post_class_id"], :name => "index_mc_post_instances_on_post_class_id", :unique => true
 
   create_table "mc_references", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -22,9 +22,13 @@ ActiveRecord::Schema.define(:version => 20150519134624) do
   add_index "mc_actionable_actions", ["actionable_type", "actionable_id", "name"], :name => "unique_mc_actionable_actions", :unique => true
 
   create_table "mc_architecturable_architectures", :force => true do |t|
-    t.integer "architecture_id", :null => false
+    t.integer "architecturable_id",   :null => false
+    t.string  "architecturable_type", :null => false
+    t.integer "architecture_id",      :null => false
   end
 
+  add_index "mc_architecturable_architectures", ["architecturable_type", "architecturable_id", "architecture_id"], :name => "unique_mc_architecturable_architectures", :unique => true
+  add_index "mc_architecturable_architectures", ["architecturable_type", "architecturable_id"], :name => "mc_architecturable_architechurables"
   add_index "mc_architecturable_architectures", ["architecture_id"], :name => "index_mc_architecturable_architectures_on_architecture_id"
 
   create_table "mc_architectures", :force => true do |t|

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -43,6 +43,14 @@ FactoryGirl.define do
     association :architecturable, factory: :metasploit_cache_payload_stage_instance
   end
 
+  factory :metasploit_cache_payload_stager_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture,
+          traits: [
+              :metasploit_cache_architecturable_architecture
+          ] do
+    association :architecturable, factory: :metasploit_cache_payload_stager_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -35,6 +35,14 @@ FactoryGirl.define do
     association :architecturable, factory: :metasploit_cache_payload_single_instance
   end
 
+  factory :metasploit_cache_payload_stage_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture,
+          traits: [
+              :metasploit_cache_architecturable_architecture
+          ] do
+    association :architecturable, factory: :metasploit_cache_payload_stage_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -19,6 +19,14 @@ FactoryGirl.define do
     association :architecturable, factory: :metasploit_cache_exploit_target
   end
 
+  factory :metasploit_cache_nop_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture,
+          traits: [
+              :metasploit_cache_architecturable_architecture
+          ] do
+    association :architecturable, factory: :metasploit_cache_nop_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -11,6 +11,14 @@ FactoryGirl.define do
     association :architecturable, factory: :metasploit_cache_encoder_instance
   end
 
+  factory :metasploit_cache_exploit_target_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture,
+          traits: [
+              :metasploit_cache_architecturable_architecture
+          ] do
+    association :architecturable, factory: :metasploit_cache_exploit_target
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -1,0 +1,21 @@
+FactoryGirl.define do
+  #
+  # Factories
+  #
+
+  factory :metasploit_cache_encoder_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture,
+          traits: [
+              :metasploit_cache_architecturable_architecture
+          ] do
+    association :architecturable, factory: :metasploit_cache_encoder_instance
+  end
+
+  #
+  # Traits
+  #
+
+  trait :metasploit_cache_architecturable_architecture do
+    architecture { generate :metasploit_cache_architecture }
+  end
+end

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -51,6 +51,14 @@ FactoryGirl.define do
     association :architecturable, factory: :metasploit_cache_payload_stager_instance
   end
 
+  factory :metasploit_cache_post_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture,
+          traits: [
+              :metasploit_cache_architecturable_architecture
+          ] do
+    association :architecturable, factory: :metasploit_cache_post_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -27,6 +27,14 @@ FactoryGirl.define do
     association :architecturable, factory: :metasploit_cache_nop_instance
   end
 
+  factory :metasploit_cache_payload_single_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture,
+          traits: [
+              :metasploit_cache_architecturable_architecture
+          ] do
+    association :architecturable, factory: :metasploit_cache_payload_single_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   factory :metasploit_cache_auxiliary_instance,
           class: Metasploit::Cache::Auxiliary::Instance do
     transient do
-      actions_count 1
+      action_count 1
     end
 
     description { generate :metasploit_cache_auxiliary_instance_description }
@@ -26,7 +26,7 @@ FactoryGirl.define do
     after(:build) { |auxiliary_instance, evaluator|
       auxiliary_instance.actions = build_list(
           :metasploit_cache_auxiliary_action,
-          evaluator.actions_count,
+          evaluator.action_count,
           actionable: auxiliary_instance
       )
     }

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -5,6 +5,10 @@ FactoryGirl.define do
 
   factory :metasploit_cache_encoder_instance,
           class: Metasploit::Cache::Encoder::Instance do
+    transient do
+      architecturable_architecture_count { 1 }
+    end
+
     description { generate :metasploit_cache_encoder_instance_description }
     name { generate :metasploit_cache_encoder_instance_name }
 
@@ -13,6 +17,18 @@ FactoryGirl.define do
     #
 
     association :encoder_class, factory: :metasploit_cache_encoder_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) { |encoder_instance, evaluator|
+      encoder_instance.architecturable_architectures = build_list(
+          :metasploit_cache_encoder_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: encoder_instance
+      )
+    }
   end
 
   #

--- a/spec/factories/metasploit/cache/exploit/targets.rb
+++ b/spec/factories/metasploit/cache/exploit/targets.rb
@@ -1,10 +1,30 @@
 FactoryGirl.define do
   factory :metasploit_cache_exploit_target,
           class: Metasploit::Cache::Exploit::Target do
+    transient do
+      architecturable_architecture_count { 1 }
+    end
+
     index { generate :metasploit_cache_exploit_target_index }
     name { generate :metasploit_cache_exploit_target_name }
 
+    #
+    # Associations
+    #
+
     association :exploit_instance, factory: :metasploit_cache_exploit_instance
+
+    #
+    # Callbacks
+    #
+
+    after(:build) { |exploit_target, evaluator|
+      exploit_target.architecturable_architectures = build_list(
+          :metasploit_cache_exploit_target_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: exploit_target
+      )
+    }
   end
 
   sequence :metasploit_cache_exploit_target_index do |n|

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -1,10 +1,31 @@
 FactoryGirl.define do
   factory :metasploit_cache_nop_instance,
           class: Metasploit::Cache::Nop::Instance do
+    transient do
+      architecturable_architecture_count { 1 }
+    end
+
     description { generate :metasploit_cache_nop_instance_description }
     name { generate :metasploit_cache_nop_instance_name }
 
+    #
+    # Associations
+    #
+
     association :nop_class, factory: :metasploit_cache_nop_class
+
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |nop_instance, evaluator|
+      nop_instance.architecturable_architectures = build_list(
+          :metasploit_cache_nop_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: nop_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
           class: Metasploit::Cache::Payload::Single::Instance do
+    transient do
+      architecturable_architecture_count { 1 }
+    end
+
     description { generate :metasploit_cache_payload_single_instance_description }
     name { generate :metasploit_cache_payload_single_instance_name }
     privileged { generate :metasploit_cache_payload_single_instance_privileged }
@@ -11,6 +15,18 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_single_class, factory: :metasploit_cache_payload_single_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |payload_single_instance, evaluator|
+      payload_single_instance.architecturable_architectures = build_list(
+          :metasploit_cache_payload_single_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: payload_single_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -1,11 +1,31 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stage_instance,
           class: Metasploit::Cache::Payload::Stage::Instance do
+    transient do
+      architecturable_architecture_count { 1 }
+    end
+    
     description { generate :metasploit_cache_payload_stage_instance_description }
     name { generate :metasploit_cache_payload_stage_instance_name }
     privileged { generate :metasploit_cache_payload_stage_instance_privileged }
 
+    #
+    # Associations
+    #
+    
     association :payload_stage_class, factory: :metasploit_cache_payload_stage_class
+    
+    #
+    # Callbacks
+    #
+
+    after(:build) do |payload_stage_instance, evaluator|
+      payload_stage_instance.architecturable_architectures = build_list(
+          :metasploit_cache_payload_stage_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: payload_stage_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stager_instance,
           class: Metasploit::Cache::Payload::Stager::Instance do
+    transient do
+      architecturable_architecture_count { 1 }
+    end
+    
     description { generate :metasploit_cache_payload_stager_instance_description }
     handler_type_alias { generate :metasploit_cache_payload_stager_handler_type_alias }
     name { generate :metasploit_cache_payload_stager_instance_name }
@@ -12,6 +16,18 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_stager_class, factory: :metasploit_cache_payload_stager_class
+     
+    #
+    # Callbacks
+    #
+
+    after(:build) do |payload_stager_instance, evaluator|
+      payload_stager_instance.architecturable_architectures = build_list(
+          :metasploit_cache_payload_stager_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: payload_stager_instance
+      )
+    end   
   end
 
   #

--- a/spec/support/shared/contexts/validates_at_least_one_associated.rb
+++ b/spec/support/shared/contexts/validates_at_least_one_associated.rb
@@ -1,0 +1,41 @@
+# validate_length_of from shoulda-matchers assumes attribute is String and doesn't work on associations
+RSpec.shared_examples_for 'validates at least one associated' do |association, factory:|
+  association_count_key = "#{association.to_s.singularize}_count".to_sym
+
+  let(:error) {
+    I18n.translate!(
+        "#{described_class.i18n_scope}.errors.models.#{described_class.model_name.i18n_key}.attributes.#{association}.too_short",
+        count: 1
+    )
+  }
+
+  context "without #{association}" do
+    subject(:instance) {
+      FactoryGirl.build(
+          factory,
+          association_count_key => 0
+      )
+    }
+
+    it "adds error on ###{association}" do
+      instance.valid?
+
+      expect(instance.errors[association]).to include(error)
+    end
+  end
+
+  context "with #{association}" do
+    subject(:instance) {
+      FactoryGirl.build(
+          factory,
+          association_count_key => 1
+      )
+    }
+
+    it "does not adds error on ###{association}" do
+      instance.valid?
+
+      expect(instance.errors[association]).not_to include(error)
+    end
+  end
+end


### PR DESCRIPTION
MSP-12431

`Metasploit::Cache::Architecturable::Architecture` uses polymorphic association, so it can be the join model for both `Metasploit::Cache::*::Instance` and `Metasploit::Cache::Exploit::Target`.  Add inversed associations:
- `Metasploit::Cache::Encoder::Instance#architectures`
- `Metasploit::Cache::Exploit::Target#architectures`
- `Metasploit::Cache::Nop::Instance#architectures`
- `Metasploit::Cache::Payload::Single::Instance#architectures`
- `Metasploit::Cache::Payload::Stage::Instance#architectures`
- `Metasploit::Cache::Payload::Stager::Instance#architectures`
- `Metasploit::Cache::Post::Instance#architectures`

Ensure there is at least one architecture for each of the architecturables by validating length of `architecturable_architectures` join model association.

# Verification Steps

## Postgresql
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without sqlite3`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.73% coverage

### Documentation Coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for scope parameters: 
```
[warn]: @param tag has unknown parameter name: module_instances 
    in file `app/models/metasploit/cache/module/class.rb' near line 147
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 317
[warn]: @param tag has unknown parameter name: architecture_abbreviations 
    in file `app/models/metasploit/cache/module/instance.rb' near line 336
[warn]: @param tag has unknown parameter name: architectured 
    in file `app/models/metasploit/cache/module/instance.rb' near line 353
[warn]: @param tag has unknown parameter name: platforms 
    in file `app/models/metasploit/cache/module/instance.rb' near line 367
[warn]: @param tag has unknown parameter name: platform_fully_qualified_names 
    in file `app/models/metasploit/cache/module/instance.rb' near line 403
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 420
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 434
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 492
```
- [ ] VERIFY no undocumented objects

## Sqlite3
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without postgresql`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.69% coverage

### Documentation coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for scope parameters: 
```
[warn]: @param tag has unknown parameter name: module_instances 
    in file `app/models/metasploit/cache/module/class.rb' near line 147
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 317
[warn]: @param tag has unknown parameter name: architecture_abbreviations 
    in file `app/models/metasploit/cache/module/instance.rb' near line 336
[warn]: @param tag has unknown parameter name: architectured 
    in file `app/models/metasploit/cache/module/instance.rb' near line 353
[warn]: @param tag has unknown parameter name: platforms 
    in file `app/models/metasploit/cache/module/instance.rb' near line 367
[warn]: @param tag has unknown parameter name: platform_fully_qualified_names 
    in file `app/models/metasploit/cache/module/instance.rb' near line 403
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 420
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 434
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 492
```
- [ ] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [ ] Edit `lib/metasploit/cache/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`