### PR TITLE
Metasploit::Cache::Licensable::License

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ Make your changes or however many commits you like, committing each with `git co
 3. Verify there was 99.73% coverage.
 
 ##### Documentation
-1. `rake yard`
-2. Verify there were no warnings.
+1. `rake yard:stats`
+2. Verify no `[warn]`ings. (Rails ERD "invalid model" Warnings are OKrm Gemfile.lock.)
 2. Verify there were no undocumented objects.
 
 #### Sqlite3
@@ -66,8 +66,8 @@ Make your changes or however many commits you like, committing each with `git co
 3. Verify there was 99.69% coverage.
 
 ##### Documentation
-1. `rake yard`
-2. Verify there were no warnings.
+1. `rake yard:stats`
+2. Verify no `[warn]`ings. (Rails ERD "invalid model" Warnings are OKrm Gemfile.lock.)
 2. Verify there were no undocumented objects.
 
 ### Push
@@ -93,8 +93,8 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 - [ ] VERIFY 99.73% coverage
 
 ### Documentation Coverage
-- [ ] `rake yard`
-- [ ] VERIFY no `[warn]`ings. (Rails ERD "invalid model" Warnings are OK.)
+- [ ] `rake yard:stats`
+- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
 - [ ] VERIFY no undocumented objects
 
 ## Sqlite3
@@ -108,8 +108,8 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 - [ ] VERIFY 99.69% coverage
 
 ### Documentation coverage
-- [ ] `rake yard`
-- [ ] VERIFY no `[warn]`ings. (Rails ERD "invalid model" Warnings are OKrm Gemfile.lock.)
+- [ ] `rake yard:stats`
+- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
 - [ ] VERIFY no undocumented objects
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Make your changes or however many commits you like, committing each with `git co
 ##### Testing
 1. `rake cucumber spec coverage`
 2. Verify there were no failures.
-3. Verify there was 99.72% coverage.
+3. Verify there was 99.73% coverage.
 
 ##### Documentation
 1. `rake yard`
@@ -90,7 +90,7 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 ### Test coverage
 - [ ] `rake cucumber spec coverage`
 - [ ] VERIFY no failures
-- [ ] VERIFY 99.72% coverage
+- [ ] VERIFY 99.73% coverage
 
 ### Documentation Coverage
 - [ ] `rake yard`

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ task :coverage do
   # coverage differs by adapter because different adapters have different handling in Metasploit::Cache::Batched::Root
   # and its specs.
   minimum_coverage_by_adapter = {
-      'postgresql' => 99.72,
+      'postgresql' => 99.73,
       'sqlite3' => 99.69
   }
 

--- a/app/models/metasploit/cache/auxiliary/instance.rb
+++ b/app/models/metasploit/cache/auxiliary/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for an auxiliary Metasploit Module.
 class Metasploit::Cache::Auxiliary::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The actions that are allowed for the auxiliary Metasploit Module.
@@ -28,17 +30,19 @@ class Metasploit::Cache::Auxiliary::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Actionable::Action',
              inverse_of: :actionable
 
-  # The {Metasploit::Cache::License} objects that are associated with this instance
-  #
-  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  # Joins {#licenses} to this auxiliary Metasploit Module.
   has_many :licensable_licenses,
            as: :licensable,
            class_name: 'Metasploit::Cache::Licensable::License'
 
+  #
+  # through: :licensable_licenses
+  #
+
+  # The {Metasploit::Cache::License} for the code in this auxiliary Metasploit Module.
   has_many :licenses,
            class_name: 'Metasploit::Cache::License',
            through: :licensable_licenses
-
 
   #
   # Attributes

--- a/app/models/metasploit/cache/auxiliary/instance.rb
+++ b/app/models/metasploit/cache/auxiliary/instance.rb
@@ -28,6 +28,18 @@ class Metasploit::Cache::Auxiliary::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Actionable::Action',
              inverse_of: :actionable
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
+
   #
   # Attributes
   #
@@ -75,14 +87,23 @@ class Metasploit::Cache::Auxiliary::Instance < ActiveRecord::Base
 
   validates :actions,
             length: {
-                minimum: 1
+              minimum: 1
             }
+
   validates :auxiliary_class,
             presence: true
+
   validates :description,
             presence: true
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
+
   validates :name,
             presence: true
+
   validates :stance,
             inclusion: {
                 in: Metasploit::Cache::Module::Stance::ALL

--- a/app/models/metasploit/cache/encoder/instance.rb
+++ b/app/models/metasploit/cache/encoder/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for an encoder  Metasploit Module.
 class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The class-level metadata for this instance metadata.
@@ -11,13 +13,16 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Encoder::Class',
              inverse_of: :encoder_instance
 
-  # The {Metasploit::Cache::License} objects that are associated with this instance
-  #
-  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  # Joins {#licenses} to this encoder Metasploit Module.
   has_many :licensable_licenses,
            as: :licensable,
            class_name: 'Metasploit::Cache::Licensable::License'
 
+  #
+  # through: :licensable_licenses
+  #
+
+  # The {Metasploit::Cache::License} for the code in this encoder Metasploit Module.
   has_many :licenses,
            class_name: 'Metasploit::Cache::License',
            through: :licensable_licenses

--- a/app/models/metasploit/cache/encoder/instance.rb
+++ b/app/models/metasploit/cache/encoder/instance.rb
@@ -11,6 +11,17 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Encoder::Class',
              inverse_of: :encoder_instance
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   #
   # Attributes
   #
@@ -32,8 +43,15 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
 
   validates :description,
             presence: true
+
   validates :encoder_class,
             presence: true
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
+
   validates :name,
             presence: true
 

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -20,6 +20,17 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
            dependent: :destroy,
            inverse_of: :exploit_instance
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   #
   # Attributes
   #
@@ -70,20 +81,32 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
                   exploit_instance.exploit_targets
                 }
             }
+
   validates :description,
             presence: true
+
   validates :disclosed_on,
             presence: true
+
   validates :exploit_class,
             presence: true
+
   validates :exploit_class_id,
             uniqueness: true
+
   validates :exploit_targets,
             length: {
                 minimum: 1
             }
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
+
   validates :name,
             presence: true
+
   validates :privileged,
             inclusion: {
                 in: [
@@ -91,6 +114,7 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
                     true
                 ]
             }
+
   validates :stance,
             inclusion: {
                 in: Metasploit::Cache::Module::Stance::ALL

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for an exploit Metasploit Module
 class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The default {#exploit_targets exploit target}.
@@ -20,13 +22,16 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
            dependent: :destroy,
            inverse_of: :exploit_instance
 
-  # The {Metasploit::Cache::License} objects that are associated with this instance
-  #
-  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  # Joins {#licenses} to this exploit Metasploit Module.
   has_many :licensable_licenses,
            as: :licensable,
            class_name: 'Metasploit::Cache::Licensable::License'
 
+  #
+  # through: :licensable_licenses
+  #
+
+  # The {Metasploit::Cache::License} for the code in this exploit Metasploit Module.
   has_many :licenses,
            class_name: 'Metasploit::Cache::License',
            through: :licensable_licenses

--- a/app/models/metasploit/cache/licensable/license.rb
+++ b/app/models/metasploit/cache/licensable/license.rb
@@ -33,7 +33,7 @@ class Metasploit::Cache::Licensable::License < ActiveRecord::Base
   #
   # @return [Metasploit::Cache::License]
   belongs_to :license,
-             class_name: "Metasploit::Cache::License"
+             class_name: 'Metasploit::Cache::License'
 
   #
   # Validations

--- a/app/models/metasploit/cache/licensable/license.rb
+++ b/app/models/metasploit/cache/licensable/license.rb
@@ -52,5 +52,28 @@ class Metasploit::Cache::Licensable::License < ActiveRecord::Base
   validates :licensable,
             presence: true
 
+  #
+  # Instance Methods
+  #
+
+  # @!method license_id=(license_id)
+  #   Sets {#license_id} and invalidates cached {#license}, so it will be reloaded on next access.
+  #
+  #   @param license_id [Integer] Primary key of {Metasploit::Cache::License} to load into {#license}.
+  #   @return [void]
+
+  # @!method licensable_id=(licensable_id)
+  #   Sets {#licensable_id} and invalidates cached {#licensable}, so it will be reloaded on next access.
+  #
+  #   @param licensable_id [Integer] Primary key of model named in {#licensable_type}.
+  #   @return [void]
+
+  # @!method licensable_type=(licensable_type)
+  #   Sets {#licensable_type} and invalidates cached {#licensable}, so it will be reloaded on next access.
+  #
+  #   @param licensable_type [String] Name of a model that is licensed.
+  #   @return [void]
+
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/licensable/license.rb
+++ b/app/models/metasploit/cache/licensable/license.rb
@@ -1,0 +1,24 @@
+# Join model for associating Metasploit::Cache::*::Instance objects with {Metasploit::Cache::License} objects.
+# Implements a polymorphic association that the other models use for implementing `#licenses`.
+class Metasploit::Cache::Licensable::License < ActiveRecord::Base
+
+  #
+  # Attributes
+  #
+
+
+  #
+  # Associations
+  #
+
+  # Allows many classes to have a {Metasploit::Cache::License} object
+  belongs_to :licensable,
+             polymorphic: true
+
+
+  #
+  # Validations
+  #
+
+  Metasploit::Concern.run(self)
+end

--- a/app/models/metasploit/cache/licensable/license.rb
+++ b/app/models/metasploit/cache/licensable/license.rb
@@ -41,14 +41,13 @@ class Metasploit::Cache::Licensable::License < ActiveRecord::Base
 
   validates :license,
             presence: true
-
-  # validates :licenseable_id,
-  #           uniqueness: true,
-  #           scope: [
-  #             :license_id,
-  #             :licensable_type,
-  #           ]
-
+  validates :license_id,
+            uniqueness: {
+                scope: [
+                    :licensable_type,
+                    :licensable_id
+                ]
+            }
   validates :licensable,
             presence: true
 

--- a/app/models/metasploit/cache/licensable/license.rb
+++ b/app/models/metasploit/cache/licensable/license.rb
@@ -42,10 +42,14 @@ class Metasploit::Cache::Licensable::License < ActiveRecord::Base
   validates :license,
             presence: true
 
-  validates :licensable_id,
-            presence: true
+  # validates :licenseable_id,
+  #           uniqueness: true,
+  #           scope: [
+  #             :license_id,
+  #             :licensable_type,
+  #           ]
 
-  validates :licensable_type,
+  validates :licensable,
             presence: true
 
   Metasploit::Concern.run(self)

--- a/app/models/metasploit/cache/licensable/license.rb
+++ b/app/models/metasploit/cache/licensable/license.rb
@@ -6,6 +6,20 @@ class Metasploit::Cache::Licensable::License < ActiveRecord::Base
   # Attributes
   #
 
+  # @!attribute license_id
+  #   Primary key of the associated {Metasploit::Cache::License}
+  #
+  #   @return [Fixnum]
+
+  # @!attribute licensable_type
+  #   Model name with an associated license
+  #
+  #   @return [String]
+
+  # @!attribute licensable_id
+  #   Primary key of the associated object whose type is named by {#licensable_type}
+  #
+  #   @return [Fixnum]
 
   #
   # Associations
@@ -15,10 +29,24 @@ class Metasploit::Cache::Licensable::License < ActiveRecord::Base
   belongs_to :licensable,
              polymorphic: true
 
+  # The license associated with the licensable
+  #
+  # @return [Metasploit::Cache::License]
+  belongs_to :license,
+             class_name: "Metasploit::Cache::License"
 
   #
   # Validations
   #
+
+  validates :license,
+            presence: true
+
+  validates :licensable_id,
+            presence: true
+
+  validates :licensable_type,
+            presence: true
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/licensable/license.rb
+++ b/app/models/metasploit/cache/licensable/license.rb
@@ -33,7 +33,8 @@ class Metasploit::Cache::Licensable::License < ActiveRecord::Base
   #
   # @return [Metasploit::Cache::License]
   belongs_to :license,
-             class_name: 'Metasploit::Cache::License'
+             class_name: 'Metasploit::Cache::License',
+             inverse_of: :licensable_licenses
 
   #
   # Validations

--- a/app/models/metasploit/cache/license.rb
+++ b/app/models/metasploit/cache/license.rb
@@ -1,6 +1,16 @@
 # Represents licenses like BSD, MIT, etc used to provide license information for Metasploit modules
 class Metasploit::Cache::License < ActiveRecord::Base
   #
+  # Associations
+  #
+
+  # Join model between this license and anything that uses this license.
+  has_many :licensable_licenses,
+           class_name: 'Metasploit::Cache::Licensable::License',
+           dependent: :destroy,
+           inverse_of: :license
+
+  #
   # Attributes
   #
 

--- a/app/models/metasploit/cache/nop/instance.rb
+++ b/app/models/metasploit/cache/nop/instance.rb
@@ -9,6 +9,17 @@ class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Nop::Class',
              inverse_of: :nop_instance
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   #
   # Attributes
   #
@@ -35,10 +46,18 @@ class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
 
   validates :description,
             presence: true
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
+
   validates :name,
             presence: true
+
   validates :nop_class,
             presence: true
+
   validates :nop_class_id,
             uniqueness: true
 

--- a/app/models/metasploit/cache/nop/instance.rb
+++ b/app/models/metasploit/cache/nop/instance.rb
@@ -1,21 +1,26 @@
 # Instance-level metadata for a nop Metasploit Module
 class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
+  #
+
+  # Joins {#licenses} to this auxiliary Metasploit Module.
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
 
   # The class level metadata for this nop Metasploit Module.
   belongs_to :nop_class,
              class_name: 'Metasploit::Cache::Nop::Class',
              inverse_of: :nop_instance
 
-  # The {Metasploit::Cache::License} objects that are associated with this instance
   #
-  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
-  has_many :licensable_licenses,
-           as: :licensable,
-           class_name: 'Metasploit::Cache::Licensable::License'
+  # through: :licensable_licenses
+  #
 
+  # The {Metasploit::Cache::License} for the code in this auxiliary Metasploit Module.
   has_many :licenses,
            class_name: 'Metasploit::Cache::License',
            through: :licensable_licenses

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -14,6 +14,17 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Payload::Single::Class',
              inverse_of: :payload_single_instance
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   #
   # Attributes
   #
@@ -47,14 +58,24 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
 
   validates :description,
             presence: true
+
   validates :handler,
             presence: true
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
+
   validates :name,
             presence: true
+
   validates :payload_single_class,
             presence: true
+
   validates :payload_single_class_id,
             uniqueness: true
+
   validates :privileged,
             inclusion: {
                 in: [

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for single payload Metasploit Modules
 class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The connection handler
@@ -9,18 +11,21 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Payload::Handler',
              inverse_of: :payload_single_instances
 
+  # Joins {#licenses} to this auxiliary Metasploit Module.
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
   # The class-level metadata for this single payload Metasploit Module.
   belongs_to :payload_single_class,
              class_name: 'Metasploit::Cache::Payload::Single::Class',
              inverse_of: :payload_single_instance
 
-  # The {Metasploit::Cache::License} objects that are associated with this instance
   #
-  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
-  has_many :licensable_licenses,
-           as: :licensable,
-           class_name: 'Metasploit::Cache::Licensable::License'
+  # through: :licensable_licenses
+  #
 
+  # The {Metasploit::Cache::License} for the code in this auxiliary Metasploit Module.
   has_many :licenses,
            class_name: 'Metasploit::Cache::License',
            through: :licensable_licenses

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -1,25 +1,30 @@
 # Instance-level metadata for stage payload Metasploit Module
 class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   #
+  #
   # Associations
   #
-
-  # The {Metasploit::Cache::License} objects that are associated with this instance
   #
-  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+
+  # Joins {#licenses} to this auxiliary Metasploit Module.
   has_many :licensable_licenses,
            as: :licensable,
            class_name: 'Metasploit::Cache::Licensable::License'
-
-  has_many :licenses,
-           class_name: 'Metasploit::Cache::License',
-           through: :licensable_licenses
 
   # The class-level metadata for this stage payload Metasploit Module.
   belongs_to :payload_stage_class,
              class_name: 'Metasploit::Cache::Payload::Stage::Class',
              inverse_of: :payload_stage_instance
-  
+
+  #
+  # through: :licensable_licenses
+  #
+
+  # The {Metasploit::Cache::License} for the code in this auxiliary Metasploit Module.
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   #
   # Attributes
   #

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -4,6 +4,17 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   # Associations
   #
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   # The class-level metadata for this stage payload Metasploit Module.
   belongs_to :payload_stage_class,
              class_name: 'Metasploit::Cache::Payload::Stage::Class',
@@ -41,10 +52,19 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
 
   validates :description,
             presence: true
+
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
+
   validates :name,
             presence: true
+
   validates :payload_stage_class,
             presence: true
+
   validates :payload_stage_class_id,
             uniqueness: true
 

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -53,7 +53,6 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   validates :description,
             presence: true
 
-
   validates :licensable_licenses,
             length: {
               minimum: 1

--- a/app/models/metasploit/cache/payload/stager/instance.rb
+++ b/app/models/metasploit/cache/payload/stager/instance.rb
@@ -14,6 +14,17 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Payload::Stager::Class',
              inverse_of: :payload_stager_instance
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   #
   # Attributes
   #
@@ -52,12 +63,20 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
 
   validates :description,
             presence: true
+
   validates :handler,
             presence: true
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
   validates :name,
             presence: true
+
   validates :payload_stager_class,
             presence: true
+
   validates :payload_stager_class_id,
             uniqueness: true
 

--- a/app/models/metasploit/cache/payload/stager/instance.rb
+++ b/app/models/metasploit/cache/payload/stager/instance.rb
@@ -1,7 +1,9 @@
 # Instance-level metadata for stager payload Metasploit Module
 class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   #
+  #
   # Associations
+  #
   #
 
   # The connection handler
@@ -9,18 +11,21 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Payload::Handler',
              inverse_of: :payload_stager_instances
 
+  # Joins {#licenses} to this auxiliary Metasploit Module.
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
   # The class-level metadata for this stager payload Metasploit Module.
   belongs_to :payload_stager_class,
              class_name: 'Metasploit::Cache::Payload::Stager::Class',
              inverse_of: :payload_stager_instance
 
-  # The {Metasploit::Cache::License} objects that are associated with this instance
   #
-  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
-  has_many :licensable_licenses,
-           as: :licensable,
-           class_name: 'Metasploit::Cache::Licensable::License'
+  # through: :licensable_licenses
+  #
 
+  # The {Metasploit::Cache::License} for the code in this auxiliary Metasploit Module.
   has_many :licenses,
            class_name: 'Metasploit::Cache::License',
            through: :licensable_licenses

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -4,6 +4,17 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   # Associations
   #
 
+  # The {Metasploit::Cache::License} objects that are associated with this instance
+  #
+  # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
+  has_many :licensable_licenses,
+           as: :licensable,
+           class_name: 'Metasploit::Cache::Licensable::License'
+
+  has_many :licenses,
+           class_name: 'Metasploit::Cache::License',
+           through: :licensable_licenses
+
   # The class level metadata for this post Metasploit Module
   belongs_to :post_class,
              class_name: 'Metasploit::Cache::Post::Class',
@@ -46,14 +57,24 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
 
   validates :description,
             presence: true
+
   validates :disclosed_on,
             presence: true
+
+  validates :licensable_licenses,
+            length: {
+              minimum: 1
+            }
+
   validates :name,
             presence: true
+
   validates :post_class,
             presence: true
+
   validates :post_class_id,
             uniqueness: true
+
   validates :privileged,
             inclusion: {
                 in: [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,11 @@ en:
               too_short: "has too few exploit targets (minimum is %{count} exploit target)"
             licensable_licenses:
               too_short: "has too few licenses - minimum is one"
+        metasploit/cache/nop/instance:
+          attributes:
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
+
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
               inclusion: "is not included in exploit targets"
             exploit_targets:
               too_short: "has too few exploit targets (minimum is %{count} exploit target)"
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
   metasploit:
     model:
       ancestors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,10 @@ en:
           attributes:
             licensable_licenses:
               too_short: "has too few licenses - minimum is one"
+        metasploit/cache/payload/stager/instance:
+          attributes:
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
 
   metasploit:
     model:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
             actions:
               does_not_contain_default_action: "does not contain default action"
               too_short: "has too few actions (minimum is %{count} action)"
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
         metasploit/cache/exploit/instance:
           attributes:
             default_exploit_target:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,10 @@ en:
               too_short: "has too few actions (minimum is %{count} action)"
             licensable_licenses:
               too_short: "has too few licenses - minimum is one"
+        metasploit/cache/encoder/instance:
+          attributes:
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
         metasploit/cache/exploit/instance:
           attributes:
             default_exploit_target:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,11 +8,11 @@ en:
               does_not_contain_default_action: "does not contain default action"
               too_short: "has too few actions (minimum is %{count} action)"
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/encoder/instance:
           attributes:
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/exploit/instance:
           attributes:
             default_exploit_target:
@@ -20,27 +20,27 @@ en:
             exploit_targets:
               too_short: "has too few exploit targets (minimum is %{count} exploit target)"
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/nop/instance:
           attributes:
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/payload/single/instance:
           attributes:
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/payload/stage/instance:
           attributes:
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/payload/stager/instance:
           attributes:
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/post/instance:
           attributes:
             licensable_licenses:
-              too_short: "has too few licenses - minimum is one"
+              too_short: "has too few licenses (minimum is %{count} license)"
 
   metasploit:
     model:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,10 @@ en:
           attributes:
             licensable_licenses:
               too_short: "has too few licenses - minimum is one"
+        metasploit/cache/post/instance:
+          attributes:
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
 
   metasploit:
     model:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
           attributes:
             licensable_licenses:
               too_short: "has too few licenses - minimum is one"
+        metasploit/cache/payload/stage/instance:
+          attributes:
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
 
   metasploit:
     model:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,10 @@ en:
           attributes:
             licensable_licenses:
               too_short: "has too few licenses - minimum is one"
+        metasploit/cache/payload/single/instance:
+          attributes:
+            licensable_licenses:
+              too_short: "has too few licenses - minimum is one"
 
   metasploit:
     model:

--- a/db/migrate/20150518163003_create_mc_licensable_licenses.rb
+++ b/db/migrate/20150518163003_create_mc_licensable_licenses.rb
@@ -1,4 +1,4 @@
-class CreateMetasploitCacheLicensableLicenses < ActiveRecord::Migration
+class CreateMcLicensableLicenses < ActiveRecord::Migration
   TABLE_NAME = "mc_licensable_licenses"
 
   # Create mc_licensable_licenses

--- a/db/migrate/20150518163003_create_mc_licensable_licenses.rb
+++ b/db/migrate/20150518163003_create_mc_licensable_licenses.rb
@@ -14,7 +14,7 @@ class CreateMcLicensableLicenses < ActiveRecord::Migration
     change_table TABLE_NAME do |t|
       t.index :license_id
       t.index [:licensable_type, :licensable_id], name: 'mc_licensable_polymorphic'
-      t.index [:license_id, :licensable_type, :licensable_id], unique: true, name: 'unique_mc_licensable_licenses'
+      t.index [:licensable_type, :licensable_id, :license_id], unique: true, name: 'unique_mc_licensable_licenses'
     end
   end
 

--- a/db/migrate/20150518163003_create_metasploit_cache_licensable_licenses.rb
+++ b/db/migrate/20150518163003_create_metasploit_cache_licensable_licenses.rb
@@ -10,6 +10,12 @@ class CreateMetasploitCacheLicensableLicenses < ActiveRecord::Migration
 
       t.timestamps
     end
+
+    change_table TABLE_NAME do |t|
+      t.index :license_id
+      t.index [:licensable_type, :licensable_id], name: 'mc_licensable_polymorphic'
+      t.index [:license_id, :licensable_type, :licensable_id], unique: true, name: 'unique_mc_licensable_licenses'
+    end
   end
 
   # Delete mc_licensable_licenses

--- a/db/migrate/20150518163003_create_metasploit_cache_licensable_licenses.rb
+++ b/db/migrate/20150518163003_create_metasploit_cache_licensable_licenses.rb
@@ -1,0 +1,20 @@
+class CreateMetasploitCacheLicensableLicenses < ActiveRecord::Migration
+  TABLE_NAME = "mc_licensable_licenses"
+
+  # Create mc_licensable_licenses
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      t.references :licensable, polymorphic: true, index:true, null:false
+      t.references :license, null: false, index:true
+
+      t.timestamps
+    end
+  end
+
+  # Delete mc_licensable_licenses
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+end

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -42,6 +42,7 @@ module Metasploit
     autoload :File
     autoload :Invalid
     autoload :License
+    autoload :Licensable
     autoload :Login
     autoload :Module
     autoload :NilifyBlanks

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -41,8 +41,8 @@ module Metasploit
     autoload :Exploit
     autoload :File
     autoload :Invalid
-    autoload :License
     autoload :Licensable
+    autoload :License
     autoload :Login
     autoload :Module
     autoload :NilifyBlanks

--- a/lib/metasploit/cache/licensable.rb
+++ b/lib/metasploit/cache/licensable.rb
@@ -1,0 +1,10 @@
+module Metasploit::Cache::Licensable
+  extend ActiveSupport::Autoload
+
+  autoload :License
+
+  def self.table_name_prefix
+    "#{parent.table_name_prefix}licensable_"
+  end
+
+end

--- a/lib/metasploit/cache/licensable.rb
+++ b/lib/metasploit/cache/licensable.rb
@@ -1,10 +1,17 @@
+# Polymorphic namespace for `ActiveRecord::Base` subclasses that support architectures.
 module Metasploit::Cache::Licensable
   extend ActiveSupport::Autoload
 
   autoload :License
 
+  #
+  # Module Methods
+  #
+
+  # The prefix for `ActiveRecord::Base` subclass table names in this namespace.
+  #
+  # @return [String]
   def self.table_name_prefix
     "#{parent.table_name_prefix}licensable_"
   end
-
 end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -13,7 +13,7 @@ module Metasploit
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 27
       # Remove on master
-      PRERELEASE = 'license-model'
+      PRERELEASE = 'licensable-association'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -79,7 +79,10 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
 
     context "validates that there is at least one license for the module" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/auxiliary/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/auxiliary/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licenses" do

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
     it { is_expected.to belong_to(:auxiliary_class).class_name('Metasploit::Cache::Auxiliary::Class').inverse_of(:auxiliary_instance) }
     it { is_expected.to have_many(:actions).class_name('Metasploit::Cache::Actionable::Action').inverse_of(:actionable) }
     it { is_expected.to belong_to(:default_action).class_name('Metasploit::Cache::Actionable::Action').inverse_of(:actionable) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'database' do
@@ -67,10 +69,36 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           )
         }
 
-        it 'does not adds error on #actions' do
+        it 'does not add error on #actions' do
           auxiliary_instance.valid?
 
           expect(auxiliary_instance.errors[:actions]).not_to include(error)
+        end
+      end
+    end
+
+    context "validates that there is at least one license for the module" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/auxiliary/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licenses" do
+        subject(:auxiliary_instance){ FactoryGirl.build(:metasploit_cache_auxiliary_instance, licenses_count:0) }
+
+        it 'adds error on #licenses' do
+          auxiliary_instance.valid?
+
+          expect(auxiliary_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licenses" do
+        subject(:auxiliary_instance){ FactoryGirl.build(:metasploit_cache_auxiliary_instance, licenses_count: 1) }
+
+        it 'does not add error on #licenses' do
+          auxiliary_instance.valid?
+
+          expect(auxiliary_instance.errors[:licensable_licenses]).to_not include(error)
         end
       end
     end

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -35,7 +35,10 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
 
     context "validate that there is at least one license per encoder" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/encoder/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/encoder/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licensable licenses" do

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:encoder_class).class_name('Metasploit::Cache::Encoder::Class').inverse_of(:encoder_instance) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'database' do
@@ -30,5 +32,36 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :encoder_class }
     it { is_expected.to validate_presence_of :name }
+
+    context "validate that there is at least one license per encoder" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/encoder/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licensable licenses" do
+        subject(:encoder_instance){
+          FactoryGirl.build(:metasploit_cache_encoder_instance, licenses_count: 0)
+        }
+
+        it "adds error on #licensable_licenses" do
+          encoder_instance.valid?
+
+          expect(encoder_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licensable licenses" do
+        subject(:encoder_instance){
+          FactoryGirl.build(:metasploit_cache_encoder_instance, licenses_count: 1)
+        }
+
+        it "does not add error on #licensable_licenses" do
+          encoder_instance.valid?
+
+          expect(encoder_instance.errors[:licensable_licenses]).to_not include(error)
+        end
+      end
+
+    end
   end
 end

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
     it { is_expected.to belong_to(:default_exploit_target).class_name('Metasploit::Cache::Exploit::Target').inverse_of(:exploit_instance) }
     it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance) }
     it { is_expected.to have_many(:exploit_targets).class_name('Metasploit::Cache::Exploit::Target').dependent(:destroy).inverse_of(:exploit_instance) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'factory' do
@@ -145,6 +147,37 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :exploit_class_id }
+    end
+
+    context "validate that there is at least one license per exploit" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/exploit/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licensable licenses" do
+        subject(:exploit_instance){
+          FactoryGirl.build(:metasploit_cache_exploit_instance, licenses_count: 0)
+        }
+
+        it "adds error on #licensable_licenses" do
+          exploit_instance.valid?
+
+          expect(exploit_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licensable licenses" do
+        subject(:exploit_instance){
+          FactoryGirl.build(:metasploit_cache_exploit_instance, licenses_count: 1)
+        }
+
+        it "does not add error on #licensable_licenses" do
+          exploit_instance.valid?
+
+          expect(exploit_instance.errors[:licensable_licenses]).to_not include(error)
+        end
+      end
+
     end
   end
 end

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -151,7 +151,10 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
 
     context "validate that there is at least one license per exploit" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/exploit/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/exploit/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licensable licenses" do

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metasploit::Cache::Licensable::License do
   end
 
   context "factories" do
-    subject(:metasploit_cache_licensable_license){ FactoryGirl.build :metasploit_cache_auxiliary_instance_license }
+    subject(:metasploit_cache_licensable_license){ FactoryGirl.build :metasploit_cache_auxiliary_license }
 
     it { is_expected.to be_valid }
   end

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Metasploit::Cache::Licensable::License do
+  context "database" do
+    context "columns" do
+      it { is_expected.to have_db_column(:license_id).of_type(:integer).with_options(null:false) }
+      it { is_expected.to have_db_column(:licensable_id).of_type(:integer).with_options(null:false) }
+      it { is_expected.to have_db_column(:licensable_type).of_type(:string).with_options(null:false) }
+    end
+  end
+
+  context "associations" do
+    it { is_expected.to belong_to(:licensable)}
+  end
+end

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Metasploit::Cache::Licensable::License do
   end
 
   context "associations" do
-    it { is_expected.to belong_to(:licensable)}
-    it { is_expected.to belong_to(:license)}
+    it { is_expected.to belong_to(:licensable) }
+    it { is_expected.to belong_to(:license) }
   end
 
   context "validations" do

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -14,8 +14,15 @@ RSpec.describe Metasploit::Cache::Licensable::License do
 
   context "validations" do
     it { is_expected.to validate_presence_of :license }
-    # it { is_expected.to validate_uniqueness_of :licensable_id }
     it { is_expected.to validate_presence_of :licensable }
+
+    context 'with existing record' do
+      let!(:existing_licensable_license) {
+        FactoryGirl.create(:metasploit_cache_auxiliary_license)
+      }
+
+      it { is_expected.to validate_uniqueness_of(:license_id).scoped_to(:licensable_type, :licensable_id) }
+    end
   end
 
   context "factories" do

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe Metasploit::Cache::Licensable::License do
 
   context "validations" do
     it { is_expected.to validate_presence_of :license }
-    it { is_expected.to validate_presence_of :licensable_id }
-    it { is_expected.to validate_presence_of :licensable_type }
+    # it { is_expected.to validate_uniqueness_of :licensable_id }
+    it { is_expected.to validate_presence_of :licensable }
+  end
+
+  context "factories" do
+    subject(:metasploit_cache_licensable_license){ FactoryGirl.build :metasploit_cache_auxiliary_instance_license }
+
+    it { is_expected.to be_valid }
   end
 end

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Metasploit::Cache::Licensable::License do
 
   context "associations" do
     it { is_expected.to belong_to(:licensable) }
-    it { is_expected.to belong_to(:license) }
+    it { is_expected.to belong_to(:license).class_name('Metasploit::Cache::License').inverse_of(:licensable_licenses) }
   end
 
   context "validations" do

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Metasploit::Cache::Licensable::License do
       it { is_expected.to have_db_column(:licensable_id).of_type(:integer).with_options(null:false) }
       it { is_expected.to have_db_column(:licensable_type).of_type(:string).with_options(null:false) }
     end
+
+    context 'indices' do
+      it { is_expected.to have_db_index(:license_id).unique(false) }
+      it { is_expected.to have_db_index([:licensable_type, :licensable_id]).unique(false) }
+      it { is_expected.to have_db_index([:licensable_type, :licensable_id, :license_id]).unique(true) }
+    end
   end
 
   context "associations" do

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -9,5 +9,12 @@ RSpec.describe Metasploit::Cache::Licensable::License do
 
   context "associations" do
     it { is_expected.to belong_to(:licensable)}
+    it { is_expected.to belong_to(:license)}
+  end
+
+  context "validations" do
+    it { is_expected.to validate_presence_of :license }
+    it { is_expected.to validate_presence_of :licensable_id }
+    it { is_expected.to validate_presence_of :licensable_type }
   end
 end

--- a/spec/app/models/metasploit/cache/license_spec.rb
+++ b/spec/app/models/metasploit/cache/license_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe Metasploit::Cache::License do
+  context 'associations' do
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License').dependent(:destroy).inverse_of(:license) }
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:abbreviation).of_type(:string).with_options(null: false, unique: true) }

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
 
     context "validate that there is at least one license per nop" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/nop/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/nop/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licensable licenses" do

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -74,8 +74,6 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
           expect(nop_instance.errors[:licensable_licenses]).to_not include(error)
         end
       end
-
-      
     end
     
   end

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'validations' do
@@ -43,5 +45,38 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
 
       it { is_expected.to validate_uniqueness_of :nop_class_id }
     end
+
+    context "validate that there is at least one license per nop" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/nop/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licensable licenses" do
+        subject(:nop_instance){
+          FactoryGirl.build(:metasploit_cache_nop_instance, licenses_count: 0)
+        }
+
+        it "adds error on #licensable_licenses" do
+          nop_instance.valid?
+
+          expect(nop_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licensable licenses" do
+        subject(:nop_instance){
+          FactoryGirl.build(:metasploit_cache_nop_instance, licenses_count: 1)
+        }
+
+        it "does not add error on #licensable_licenses" do
+          nop_instance.valid?
+
+          expect(nop_instance.errors[:licensable_licenses]).to_not include(error)
+        end
+      end
+
+      
+    end
+    
   end
 end

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -51,32 +51,32 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
       it { is_expected.to validate_uniqueness_of :payload_single_class_id }
     end
 
-    context "validate that there is at least one license per nop" do
+    context "validate that there is at least one license per single" do
       let(:error){
         I18n.translate!('activerecord.errors.models.metasploit/cache/payload/single/instance.attributes.licensable_licenses.too_short')
       }
 
       context "without licensable licenses" do
-        subject(:nop_instance){
+        subject(:single_instance){
           FactoryGirl.build(:metasploit_cache_payload_single_instance, licenses_count: 0)
         }
 
         it "adds error on #licensable_licenses" do
-          nop_instance.valid?
+          single_instance.valid?
 
-          expect(nop_instance.errors[:licensable_licenses]).to include(error)
+          expect(single_instance.errors[:licensable_licenses]).to include(error)
         end
       end
 
       context "with licensable licenses" do
-        subject(:nop_instance){
+        subject(:single_instance){
           FactoryGirl.build(:metasploit_cache_payload_single_instance, licenses_count: 1)
         }
 
         it "does not add error on #licensable_licenses" do
-          nop_instance.valid?
+          single_instance.valid?
 
-          expect(nop_instance.errors[:licensable_licenses]).to_not include(error)
+          expect(single_instance.errors[:licensable_licenses]).to_not include(error)
         end
       end
     end

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'database' do
@@ -47,6 +49,36 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :payload_single_class_id }
+    end
+
+    context "validate that there is at least one license per nop" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/payload/single/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licensable licenses" do
+        subject(:nop_instance){
+          FactoryGirl.build(:metasploit_cache_payload_single_instance, licenses_count: 0)
+        }
+
+        it "adds error on #licensable_licenses" do
+          nop_instance.valid?
+
+          expect(nop_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licensable licenses" do
+        subject(:nop_instance){
+          FactoryGirl.build(:metasploit_cache_payload_single_instance, licenses_count: 1)
+        }
+
+        it "does not add error on #licensable_licenses" do
+          nop_instance.valid?
+
+          expect(nop_instance.errors[:licensable_licenses]).to_not include(error)
+        end
+      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -53,7 +53,10 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
 
     context "validate that there is at least one license per single" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/payload/single/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/payload/single/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licensable licenses" do

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
     context 'indices' do
       it { is_expected.to have_db_index(:payload_stage_class_id).unique(true) }
     end
+
+    context "associations" do
+      it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+      it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
+    end
   end
 
   context 'factories' do
@@ -40,6 +45,36 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :payload_stage_class_id }
+    end
+
+    context "validate that there is at least one license per stage" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/payload/stage/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licensable licenses" do
+        subject(:stage_instance){
+          FactoryGirl.build(:metasploit_cache_payload_stage_instance, licenses_count: 0)
+        }
+
+        it "adds error on #licensable_licenses" do
+          stage_instance.valid?
+
+          expect(stage_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licensable licenses" do
+        subject(:stage_instance){
+          FactoryGirl.build(:metasploit_cache_payload_stage_instance, licenses_count: 1)
+        }
+
+        it "does not add error on #licensable_licenses" do
+          stage_instance.valid?
+
+          expect(stage_instance.errors[:licensable_licenses]).to_not include(error)
+        end
+      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -49,7 +49,10 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
 
     context "validate that there is at least one license per stage" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/payload/stage/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/payload/stage/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licensable licenses" do

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
 
     context "validate that there is at least one license per stager" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/payload/stager/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/payload/stager/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licensable licenses" do

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_stager_instances) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'database' do
@@ -49,6 +51,36 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :payload_stager_class_id }
+    end
+
+    context "validate that there is at least one license per stager" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/payload/stager/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licensable licenses" do
+        subject(:stager_instance){
+          FactoryGirl.build(:metasploit_cache_payload_stager_instance, licenses_count: 0)
+        }
+
+        it "adds error on #licensable_licenses" do
+          stager_instance.valid?
+
+          expect(stager_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licensable licenses" do
+        subject(:stager_instance){
+          FactoryGirl.build(:metasploit_cache_payload_stager_instance, licenses_count: 1)
+        }
+
+        it "does not add error on #licensable_licenses" do
+          stager_instance.valid?
+
+          expect(stager_instance.errors[:licensable_licenses]).to_not include(error)
+        end
+      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Metasploit::Cache::Post::Instance do
 
   context 'associations' do
     it { is_expected.to belong_to(:post_class).class_name('Metasploit::Cache::Post::Class').inverse_of(:post_instance) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'factories' do
@@ -46,6 +48,36 @@ RSpec.describe Metasploit::Cache::Post::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :post_class_id }
+    end
+
+    context "validate that there is at least one license per post" do
+      let(:error){
+        I18n.translate!('activerecord.errors.models.metasploit/cache/post/instance.attributes.licensable_licenses.too_short')
+      }
+
+      context "without licensable licenses" do
+        subject(:post_instance){
+          FactoryGirl.build(:metasploit_cache_post_instance, licenses_count: 0)
+        }
+
+        it "adds error on #licensable_licenses" do
+          post_instance.valid?
+
+          expect(post_instance.errors[:licensable_licenses]).to include(error)
+        end
+      end
+
+      context "with licensable licenses" do
+        subject(:post_instance){
+          FactoryGirl.build(:metasploit_cache_post_instance, licenses_count: 1)
+        }
+
+        it "does not add error on #licensable_licenses" do
+          post_instance.valid?
+
+          expect(post_instance.errors[:licensable_licenses]).to_not include(error)
+        end
+      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe Metasploit::Cache::Post::Instance do
 
     context "validate that there is at least one license per post" do
       let(:error){
-        I18n.translate!('activerecord.errors.models.metasploit/cache/post/instance.attributes.licensable_licenses.too_short')
+        I18n.translate!(
+            'activerecord.errors.models.metasploit/cache/post/instance.attributes.licensable_licenses.too_short',
+            count: 1
+        )
       }
 
       context "without licensable licenses" do

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -118,6 +118,10 @@ ActiveRecord::Schema.define(:version => 20150518163003) do
     t.datetime "updated_at",      :null => false
   end
 
+  add_index "mc_licensable_licenses", ["licensable_type", "licensable_id"], :name => "mc_licensable_polymorphic"
+  add_index "mc_licensable_licenses", ["license_id", "licensable_type", "licensable_id"], :name => "unique_mc_licensable_licenses", :unique => true
+  add_index "mc_licensable_licenses", ["license_id"], :name => "index_mc_licensable_licenses_on_license_id"
+
   create_table "mc_licenses", :force => true do |t|
     t.string "abbreviation", :null => false
     t.text   "summary",      :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -118,8 +118,8 @@ ActiveRecord::Schema.define(:version => 20150518163003) do
     t.datetime "updated_at",      :null => false
   end
 
+  add_index "mc_licensable_licenses", ["licensable_type", "licensable_id", "license_id"], :name => "unique_mc_licensable_licenses", :unique => true
   add_index "mc_licensable_licenses", ["licensable_type", "licensable_id"], :name => "mc_licensable_polymorphic"
-  add_index "mc_licensable_licenses", ["license_id", "licensable_type", "licensable_id"], :name => "unique_mc_licensable_licenses", :unique => true
   add_index "mc_licensable_licenses", ["license_id"], :name => "index_mc_licensable_licenses_on_license_id"
 
   create_table "mc_licenses", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150515163602) do
+ActiveRecord::Schema.define(:version => 20150518163003) do
 
   create_table "mc_actionable_actions", :force => true do |t|
     t.string  "name",            :null => false
@@ -109,6 +109,14 @@ ActiveRecord::Schema.define(:version => 20150515163602) do
   add_index "mc_exploit_targets", ["exploit_instance_id", "index"], :name => "index_mc_exploit_targets_on_exploit_instance_id_and_index", :unique => true
   add_index "mc_exploit_targets", ["exploit_instance_id", "name"], :name => "index_mc_exploit_targets_on_exploit_instance_id_and_name", :unique => true
   add_index "mc_exploit_targets", ["exploit_instance_id"], :name => "index_mc_exploit_targets_on_exploit_instance_id"
+
+  create_table "mc_licensable_licenses", :force => true do |t|
+    t.integer  "licensable_id",   :null => false
+    t.string   "licensable_type", :null => false
+    t.integer  "license_id",      :null => false
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+  end
 
   create_table "mc_licenses", :force => true do |t|
     t.string "abbreviation", :null => false

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
           class: Metasploit::Cache::Auxiliary::Instance do
     transient do
       actions_count 1
+      licenses_count 1
     end
 
     description { generate :metasploit_cache_auxiliary_instance_description }
@@ -23,12 +24,22 @@ FactoryGirl.define do
     # Callbacks
     #
 
+    # Create associated objects w/ the counts established above in the
+    # transient attributes. This enables specs using these factories to
+    # specify a number of associated objects and therefore easily make valid/invalid
+    # instances.
     after(:build) { |auxiliary_instance, evaluator|
       auxiliary_instance.actions = build_list(
           :metasploit_cache_auxiliary_action,
           evaluator.actions_count,
           actionable: auxiliary_instance
       )
+      auxiliary_instance.licensable_licenses = build_list(
+          :metasploit_cache_auxiliary_instance_license,
+          evaluator.licenses_count,
+          licensable: auxiliary_instance
+      )
+      true
     }
   end
 

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -39,7 +39,6 @@ FactoryGirl.define do
           evaluator.licenses_count,
           licensable: auxiliary_instance
       )
-      true
     }
   end
 

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
           actionable: auxiliary_instance
       )
       auxiliary_instance.licensable_licenses = build_list(
-          :metasploit_cache_auxiliary_instance_license,
+          :metasploit_cache_auxiliary_license,
           evaluator.licenses_count,
           licensable: auxiliary_instance
       )

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -8,11 +8,27 @@ FactoryGirl.define do
     description { generate :metasploit_cache_encoder_instance_description }
     name { generate :metasploit_cache_encoder_instance_name }
 
+    transient do
+      licenses_count 1
+    end
+
     #
     # Associations
     #
 
     association :encoder_class, factory: :metasploit_cache_encoder_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |encoder_instance, evaluator|
+      encoder_instance.licensable_licenses = build_list(
+        :metasploit_cache_auxiliary_instance_license,
+        evaluator.licenses_count,
+        licensable: encoder_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -24,7 +24,7 @@ FactoryGirl.define do
 
     after(:build) do |encoder_instance, evaluator|
       encoder_instance.licensable_licenses = build_list(
-        :metasploit_cache_auxiliary_instance_license,
+        :metasploit_cache_encoder_license,
         evaluator.licenses_count,
         licensable: encoder_instance
       )

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
           class: Metasploit::Cache::Exploit::Instance do
     transient do
       exploit_target_count 1
+      licenses_count 1
     end
 
     description { generate :metasploit_cache_exploit_instance_description }
@@ -22,6 +23,12 @@ FactoryGirl.define do
           :metasploit_cache_exploit_target,
           evaluator.exploit_target_count,
           exploit_instance: exploit_instance
+      )
+
+      exploit_instance.licensable_licenses = build_list(
+        :metasploit_cache_exploit_license,
+        evaluator.licenses_count,
+        licensable: exploit_instance
       )
     }
   end

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -12,6 +12,10 @@ FactoryGirl.define do
     privileged { generate :metasploit_cache_exploit_instance_privileged }
     stance { generate :metasploit_cache_module_stance }
 
+    #
+    # Associations
+    #
+
     association :exploit_class, factory: :metasploit_cache_exploit_class
 
     #

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
+  #
+  # Factories
+  #
 
   factory :metasploit_cache_auxiliary_license,
                  class: Metasploit::Cache::Licensable::License,
@@ -15,47 +18,44 @@ FactoryGirl.define do
   factory :metasploit_cache_exploit_license,
           class: Metasploit::Cache::Licensable::License,
           traits: [:metasploit_cache_licensable_license] do
-
     association :licensable, factory: :metasploit_cache_exploit_instance
   end
 
   factory :metasploit_cache_nop_license,
           class: Metasploit::Cache::Licensable::License,
           traits: [:metasploit_cache_licensable_license] do
-
     association :licensable, factory: :metasploit_cache_nop_instance
   end
 
   factory :metasploit_cache_payload_single_license,
           class: Metasploit::Cache::Licensable::License,
           traits: [:metasploit_cache_licensable_license] do
-
     association :licensable, factory: :metasploit_cache_payload_single_instance
   end
 
   factory :metasploit_cache_payload_stage_license,
           class: Metasploit::Cache::Licensable::License,
           traits: [:metasploit_cache_licensable_license] do
-
     association :licensable, factory: :metasploit_cache_payload_stage_instance
   end
 
   factory :metasploit_cache_payload_stager_license,
           class: Metasploit::Cache::Licensable::License,
           traits: [:metasploit_cache_licensable_license] do
-
     association :licensable, factory: :metasploit_cache_payload_stager_instance
   end
 
   factory :metasploit_cache_payload_post_license,
           class: Metasploit::Cache::Licensable::License,
           traits: [:metasploit_cache_licensable_license] do
-
     association :licensable, factory: :metasploit_cache_payload_post_instance
   end
+
+  #
+  # Traits
+  #
 
   trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
   end
-
 end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -19,6 +19,13 @@ FactoryGirl.define do
     association :licensable, factory: :metasploit_cache_exploit_instance
   end
 
+  factory :metasploit_cache_nop_license,
+          class: Metasploit::Cache::Licensable::License,
+          traits: [:metasploit_cache_licensable_license] do
+
+    association :licensable, factory: :metasploit_cache_nop_instance
+  end
+
   trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
   end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -26,6 +26,13 @@ FactoryGirl.define do
     association :licensable, factory: :metasploit_cache_nop_instance
   end
 
+  factory :metasploit_cache_payload_single_license,
+          class: Metasploit::Cache::Licensable::License,
+          traits: [:metasploit_cache_licensable_license] do
+
+    association :licensable, factory: :metasploit_cache_payload_single_instance
+  end
+
   trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
   end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -1,8 +1,25 @@
 FactoryGirl.define do
 
-  factory :metasploit_cache_auxiliary_instance_license,
-                 class: Metasploit::Cache::Licensable::License do
+  factory :metasploit_cache_auxiliary_license,
+                 class: Metasploit::Cache::Licensable::License,
+                 traits: [:metasploit_cache_licensable_license] do
     association :licensable, factory: :metasploit_cache_auxiliary_instance
+  end
+
+  factory :metasploit_cache_encoder_license,
+          class: Metasploit::Cache::Licensable::License,
+          traits: [:metasploit_cache_licensable_license] do
+    association :licensable, factory: :metasploit_cache_encoder_instance
+  end
+
+  factory :metasploit_cache_exploit_license,
+          class: Metasploit::Cache::Licensable::License,
+          traits: [:metasploit_cache_licensable_license] do
+
+    association :licensable, factory: :metasploit_cache_exploit_instance
+  end
+
+  trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
   end
 

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -33,6 +33,13 @@ FactoryGirl.define do
     association :licensable, factory: :metasploit_cache_payload_single_instance
   end
 
+  factory :metasploit_cache_payload_stage_license,
+          class: Metasploit::Cache::Licensable::License,
+          traits: [:metasploit_cache_licensable_license] do
+
+    association :licensable, factory: :metasploit_cache_payload_stage_instance
+  end
+
   trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
   end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+
+  factory :metasploit_cache_auxiliary_instance_license,
+                 class: Metasploit::Cache::Licensable::License do
+    association :licensable, factory: :metasploit_cache_auxiliary_instance
+    association :license, factory: :metasploit_cache_license
+  end
+
+end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -47,6 +47,13 @@ FactoryGirl.define do
     association :licensable, factory: :metasploit_cache_payload_stager_instance
   end
 
+  factory :metasploit_cache_payload_post_license,
+          class: Metasploit::Cache::Licensable::License,
+          traits: [:metasploit_cache_licensable_license] do
+
+    association :licensable, factory: :metasploit_cache_payload_post_instance
+  end
+
   trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
   end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -40,6 +40,13 @@ FactoryGirl.define do
     association :licensable, factory: :metasploit_cache_payload_stage_instance
   end
 
+  factory :metasploit_cache_payload_stager_license,
+          class: Metasploit::Cache::Licensable::License,
+          traits: [:metasploit_cache_licensable_license] do
+
+    association :licensable, factory: :metasploit_cache_payload_stager_instance
+  end
+
   trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
   end

--- a/spec/factories/metasploit/cache/licenses.rb
+++ b/spec/factories/metasploit/cache/licenses.rb
@@ -1,15 +1,25 @@
 FactoryGirl.define do
   factory :metasploit_cache_license, class: Metasploit::Cache::License do
-    abbreviation "BSD-2"
-    summary(
+    abbreviation { generate :metasploit_cache_license_abbreviation }
+    summary { generate :metasploit_cache_license_summary }
+    url { generate :metasploit_cache_license_url }
+  end
+
+  sequence :metasploit_cache_license_abbreviation do |n|
+    "BSD-#{n}"
+  end
+
+  sequence :metasploit_cache_license_summary do |n|
       <<EOS
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#{n}-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 EOS
-    )
-    url "http://opensource.org/licenses/BSD-2-Clause"
+  end
+
+  sequence :metasploit_cache_license_url do |n|
+    "http://opensource.org/licenses/BSD-#{n}-Clause"
   end
 end

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -9,7 +9,15 @@ FactoryGirl.define do
     description { generate :metasploit_cache_nop_instance_description }
     name { generate :metasploit_cache_nop_instance_name }
 
+    #
+    # Associations
+    #
+
     association :nop_class, factory: :metasploit_cache_nop_class
+
+    #
+    # Callbacks
+    #
 
     after(:build) { |nop_instance, evaluator|
       nop_instance.licensable_licenses = build_list(

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -1,10 +1,24 @@
 FactoryGirl.define do
   factory :metasploit_cache_nop_instance,
           class: Metasploit::Cache::Nop::Instance do
+    transient do
+      licenses_count 1
+    end
+
+
     description { generate :metasploit_cache_nop_instance_description }
     name { generate :metasploit_cache_nop_instance_name }
 
     association :nop_class, factory: :metasploit_cache_nop_class
+
+    after(:build) { |nop_instance, evaluator|
+      nop_instance.licensable_licenses = build_list(
+        :metasploit_cache_nop_license,
+        evaluator.licenses_count,
+        licensable: nop_instance
+      )
+    }
+
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
           class: Metasploit::Cache::Payload::Single::Instance do
+    transient do
+      licenses_count 1
+    end
+
     description { generate :metasploit_cache_payload_single_instance_description }
     name { generate :metasploit_cache_payload_single_instance_name }
     privileged { generate :metasploit_cache_payload_single_instance_privileged }
@@ -11,6 +15,19 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_single_class, factory: :metasploit_cache_payload_single_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |single_instance, evaluator|
+      single_instance.licensable_licenses = build_list(
+        :metasploit_cache_payload_single_license,
+        evaluator.licenses_count,
+        licensable: single_instance
+      )
+    end
+
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -12,12 +12,13 @@ FactoryGirl.define do
     #
     # Associations
     #
-    association :payload_stage_class, factory: :metasploit_cache_payload_stage_class
 
+    association :payload_stage_class, factory: :metasploit_cache_payload_stage_class
 
     #
     # Callbacks
     #
+
     after(:build) do |stage_instance, evaluator|
       stage_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stage_license,

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -14,10 +14,10 @@ FactoryGirl.define do
     #
     association :payload_stage_class, factory: :metasploit_cache_payload_stage_class
 
+
     #
     # Callbacks
     #
-
     after(:build) do |stage_instance, evaluator|
       stage_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stage_license,

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -1,11 +1,30 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stage_instance,
           class: Metasploit::Cache::Payload::Stage::Instance do
+    transient do
+      licenses_count 1
+    end
+
     description { generate :metasploit_cache_payload_stage_instance_description }
     name { generate :metasploit_cache_payload_stage_instance_name }
     privileged { generate :metasploit_cache_payload_stage_instance_privileged }
 
+    #
+    # Associations
+    #
     association :payload_stage_class, factory: :metasploit_cache_payload_stage_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |stage_instance, evaluator|
+      stage_instance.licensable_licenses = build_list(
+        :metasploit_cache_payload_stage_license,
+        evaluator.licenses_count,
+        licensable: stage_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stager_instance,
           class: Metasploit::Cache::Payload::Stager::Instance do
+    transient do
+      licenses_count 1
+    end
+
     description { generate :metasploit_cache_payload_stager_instance_description }
     handler_type_alias { generate :metasploit_cache_payload_stager_handler_type_alias }
     name { generate :metasploit_cache_payload_stager_instance_name }
@@ -12,6 +16,19 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_stager_class, factory: :metasploit_cache_payload_stager_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |stager_instance, evaluator|
+      stager_instance.licensable_licenses = build_list(
+        :metasploit_cache_payload_stager_license,
+        evaluator.licenses_count,
+        licensable: stager_instance
+      )
+    end
+
   end
 
   #

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -1,12 +1,28 @@
 FactoryGirl.define do
   factory :metasploit_cache_post_instance,
           class: Metasploit::Cache::Post::Instance do
+    transient do
+      licenses_count 1
+    end
+
     description { generate :metasploit_cache_post_instance_description }
     disclosed_on { generate :metasploit_cache_post_instance_disclosed_on }
     name { generate :metasploit_cache_post_instance_name }
     privileged { generate :metasploit_cache_post_instance_privileged }
 
     association :post_class, factory: :metasploit_cache_post_class
+
+    #
+    # Callbacks
+    #
+
+    after(:build) do |post_instance, evaluator|
+      post_instance.licensable_licenses = build_list(
+        :metasploit_cache_payload_post_license,
+        evaluator.licenses_count,
+        licensable: post_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -10,6 +10,10 @@ FactoryGirl.define do
     name { generate :metasploit_cache_post_instance_name }
     privileged { generate :metasploit_cache_post_instance_privileged }
 
+    #
+    # Associations
+    #
+
     association :post_class, factory: :metasploit_cache_post_class
 
     #

--- a/spec/factories/metasploit_cache_licensable_licenses.rb
+++ b/spec/factories/metasploit_cache_licensable_licenses.rb
@@ -1,6 +1,0 @@
-FactoryGirl.define do
-  factory :metasploit_cache_licensable_license, :class => 'Metasploit::Cache::Licensable::License' do
-    
-  end
-
-end

--- a/spec/factories/metasploit_cache_licensable_licenses.rb
+++ b/spec/factories/metasploit_cache_licensable_licenses.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :metasploit_cache_licensable_license, :class => 'Metasploit::Cache::Licensable::License' do
+    
+  end
+
+end


### PR DESCRIPTION
MSP-12435

# Pre-Verification Steps

- [x] Land #43

# Verification Steps

## Postgresql
- [x] `rm Gemfile.lock`
- [x] `bundle install --without sqlite3`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.73% coverage

### Documentation Coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [x] VERIFY no undocumented objects

## Sqlite3
- [x] `rm Gemfile.lock`
- [x] `bundle install --without postgresql`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 99.69% coverage

### Documentation coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [x] Edit `lib/metasploit/cache/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`