### PR TITLE
Metasploit::Cache::Platformable::Platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,11 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 100% coverage.
+3. Verify there was 99.73% coverage.
 
 ##### Documentation
-1. `rake yard`
-2. Verify there were no warnings.
+1. `rake yard:stats`
+2. Verify only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
 2. Verify there were no undocumented objects.
 
 #### Sqlite3
@@ -63,11 +63,11 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 100% coverage.
+3. Verify there was 99.69% coverage.
 
 ##### Documentation
-1. `rake yard`
-2. Verify there were no warnings.
+1. `rake yard:stats`
+2. Verify only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
 2. Verify there were no undocumented objects.
 
 ### Push
@@ -90,11 +90,11 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] VERIFY 99.73% coverage
 
 ### Documentation Coverage
-- [ ] `rake yard`
-- [ ] VERIFY no warnings
+- [ ] `rake yard:stats`
+- [ ] Verify only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
 - [ ] VERIFY no undocumented objects
 
 ## Sqlite3
@@ -104,8 +104,8 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
-- [ ] VERIFY no failures
-- [ ] VERIFY 100% coverage
+- [ ] Verify only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
+- [ ] VERIFY 99.69% coverage
 
 ### Documentation coverage
 - [ ] `rake yard`

--- a/Rakefile
+++ b/Rakefile
@@ -44,8 +44,8 @@ task :coverage do
   # coverage differs by adapter because different adapters have different handling in Metasploit::Cache::Batched::Root
   # and its specs.
   minimum_coverage_by_adapter = {
-      'postgresql' => 99.72,
-      'sqlite3' => 99.68
+      'postgresql' => 99.73,
+      'sqlite3' => 99.69
   }
 
   SimpleCov.configure do

--- a/app/models/metasploit/cache/encoder/instance.rb
+++ b/app/models/metasploit/cache/encoder/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for an encoder  Metasploit Module.
 class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The class-level metadata for this instance metadata.
@@ -10,6 +12,21 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   belongs_to :encoder_class,
              class_name: 'Metasploit::Cache::Encoder::Class',
              inverse_of: :encoder_instance
+
+  # Joins {#platforms} to this encoder Metasploit Module.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platformable
+
+  #
+  # through: :platformable_platform
+  #
+
+  # Platforms this encoder Metasploit Module works on.
+  has_many :platforms,
+           class_name: 'Metasploit::Cache::Platform',
+           through: :platformable_platforms
 
   #
   # Attributes
@@ -36,6 +53,10 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
             presence: true
   validates :name,
             presence: true
+  validates :platformable_platforms,
+            length: {
+              minimum: 1
+            }
 
   #
   # Instance Methods

--- a/app/models/metasploit/cache/exploit/target.rb
+++ b/app/models/metasploit/cache/exploit/target.rb
@@ -2,13 +2,29 @@
 # and platforms that customize the behavior of the exploit Metasploit Module.
 class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # {Metasploit::Cache::Exploit::Instance Exploit Metasploit Module} on which this is a target.
   belongs_to :exploit_instance,
              class_name: 'Metasploit::Cache::Exploit::Instance',
              inverse_of: :exploit_targets
+
+  # Joins {#platforms} to this exploit Metasploit Module target.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platformable
+
+  #
+  # through: :platformable_platform
+  #
+
+  has_many :platforms,
+           class_name: 'Metasploit::Cache::Platform',
+           through: :platformable_platform
 
   #
   # Attributes
@@ -43,6 +59,10 @@ class Metasploit::Cache::Exploit::Target < ActiveRecord::Base
             presence: true,
             uniqueness: {
                 scope: :exploit_instance_id
+            }
+  validates :platformable_platforms,
+            length: {
+                minimum: 1
             }
 
   #

--- a/app/models/metasploit/cache/nop/instance.rb
+++ b/app/models/metasploit/cache/nop/instance.rb
@@ -1,13 +1,30 @@
 # Instance-level metadata for a nop Metasploit Module
 class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The class level metadata for this nop Metasploit Module.
   belongs_to :nop_class,
              class_name: 'Metasploit::Cache::Nop::Class',
              inverse_of: :nop_instance
+
+  # Joins {#platforms} to this encoder Metasploit Module.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platformable
+
+  #
+  # through: :platformable_platform
+  #
+
+  # Platforms this encoder Metasploit Module works on.
+  has_many :platforms,
+           class_name: 'Metasploit::Cache::Platform',
+           through: :platformable_platforms
 
   #
   # Attributes
@@ -41,6 +58,10 @@ class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
             presence: true
   validates :nop_class_id,
             uniqueness: true
+  validates :platformable_platforms,
+            length: {
+                minimum: 1
+            }
 
   #
   # Instance Methods

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for single payload Metasploit Modules
 class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The connection handler
@@ -13,6 +15,21 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   belongs_to :payload_single_class,
              class_name: 'Metasploit::Cache::Payload::Single::Class',
              inverse_of: :payload_single_instance
+
+  # Joins {#platforms} to this single payload Metasploit Module.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platformable
+
+  #
+  # through: :platformable_platform
+  #
+
+  # Platforms this playload single Metasploit Module works on.
+  has_many :platforms,
+           class_name: 'Metasploit::Cache::Platform',
+           through: :platformable_platforms
 
   #
   # Attributes
@@ -55,6 +72,10 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
             presence: true
   validates :payload_single_class_id,
             uniqueness: true
+  validates :platformable_platforms,
+            length: {
+                minimum: 1
+            }
   validates :privileged,
             inclusion: {
                 in: [

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -1,14 +1,31 @@
 # Instance-level metadata for stage payload Metasploit Module
 class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The class-level metadata for this stage payload Metasploit Module.
   belongs_to :payload_stage_class,
              class_name: 'Metasploit::Cache::Payload::Stage::Class',
              inverse_of: :payload_stage_instance
-  
+
+  # Joins {#platforms} to this stage payload Metasploit Module.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platformable
+
+  #
+  # through: :platformable_platform
+  #
+
+  # Platforms this payload stage Metasploit Module works on.
+  has_many :platforms,
+           class_name: 'Metasploit::Cache::Platform',
+           through: :platformable_platforms
+
   #
   # Attributes
   #
@@ -47,6 +64,10 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
             presence: true
   validates :payload_stage_class_id,
             uniqueness: true
+  validates :platformable_platforms,
+            length: {
+                minimum: 1
+            }
 
   #
   # Instance Methods

--- a/app/models/metasploit/cache/payload/stager/instance.rb
+++ b/app/models/metasploit/cache/payload/stager/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for stager payload Metasploit Module
 class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The connection handler
@@ -13,6 +15,21 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   belongs_to :payload_stager_class,
              class_name: 'Metasploit::Cache::Payload::Stager::Class',
              inverse_of: :payload_stager_instance
+
+  # Joins {#platforms} to this stager payload Metasploit Module.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platformable
+
+  #
+  # through: :platformable_platform
+  #
+
+  # Platforms this payload stager Metasploit Module works on.
+  has_many :platforms,
+           class_name: 'Metasploit::Cache::Platform',
+           through: :platformable_platforms
 
   #
   # Attributes
@@ -60,7 +77,10 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
             presence: true
   validates :payload_stager_class_id,
             uniqueness: true
-
+  validates :platformable_platforms,
+            length: {
+                minimum: 1
+            }
   #
   # Instance Methods
   #

--- a/app/models/metasploit/cache/platform.rb
+++ b/app/models/metasploit/cache/platform.rb
@@ -26,6 +26,16 @@ class Metasploit::Cache::Platform < ActiveRecord::Base
   # Joins this {Metasploit::Cache::Platform} to {Metasploit::Cache::Module::Instance modules} that support the platform.
   has_many :module_platforms, class_name: 'Metasploit::Cache::Module::Platform', dependent: :destroy, inverse_of: :platform
 
+  # Joins this {Metasploit::cache::Platform} to Metasploit::Cache::Encoder::Instance encoder},
+  # {Metasploit::Cache::Nop::Instance nop}, {Metasploit::Cache::Payload::Single::Instance single payload},
+  # {Metasploit::Cache::Payload::Stage::Instance stage payload},
+  # {Metasploit::Cache::Payload::Stager::Instance stager payload}, or {Metasploit::Cache::Post::Instance post}) Metasploit
+  # Modules or {Metasploit::Cache::Exploit::Target exploit Metasploit Module targets}.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platform
+
   # Joins this to {Metasploit::Cache::Module::Target targets} that support this platform.
   has_many :target_platforms, class_name: 'Metasploit::Cache::Module::Target::Platform', dependent: :destroy, inverse_of: :platform
 

--- a/app/models/metasploit/cache/platformable/platform.rb
+++ b/app/models/metasploit/cache/platformable/platform.rb
@@ -4,4 +4,5 @@
 # {Metasploit::Cache::Payload::Stager::Instance stager payload}, or {Metasploit::Cache::Post::Instance post}) Metasploit
 # Modules or {Metasploit::Cache::Exploit::Target exploit Metasploit Module targets}.
 class Metasploit::Cache::Platformable::Platform
+  Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/platformable/platform.rb
+++ b/app/models/metasploit/cache/platformable/platform.rb
@@ -19,6 +19,15 @@ class Metasploit::Cache::Platformable::Platform < ActiveRecord::Base
              inverse_of: :platformable_platforms
 
   #
+  # Attributes
+  #
+
+  # @!attribute platform_id
+  #   The foreign key for {#platform}.
+  #
+  #   @return [Integer]
+
+  #
   # Validates
   #
 
@@ -33,6 +42,16 @@ class Metasploit::Cache::Platformable::Platform < ActiveRecord::Base
                     :platformable_id
                 ]
             }
+
+  #
+  # Instance Methods
+  #
+
+  # @!method platform_id=(platform_id)
+  #   Sets {#platform_id} and invalidates the cached {#platform} so it is reloaded on next access.
+  #
+  #   @param platform_id [Integer] The foreign key used to load {#platform}.
+  #   @return [void]
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/platformable/platform.rb
+++ b/app/models/metasploit/cache/platformable/platform.rb
@@ -1,0 +1,7 @@
+# Polymorphic join model between platforms and {Metasploit::Cache::Encoder::Instance encoder},
+# {Metasploit::Cache::Nop::Instance nop}, {Metasploit::Cache::Payload::Single::Instance single payload},
+# {Metasploit::Cache::Payload::Stage::Instance stage payload},
+# {Metasploit::Cache::Payload::Stager::Instance stager payload}, or {Metasploit::Cache::Post::Instance post}) Metasploit
+# Modules or {Metasploit::Cache::Exploit::Target exploit Metasploit Module targets}.
+class Metasploit::Cache::Platformable::Platform
+end

--- a/app/models/metasploit/cache/platformable/platform.rb
+++ b/app/models/metasploit/cache/platformable/platform.rb
@@ -1,8 +1,24 @@
-# Polymorphic join model between platforms and {Metasploit::Cache::Encoder::Instance encoder},
+# Polymorphic join model between {#platform platforms} and {Metasploit::Cache::Encoder::Instance encoder},
 # {Metasploit::Cache::Nop::Instance nop}, {Metasploit::Cache::Payload::Single::Instance single payload},
 # {Metasploit::Cache::Payload::Stage::Instance stage payload},
 # {Metasploit::Cache::Payload::Stager::Instance stager payload}, or {Metasploit::Cache::Post::Instance post}) Metasploit
 # Modules or {Metasploit::Cache::Exploit::Target exploit Metasploit Module targets}.
-class Metasploit::Cache::Platformable::Platform
+class Metasploit::Cache::Platformable::Platform < ActiveRecord::Base
+  #
+  # Associations
+  #
+
+  # The platform supported by the `#platformable`.
+  belongs_to :platform,
+             class_name: 'Metasploit::Cache::Platform',
+             inverse_of: :platformable_platforms
+
+  #
+  # Validates
+  #
+
+  validates :platform,
+            presence: true
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/platformable/platform.rb
+++ b/app/models/metasploit/cache/platformable/platform.rb
@@ -8,6 +8,11 @@ class Metasploit::Cache::Platformable::Platform < ActiveRecord::Base
   # Associations
   #
 
+  # The thing that supports {#platform}.
+  belongs_to :platformable,
+             inverse_of: :platformable_platforms,
+             polymorphic: true
+
   # The platform supported by the `#platformable`.
   belongs_to :platform,
              class_name: 'Metasploit::Cache::Platform',
@@ -17,8 +22,17 @@ class Metasploit::Cache::Platformable::Platform < ActiveRecord::Base
   # Validates
   #
 
+  validates :platformable,
+            presence: true
   validates :platform,
             presence: true
+  validates :platform_id,
+            uniqueness: {
+                scope: [
+                    :platformable_type,
+                    :platformable_id
+                ]
+            }
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -1,13 +1,30 @@
 # Instance-level metadata for a post Metasploit Module.
 class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
+  #
+
+  # Joins {#platforms} to this post Metasploit Module.
+  has_many :platformable_platforms,
+           class_name: 'Metasploit::Cache::Platformable::Platform',
+           dependent: :destroy,
+           inverse_of: :platformable
 
   # The class level metadata for this post Metasploit Module
   belongs_to :post_class,
              class_name: 'Metasploit::Cache::Post::Class',
              inverse_of: :post_instance
+
+  #
+  # through: :platformable_platform
+  #
+
+  # Platforms this post Metasploit Module works on.
+  has_many :platforms,
+           class_name: 'Metasploit::Cache::Platform',
+           through: :platformable_platforms
 
   #
   # Attributes
@@ -50,6 +67,10 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
             presence: true
   validates :name,
             presence: true
+  validates :platformable_platforms,
+            length: {
+                minimum: 1
+            }
   validates :post_class,
             presence: true
   validates :post_class_id,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,10 @@ en:
           attributes:
             platformable_platforms:
               too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
+        metasploit/cache/payload/single/instance:
+          attributes:
+            platformable_platforms:
+              too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,10 @@ en:
           attributes:
             platformable_platforms:
               too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
+        metasploit/cache/payload/stager/instance:
+          attributes:
+            platformable_platforms:
+              too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,10 @@ en:
             actions:
               does_not_contain_default_action: "does not contain default action"
               too_short: "has too few actions (minimum is %{count} action)"
+        metasploit/cache/encoder/instance:
+          attributes:
+            platformable_platforms:
+              too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
         metasploit/cache/exploit/instance:
           attributes:
             default_exploit_target:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,10 @@ en:
           attributes:
             platformable_platforms:
               too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
+        metasploit/cache/post/instance:
+          attributes:
+            platformable_platforms:
+              too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,10 @@ en:
               inclusion: "is not included in exploit targets"
             exploit_targets:
               too_short: "has too few exploit targets (minimum is %{count} exploit target)"
+        metasploit/cache/exploit/target:
+          attributes:
+            platformable_platforms:
+              too_short: "has too few platformable platforms (minimum us %{count} platformable platform)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
           attributes:
             platformable_platforms:
               too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
+        metasploit/cache/payload/stage/instance:
+          attributes:
+            platformable_platforms:
+              too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,10 @@ en:
           attributes:
             platformable_platforms:
               too_short: "has too few platformable platforms (minimum us %{count} platformable platform)"
+        metasploit/cache/nop/instance:
+          attributes:
+            platformable_platforms:
+              too_short: "has too few platformable platforms (minimum is %{count} platformable platform)"
   metasploit:
     model:
       ancestors:

--- a/db/migrate/20150520145231_create_mc_platformable_platforms.rb
+++ b/db/migrate/20150520145231_create_mc_platformable_platforms.rb
@@ -25,6 +25,9 @@ class CreateMcPlatformablePlatforms < ActiveRecord::Migration
       # References
       #
 
+      t.references :platformable,
+                   null: false,
+                   polymorphic: true
       t.references :platform,
                    null: false
     end
@@ -32,6 +35,12 @@ class CreateMcPlatformablePlatforms < ActiveRecord::Migration
     change_table TABLE_NAME do |t|
       t.index :platform_id,
               unique: false
+      t.index [:platformable_type, :platformable_id],
+              name: 'mc_platformable_platformables',
+              unique: false
+      t.index [:platformable_type, :platformable_id, :platform_id],
+              name: 'unique_mc_platformable_platforms',
+              unique: true
     end
   end
 end

--- a/db/migrate/20150520145231_create_mc_platformable_platforms.rb
+++ b/db/migrate/20150520145231_create_mc_platformable_platforms.rb
@@ -1,0 +1,37 @@
+class CreateMcPlatformablePlatforms < ActiveRecord::Migration
+  #
+  # CONSTANTS
+  #
+  # Name of the table being created
+  TABLE_NAME = :mc_platformable_platforms
+
+  #
+  # Instance Methods
+  #
+
+  # Drop {TABLE_NAME}.
+  #
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+
+  # Create {TABLE_NAME}.
+  #
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      #
+      # References
+      #
+
+      t.references :platform,
+                   null: false
+    end
+
+    change_table TABLE_NAME do |t|
+      t.index :platform_id,
+              unique: false
+    end
+  end
+end

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -48,6 +48,7 @@ module Metasploit
     autoload :NullProgressBar
     autoload :Payload
     autoload :Platform
+    autoload :Platformable
     autoload :Post
     autoload :ProxiedValidation
     autoload :RealPathname

--- a/lib/metasploit/cache/platformable.rb
+++ b/lib/metasploit/cache/platformable.rb
@@ -1,0 +1,6 @@
+# Polymorphic namespace for `ActiveRecord::Base` subclasses that support platforms.
+module Metasploit::Cache::Platformable
+  extend ActiveSupport::Autoload
+
+  autoload :Platform
+end

--- a/lib/metasploit/cache/platformable.rb
+++ b/lib/metasploit/cache/platformable.rb
@@ -3,4 +3,15 @@ module Metasploit::Cache::Platformable
   extend ActiveSupport::Autoload
 
   autoload :Platform
+
+  #
+  # Module Methods
+  #
+
+  # The prefix for ActiveRecord::Base subclass table names in this namespace.
+  #
+  # @return [String]
+  def self.table_name_prefix
+    "#{parent.table_name_prefix}platformable_"
+  end
 end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,7 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 64
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 27
+      PATCH = 28
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'platformable-platform'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -35,45 +35,9 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
   context 'validations' do
     it { is_expected.to validate_presence_of(:auxiliary_class) }
 
-    # validate_lenght_of from shoulda-matchers assumes attribute is String and doesn't work on associations
-    context 'validates length of actions is at least 1' do
-      let(:error) {
-        I18n.translate!(
-          'activerecord.errors.models.metasploit/cache/auxiliary/instance.attributes.actions.too_short',
-           count: 1
-        )
-      }
-
-      context 'without actions' do
-        subject(:auxiliary_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_auxiliary_instance,
-              actions_count: 0
-          )
-        }
-
-        it 'adds error on #actions' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:actions]).to include(error)
-        end
-      end
-
-      context 'with actions' do
-        subject(:auxiliary_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_auxiliary_instance,
-              actions_count: 1
-          )
-        }
-
-        it 'does not adds error on #actions' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:actions]).not_to include(error)
-        end
-      end
-    end
+    it_should_behave_like 'validates at least one in association',
+                          :actions,
+                          factory: :metasploit_cache_auxiliary_instance
 
     context 'actions_contains_default_action' do
       let(:error) {
@@ -88,7 +52,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
             subject(:auxiliary_instance) {
               FactoryGirl.build(
                              :metasploit_cache_auxiliary_instance,
-                             actions_count: 1
+                             action_count: 1
               ).tap { |auxiliary_instance|
                 auxiliary_instance.default_action = auxiliary_instance.actions.first
               }
@@ -117,7 +81,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
             subject(:auxiliary_instance) {
               FactoryGirl.build(
                              :metasploit_cache_auxiliary_instance,
-                             actions_count: 1
+                             action_count: 1
               ).tap { |auxiliary_instance|
                 auxiliary_instance.default_action = FactoryGirl.build(
                     :metasploit_cache_auxiliary_action,
@@ -150,7 +114,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 1
+                action_count: 1
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = nil
             }
@@ -177,7 +141,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 0
+                action_count: 0
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = FactoryGirl.build(
                   :metasploit_cache_auxiliary_action,
@@ -205,7 +169,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 0
+                action_count: 0
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = nil
             }

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -30,5 +30,9 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :encoder_class }
     it { is_expected.to validate_presence_of :name }
+
+    it_should_behave_like 'validates at least one in association',
+                          :platformable_platforms,
+                          factory: :metasploit_cache_encoder_instance
   end
 end

--- a/spec/app/models/metasploit/cache/exploit/target_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/target_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
 
   context 'associations' do
     it { is_expected.to belong_to(:exploit_instance).class_name('Metasploit::Cache::Exploit::Instance').inverse_of(:exploit_targets) }
+    it { is_expected.to have_many(:platformable_platforms).class_name('Metasploit::Cache::Platformable::Platform').dependent(:destroy).inverse_of(:platformable) }
+    it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }
   end
 
   context 'database' do
@@ -33,6 +35,10 @@ RSpec.describe Metasploit::Cache::Exploit::Target do
     it { is_expected.to validate_presence_of :exploit_instance }
     it { is_expected.to validate_presence_of :index }
     it { is_expected.to validate_presence_of :name }
+
+    it_should_behave_like 'validates at least one in association',
+                          :platformable_platforms,
+                          factory: :metasploit_cache_exploit_target
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Metasploit::Cache::Nop::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
+    it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }
+    it { is_expected.to have_many(:platformable_platforms).class_name('Metasploit::Cache::Platformable::Platform').inverse_of(:platformable) }
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
@@ -23,14 +29,14 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
     end
   end
 
-  context 'associations' do
-    it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
-  end
-
   context 'validations' do
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :nop_class }
+
+    it_should_behave_like 'validates at least one in association',
+                          :platformable_platforms,
+                          factory: :metasploit_cache_nop_instance
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
+    it { is_expected.to belong_to(:payload_single_class).class_name('Metasploit::Cache::Payload::Single::Class').inverse_of(:payload_single_instance) }
   end
 
   context 'database' do

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
   context 'associations' do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
     it { is_expected.to belong_to(:payload_single_class).class_name('Metasploit::Cache::Payload::Single::Class').inverse_of(:payload_single_instance) }
+    it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }
+    it { is_expected.to have_many(:platformable_platforms).class_name('Metasploit::Cache::Platformable::Platform').inverse_of(:platformable) }
   end
 
   context 'database' do
@@ -37,6 +39,10 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :payload_single_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
+
+    it_should_behave_like 'validates at least one in association',
+                          :platformable_platforms,
+                          factory: :metasploit_cache_payload_single_instance
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to belong_to(:payload_stage_class).class_name('Metasploit::Cache::Payload::Stage::Class').inverse_of(:payload_stage_instance) }
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:payload_stage_class).class_name('Metasploit::Cache::Payload::Stage::Class').inverse_of(:payload_stage_instance) }
+    it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }
+    it { is_expected.to have_many(:platformable_platforms).class_name('Metasploit::Cache::Platformable::Platform').inverse_of(:platformable) }
   end
 
   context 'database' do
@@ -12,6 +14,10 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
       it { is_expected.to have_db_column(:payload_stage_class_id).of_type(:integer).with_options(null: false) }
       it { is_expected.to have_db_column(:privileged).of_type(:boolean).with_options(null: false) }
     end
+
+    it_should_behave_like 'validates at least one in association',
+                          :platformable_platforms,
+                          factory: :metasploit_cache_payload_stage_instance
 
     context 'indices' do
       it { is_expected.to have_db_index(:payload_stage_class_id).unique(true) }

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
   context 'associations' do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_stager_instances) }
     it { is_expected.to belong_to(:payload_stager_class).class_name('Metasploit::Cache::Payload::Stager::Class').inverse_of(:payload_stager_instance) }
+    it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }
+    it { is_expected.to have_many(:platformable_platforms).class_name('Metasploit::Cache::Platformable::Platform').inverse_of(:platformable) }
   end
 
   context 'database' do
@@ -39,6 +41,10 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :payload_stager_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
+
+    it_should_behave_like 'validates at least one in association',
+                          :platformable_platforms,
+                          factory: :metasploit_cache_payload_stager_instance
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_stager_instances) }
+    it { is_expected.to belong_to(:payload_stager_class).class_name('Metasploit::Cache::Payload::Stager::Class').inverse_of(:payload_stager_instance) }
   end
 
   context 'database' do

--- a/spec/app/models/metasploit/cache/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platform_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Metasploit::Cache::Platform do
   context 'associations' do
     it { should have_many(:module_instances).class_name('Metasploit::Cache::Module::Instance').through(:module_platforms) }
     it { should have_many(:module_platforms).class_name('Metasploit::Cache::Module::Platform').dependent(:destroy) }
+    it { is_expected.to have_many(:platformable_platforms).class_name('Metasploit::Cache::Platformable::Platform').dependent(:destroy).inverse_of(:platform) }
     it { should have_many(:target_platforms).class_name('Metasploit::Cache::Module::Target::Platform').dependent(:destroy) }
   end
 

--- a/spec/app/models/metasploit/cache/platformable/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platformable/platform_spec.rb
@@ -3,19 +3,91 @@ RSpec.describe Metasploit::Cache::Platformable::Platform do
 
   context 'associations' do
     it { is_expected.to belong_to(:platform).class_name('Metasploit::Cache::Platform').inverse_of(:platformable_platforms) }
+    it { is_expected.to belong_to(:platformable) }
   end
 
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:platform_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:platformable_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:platformable_type).of_type(:string).with_options(null: false) }
     end
 
     context 'indices' do
-      it { is_expected.to have_db_index(:platform_id) }
+      it { is_expected.to have_db_index(:platform_id).unique(false) }
+      it { is_expected.to have_db_index([:platformable_type, :platformable_id]).unique(false) }
+      it { is_expected.to have_db_index([:platformable_type, :platformable_id, :platform_id]).unique(true) }
+    end
+  end
+
+  context 'factories' do
+    context 'metasploit_cache_encoder_platform' do
+      subject(:metasploit_cache_encoder_platform) {
+        FactoryGirl.build(:metasploit_cache_encoder_platform)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_exploit_target_platform' do
+      subject(:metasploit_cache_exploit_target_platform) {
+        FactoryGirl.build(:metasploit_cache_exploit_target_platform)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_nop_platform' do
+      subject(:metasploit_cache_nop_platform) {
+        FactoryGirl.build(:metasploit_cache_nop_platform)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_payload_single_platform' do
+      subject(:metasploit_cache_payload_single_platform) {
+        FactoryGirl.build(:metasploit_cache_payload_single_platform)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_payload_stage_platform' do
+      subject(:metasploit_cache_payload_stage_platform) {
+        FactoryGirl.build(:metasploit_cache_payload_stage_platform)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_payload_stager_platform' do
+      subject(:metasploit_cache_payload_stager_platform) {
+        FactoryGirl.build(:metasploit_cache_payload_stager_platform)
+      }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_cache_post_platform' do
+      subject(:metasploit_cache_post_platform) {
+        FactoryGirl.build(:metasploit_cache_post_platform)
+      }
+
+      it { is_expected.to be_valid }
     end
   end
 
   context 'validations' do
     it { is_expected.to validate_presence_of :platform }
+    it { is_expected.to validate_presence_of :platformable }
+
+    context 'with pre-existing record' do
+      let!(:existing_platformable_platform) {
+        FactoryGirl.create(:metasploit_cache_encoder_platform)
+      }
+
+      it { is_expected.to validate_uniqueness_of(:platform_id).scoped_to(:platformable_type, :platformable_id) }
+    end
   end
 end

--- a/spec/app/models/metasploit/cache/platformable/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platformable/platform_spec.rb
@@ -1,3 +1,21 @@
 RSpec.describe Metasploit::Cache::Platformable::Platform do
   it_should_behave_like 'Metasploit::Concern.run'
+
+  context 'associations' do
+    it { is_expected.to belong_to(:platform).class_name('Metasploit::Cache::Platform').inverse_of(:platformable_platforms) }
+  end
+
+  context 'database' do
+    context 'columns' do
+      it { is_expected.to have_db_column(:platform_id).of_type(:integer).with_options(null: false) }
+    end
+
+    context 'indices' do
+      it { is_expected.to have_db_index(:platform_id) }
+    end
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of :platform }
+  end
 end

--- a/spec/app/models/metasploit/cache/platformable/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platformable/platform_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Metasploit::Cache::Platformable::Platform do
+end

--- a/spec/app/models/metasploit/cache/platformable/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platformable/platform_spec.rb
@@ -1,2 +1,3 @@
 RSpec.describe Metasploit::Cache::Platformable::Platform do
+  it_should_behave_like 'Metasploit::Concern.run'
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Metasploit::Cache::Post::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }
+    it { is_expected.to have_many(:platformable_platforms).class_name('Metasploit::Cache::Platformable::Platform').inverse_of(:platformable) }
+    it { is_expected.to belong_to(:post_class).class_name('Metasploit::Cache::Post::Class').inverse_of(:post_instance) }
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
@@ -13,10 +19,6 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     context 'indices' do
       it { is_expected.to have_db_index(:post_class_id).unique(true) }
     end
-  end
-
-  context 'associations' do
-    it { is_expected.to belong_to(:post_class).class_name('Metasploit::Cache::Post::Class').inverse_of(:post_instance) }
   end
 
   context 'factories' do
@@ -35,6 +37,10 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :post_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
+
+    it_should_behave_like 'validates at least one in association',
+                          :platformable_platforms,
+                          factory: :metasploit_cache_post_instance
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -21,16 +21,6 @@ ActiveRecord::Schema.define(:version => 20150520145231) do
 
   add_index "mc_actionable_actions", ["actionable_type", "actionable_id", "name"], :name => "unique_mc_actionable_actions", :unique => true
 
-  create_table "mc_architecturable_architectures", :force => true do |t|
-    t.integer "architecturable_id",   :null => false
-    t.string  "architecturable_type", :null => false
-    t.integer "architecture_id",      :null => false
-  end
-
-  add_index "mc_architecturable_architectures", ["architecturable_type", "architecturable_id", "architecture_id"], :name => "unique_mc_architecturable_architectures", :unique => true
-  add_index "mc_architecturable_architectures", ["architecturable_type", "architecturable_id"], :name => "mc_architecturable_architechurables"
-  add_index "mc_architecturable_architectures", ["architecture_id"], :name => "index_mc_architecturable_architectures_on_architecture_id"
-
   create_table "mc_architectures", :force => true do |t|
     t.integer "bits"
     t.string  "abbreviation", :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -294,10 +294,14 @@ ActiveRecord::Schema.define(:version => 20150520145231) do
   add_index "mc_payload_stager_instances", ["payload_stager_class_id"], :name => "index_mc_payload_stager_instances_on_payload_stager_class_id", :unique => true
 
   create_table "mc_platformable_platforms", :force => true do |t|
-    t.integer "platform_id", :null => false
+    t.integer "platformable_id",   :null => false
+    t.string  "platformable_type", :null => false
+    t.integer "platform_id",       :null => false
   end
 
   add_index "mc_platformable_platforms", ["platform_id"], :name => "index_mc_platformable_platforms_on_platform_id"
+  add_index "mc_platformable_platforms", ["platformable_type", "platformable_id", "platform_id"], :name => "unique_mc_platformable_platforms", :unique => true
+  add_index "mc_platformable_platforms", ["platformable_type", "platformable_id"], :name => "mc_platformable_platformables"
 
   create_table "mc_platforms", :force => true do |t|
     t.text    "fully_qualified_name", :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150507130708) do
+ActiveRecord::Schema.define(:version => 20150520145231) do
 
   create_table "mc_actionable_actions", :force => true do |t|
     t.string  "name",            :null => false
@@ -20,6 +20,16 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
   end
 
   add_index "mc_actionable_actions", ["actionable_type", "actionable_id", "name"], :name => "unique_mc_actionable_actions", :unique => true
+
+  create_table "mc_architecturable_architectures", :force => true do |t|
+    t.integer "architecturable_id",   :null => false
+    t.string  "architecturable_type", :null => false
+    t.integer "architecture_id",      :null => false
+  end
+
+  add_index "mc_architecturable_architectures", ["architecturable_type", "architecturable_id", "architecture_id"], :name => "unique_mc_architecturable_architectures", :unique => true
+  add_index "mc_architecturable_architectures", ["architecturable_type", "architecturable_id"], :name => "mc_architecturable_architechurables"
+  add_index "mc_architecturable_architectures", ["architecture_id"], :name => "index_mc_architecturable_architectures_on_architecture_id"
 
   create_table "mc_architectures", :force => true do |t|
     t.integer "bits"
@@ -282,6 +292,12 @@ ActiveRecord::Schema.define(:version => 20150507130708) do
 
   add_index "mc_payload_stager_instances", ["handler_id"], :name => "index_mc_payload_stager_instances_on_handler_id"
   add_index "mc_payload_stager_instances", ["payload_stager_class_id"], :name => "index_mc_payload_stager_instances_on_payload_stager_class_id", :unique => true
+
+  create_table "mc_platformable_platforms", :force => true do |t|
+    t.integer "platform_id", :null => false
+  end
+
+  add_index "mc_platformable_platforms", ["platform_id"], :name => "index_mc_platformable_platforms_on_platform_id"
 
   create_table "mc_platforms", :force => true do |t|
     t.text    "fully_qualified_name", :null => false

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   factory :metasploit_cache_auxiliary_instance,
           class: Metasploit::Cache::Auxiliary::Instance do
     transient do
-      actions_count 1
+      action_count 1
     end
 
     description { generate :metasploit_cache_auxiliary_instance_description }
@@ -26,7 +26,7 @@ FactoryGirl.define do
     after(:build) { |auxiliary_instance, evaluator|
       auxiliary_instance.actions = build_list(
           :metasploit_cache_auxiliary_action,
-          evaluator.actions_count,
+          evaluator.action_count,
           actionable: auxiliary_instance
       )
     }

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -5,6 +5,10 @@ FactoryGirl.define do
 
   factory :metasploit_cache_encoder_instance,
           class: Metasploit::Cache::Encoder::Instance do
+    transient do
+      platformable_platform_count { 1 }
+    end
+
     description { generate :metasploit_cache_encoder_instance_description }
     name { generate :metasploit_cache_encoder_instance_name }
 
@@ -13,6 +17,18 @@ FactoryGirl.define do
     #
 
     association :encoder_class, factory: :metasploit_cache_encoder_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |encoder_instance, evaluator|
+      encoder_instance.platformable_platforms = build_list(
+          :metasploit_cache_encoder_platform,
+          evaluator.platformable_platform_count,
+          platformable: encoder_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/exploit/targets.rb
+++ b/spec/factories/metasploit/cache/exploit/targets.rb
@@ -1,10 +1,30 @@
 FactoryGirl.define do
   factory :metasploit_cache_exploit_target,
           class: Metasploit::Cache::Exploit::Target do
+    transient do
+      platformable_platform_count { 1 }
+    end
+
     index { generate :metasploit_cache_exploit_target_index }
     name { generate :metasploit_cache_exploit_target_name }
+    
+    #
+    # Associations
+    #
 
     association :exploit_instance, factory: :metasploit_cache_exploit_instance
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |exploit_target, evaluator|
+      exploit_target.platformable_platforms = build_list(
+          :metasploit_cache_exploit_target_platform,
+          evaluator.platformable_platform_count,
+          platformable: exploit_target
+      )
+    end
   end
 
   sequence :metasploit_cache_exploit_target_index do |n|

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -1,10 +1,30 @@
 FactoryGirl.define do
   factory :metasploit_cache_nop_instance,
           class: Metasploit::Cache::Nop::Instance do
+    transient do
+      platformable_platform_count { 1 }
+    end
+
     description { generate :metasploit_cache_nop_instance_description }
     name { generate :metasploit_cache_nop_instance_name }
 
+    #
+    # Associations
+    #
+
     association :nop_class, factory: :metasploit_cache_nop_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |nop_instance, evaluator|
+      nop_instance.platformable_platforms = build_list(
+          :metasploit_cache_nop_platform,
+          evaluator.platformable_platform_count,
+          platformable: nop_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
           class: Metasploit::Cache::Payload::Single::Instance do
+    transient do
+      platformable_platform_count { 1 }
+    end
+
     description { generate :metasploit_cache_payload_single_instance_description }
     name { generate :metasploit_cache_payload_single_instance_name }
     privileged { generate :metasploit_cache_payload_single_instance_privileged }
@@ -11,6 +15,18 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_single_class, factory: :metasploit_cache_payload_single_class
+    
+    #
+    # Callbacks
+    #
+
+    after(:build) do |payload_single_instance, evaluator|
+      payload_single_instance.platformable_platforms = build_list(
+          :metasploit_cache_payload_single_platform,
+          evaluator.platformable_platform_count,
+          platformable: payload_single_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -1,11 +1,31 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stage_instance,
           class: Metasploit::Cache::Payload::Stage::Instance do
+    transient do
+      platformable_platform_count { 1 }
+    end
+    
     description { generate :metasploit_cache_payload_stage_instance_description }
     name { generate :metasploit_cache_payload_stage_instance_name }
     privileged { generate :metasploit_cache_payload_stage_instance_privileged }
 
+    #
+    # Associations
+    #
+    
     association :payload_stage_class, factory: :metasploit_cache_payload_stage_class
+    
+    #
+    # Callbacks
+    #
+
+    after(:build) do |payload_stage_instance, evaluator|
+      payload_stage_instance.platformable_platforms = build_list(
+          :metasploit_cache_payload_stage_platform,
+          evaluator.platformable_platform_count,
+          platformable: payload_stage_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stager_instance,
           class: Metasploit::Cache::Payload::Stager::Instance do
+    transient do
+      platformable_platform_count { 1 }
+    end
+
     description { generate :metasploit_cache_payload_stager_instance_description }
     handler_type_alias { generate :metasploit_cache_payload_stager_handler_type_alias }
     name { generate :metasploit_cache_payload_stager_instance_name }
@@ -12,6 +16,18 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_stager_class, factory: :metasploit_cache_payload_stager_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |payload_stage_instance, evaluator|
+      payload_stage_instance.platformable_platforms = build_list(
+          :metasploit_cache_payload_stage_platform,
+          evaluator.platformable_platform_count,
+          platformable: payload_stage_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -19,6 +19,14 @@ FactoryGirl.define do
     association :platformable, factory: :metasploit_cache_exploit_target
   end
 
+  factory :metasploit_cache_nop_platform,
+          class: Metasploit::Cache::Platformable::Platform,
+          traits: [
+              :metasploit_cache_platformable_platform
+          ] do
+    association :platformable, factory: :metasploit_cache_nop_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -35,6 +35,14 @@ FactoryGirl.define do
     association :platformable, factory: :metasploit_cache_payload_single_instance
   end
 
+  factory :metasploit_cache_payload_stage_platform,
+          class: Metasploit::Cache::Platformable::Platform,
+          traits: [
+              :metasploit_cache_platformable_platform
+          ] do
+    association :platformable, factory: :metasploit_cache_payload_stage_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -51,6 +51,14 @@ FactoryGirl.define do
     association :platformable, factory: :metasploit_cache_payload_stager_instance
   end
 
+  factory :metasploit_cache_post_platform,
+          class: Metasploit::Cache::Platformable::Platform,
+          traits: [
+              :metasploit_cache_platformable_platform
+          ] do
+    association :platformable, factory: :metasploit_cache_post_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -43,6 +43,14 @@ FactoryGirl.define do
     association :platformable, factory: :metasploit_cache_payload_stage_instance
   end
 
+  factory :metasploit_cache_payload_stager_platform,
+          class: Metasploit::Cache::Platformable::Platform,
+          traits: [
+              :metasploit_cache_platformable_platform
+          ] do
+    association :platformable, factory: :metasploit_cache_payload_stager_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -1,0 +1,21 @@
+FactoryGirl.define do
+  #
+  # Factories
+  #
+
+  factory :metasploit_cache_encoder_platform,
+          class: Metasploit::Cache::Platformable::Platform,
+          traits: [
+              :metasploit_cache_platformable_platform
+          ] do
+    association :platformable, factory: :metasploit_cache_encoder_instance
+  end
+
+  #
+  # Traits
+  #
+
+  trait :metasploit_cache_platformable_platform do
+    platform { generate :metasploit_cache_platform }
+  end
+end

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -27,6 +27,14 @@ FactoryGirl.define do
     association :platformable, factory: :metasploit_cache_nop_instance
   end
 
+  factory :metasploit_cache_payload_single_platform,
+          class: Metasploit::Cache::Platformable::Platform,
+          traits: [
+              :metasploit_cache_platformable_platform
+          ] do
+    association :platformable, factory: :metasploit_cache_payload_single_instance
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -11,6 +11,14 @@ FactoryGirl.define do
     association :platformable, factory: :metasploit_cache_encoder_instance
   end
 
+  factory :metasploit_cache_exploit_target_platform,
+          class: Metasploit::Cache::Platformable::Platform,
+          traits: [
+              :metasploit_cache_platformable_platform
+          ] do
+    association :platformable, factory: :metasploit_cache_exploit_target
+  end
+
   #
   # Traits
   #

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -1,12 +1,32 @@
 FactoryGirl.define do
   factory :metasploit_cache_post_instance,
           class: Metasploit::Cache::Post::Instance do
+    transient do
+      platformable_platform_count { 1 }
+    end
+    
     description { generate :metasploit_cache_post_instance_description }
     disclosed_on { generate :metasploit_cache_post_instance_disclosed_on }
     name { generate :metasploit_cache_post_instance_name }
     privileged { generate :metasploit_cache_post_instance_privileged }
 
+    #
+    # Associations
+    #
+    
     association :post_class, factory: :metasploit_cache_post_class
+    
+    #
+    # Callbacks
+    #
+
+    after(:build) do |post_instance, evaluator|
+      post_instance.platformable_platforms = build_list(
+          :metasploit_cache_post_platform,
+          evaluator.platformable_platform_count,
+          platformable: post_instance
+      )
+    end
   end
 
   #

--- a/spec/support/shared/examples/validates_at_least_one_in_association.rb
+++ b/spec/support/shared/examples/validates_at_least_one_in_association.rb
@@ -1,0 +1,41 @@
+# validate_length_of from shoulda-matchers assumes attribute is String and doesn't work on associations
+RSpec.shared_examples_for 'validates at least one in association' do |association, factory:|
+  association_count_key = "#{association.to_s.singularize}_count".to_sym
+
+  let(:error) {
+    I18n.translate!(
+        "#{described_class.i18n_scope}.errors.models.#{described_class.model_name.i18n_key}.attributes.#{association}.too_short",
+        count: 1
+    )
+  }
+
+  context "without #{association}" do
+    subject(:instance) {
+      FactoryGirl.build(
+          factory,
+          association_count_key => 0
+      )
+    }
+
+    it "adds error on ###{association}" do
+      instance.valid?
+
+      expect(instance.errors[association]).to include(error)
+    end
+  end
+
+  context "with #{association}" do
+    subject(:instance) {
+      FactoryGirl.build(
+          factory,
+          association_count_key => 1
+      )
+    }
+
+    it "does not adds error on ###{association}" do
+      instance.valid?
+
+      expect(instance.errors[association]).not_to include(error)
+    end
+  end
+end


### PR DESCRIPTION
MSP-12432

`Metasploit::Cache::Platformable::Platform` uses polymorphic association, so it can be the join model for both `Metasploit::Cache::*::Instance` and `Metasploit::Cache::Exploit::Target`.  Add inversed associations:
- `Metasploit::Cache::Encoder::Instance#platforms`
- `Metasploit::Cache::Exploit::Target#platforms`
- `Metasploit::Cache::Nop::Instance#platforms`
- `Metasploit::Cache::Payload::Single::Instance#platforms`
- `Metasploit::Cache::Payload::Stage::Instance#platforms`
- `Metasploit::Cache::Payload::Stager::Instance#platforms`
- `Metasploit::Cache::Post::Instance#platforms`

Ensure there is at least one architecture for each of the platformables by validating length of `platformable_platforms` join model association.

# Verification Steps

## Postgresql
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without sqlite3`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.73% coverage

### Documentation Coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for scope parameters: 
```
[warn]: @param tag has unknown parameter name: module_instances 
    in file `app/models/metasploit/cache/module/class.rb' near line 147
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 317
[warn]: @param tag has unknown parameter name: architecture_abbreviations 
    in file `app/models/metasploit/cache/module/instance.rb' near line 336
[warn]: @param tag has unknown parameter name: architectured 
    in file `app/models/metasploit/cache/module/instance.rb' near line 353
[warn]: @param tag has unknown parameter name: platforms 
    in file `app/models/metasploit/cache/module/instance.rb' near line 367
[warn]: @param tag has unknown parameter name: platform_fully_qualified_names 
    in file `app/models/metasploit/cache/module/instance.rb' near line 403
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 420
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 434
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 492
```
- [ ] VERIFY no undocumented objects

## Sqlite3
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without postgresql`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.69% coverage

### Documentation coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for scope parameters: 
```
[warn]: @param tag has unknown parameter name: module_instances 
    in file `app/models/metasploit/cache/module/class.rb' near line 147
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 317
[warn]: @param tag has unknown parameter name: architecture_abbreviations 
    in file `app/models/metasploit/cache/module/instance.rb' near line 336
[warn]: @param tag has unknown parameter name: architectured 
    in file `app/models/metasploit/cache/module/instance.rb' near line 353
[warn]: @param tag has unknown parameter name: platforms 
    in file `app/models/metasploit/cache/module/instance.rb' near line 367
[warn]: @param tag has unknown parameter name: platform_fully_qualified_names 
    in file `app/models/metasploit/cache/module/instance.rb' near line 403
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 420
[warn]: @param tag has unknown parameter name: module_instance 
    in file `app/models/metasploit/cache/module/instance.rb' near line 434
[warn]: @param tag has unknown parameter name: module_target 
    in file `app/models/metasploit/cache/module/instance.rb' near line 492
```
- [ ] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [ ] Edit `lib/metasploit/cache/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`