### PR TITLE
Metasploit::Cache::Contribution

### DIFF
--- a/app/models/metasploit/cache/author.rb
+++ b/app/models/metasploit/cache/author.rb
@@ -20,11 +20,22 @@ class Metasploit::Cache::Author < ActiveRecord::Base
   has_many :module_authors, class_name: 'Metasploit::Cache::Module::Author', dependent: :destroy, inverse_of: :author
 
   #
+  # through: :contributions
+  #
+
+  # Email addresses used by this author across all {#contributions}.
+  has_many :email_addresses,
+           class_name: 'Metasploit::Cache::EmailAddress',
+           through: :contributions
+
+  #
   # through: :module_authors
   #
 
   # Email addresses used by this author across all {#module_instances}.
-  has_many :email_addresses, class_name: 'Metasploit::Cache::EmailAddress', through: :module_authors
+  has_many :module_author_email_addresses,
+           class_name: 'Metasploit::Cache::EmailAddress',
+           through: :module_authors
 
   # Modules written by this author.
   has_many :module_instances, class_name: 'Metasploit::Cache::Module::Instance', through: :module_authors

--- a/app/models/metasploit/cache/author.rb
+++ b/app/models/metasploit/cache/author.rb
@@ -10,6 +10,12 @@ class Metasploit::Cache::Author < ActiveRecord::Base
   # Associations
   #
 
+  # Joins to this author.
+  has_many :contributions,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :author
+
   # Joins this to {#email_addresses} and {#module_instances}.
   has_many :module_authors, class_name: 'Metasploit::Cache::Module::Author', dependent: :destroy, inverse_of: :author
 

--- a/app/models/metasploit/cache/auxiliary/instance.rb
+++ b/app/models/metasploit/cache/auxiliary/instance.rb
@@ -21,6 +21,13 @@ class Metasploit::Cache::Auxiliary::Instance < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Auxiliary::Class',
              inverse_of: :auxiliary_instance
 
+  # Code contributions to this auxiliary Metasploit Module
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
   # @note The default action must be manually added to {#actions}.
   #
   # The (optional) default action for the auxiliary Metasploit Module.
@@ -96,6 +103,11 @@ class Metasploit::Cache::Auxiliary::Instance < ActiveRecord::Base
 
   validates :auxiliary_class,
             presence: true
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :description,
             presence: true

--- a/app/models/metasploit/cache/contribution.rb
+++ b/app/models/metasploit/cache/contribution.rb
@@ -9,10 +9,28 @@ class Metasploit::Cache::Contribution < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Author',
              inverse_of: :contributions
 
+  belongs_to :contributable,
+             polymorphic: true
+
   # Email address {#author} used when writing this contribution.
   belongs_to :email_address,
              class_name: 'Metasploit::Cache::EmailAddress',
              inverse_of: :contributions
+
+  #
+  # Attributes
+  #
+
+  # @!attribute author_id
+  #   Foreign key for {#author}.
+  #
+  #   @return [Integer]
+
+  # @!attribute email_address_id
+  #   Foreign key for {#email_address}.
+  #
+  #   @return [Integer]
+  #   @return [nil] if no {#email_address}.
 
   #
   # Validations
@@ -21,8 +39,41 @@ class Metasploit::Cache::Contribution < ActiveRecord::Base
   validates :author,
             presence: true
 
-  validates :email_address,
+  validates :author_id,
+            uniqueness: {
+                scope: [
+                    :contributable_type,
+                    :contributable_id
+                ]
+            }
+
+  validates :contributable,
             presence: true
+
+  validates :email_address_id,
+            uniqueness: {
+                allow_nil: true,
+                scope: [
+                    :contributable_type,
+                    :contributable_id
+                ]
+            }
+
+  #
+  # Instance Methods
+  #
+
+  # @!method author_id=(author_id)
+  #   Sets {#author_id} and invalidates cached {#author} so it is reloaded on next access.
+  #
+  #   @param author_id [Integer]
+  #   @return [void]
+
+  # @!method email_address_id=(email_address_id)
+  #   Sets {#email_address_id} and invalidates cached {#email_address} so it is reloaded on next access.
+  #
+  #   @param email_address_id [Integer]
+  #   @return [void]
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/contribution.rb
+++ b/app/models/metasploit/cache/contribution.rb
@@ -1,0 +1,3 @@
+# A contribution an `#author` made using a given `#email_address` to a polymorphic `#contributable`.
+class Metasploit::Cache::Contribution
+end

--- a/app/models/metasploit/cache/contribution.rb
+++ b/app/models/metasploit/cache/contribution.rb
@@ -1,4 +1,13 @@
 # A contribution an `#author` made using a given `#email_address` to a polymorphic `#contributable`.
-class Metasploit::Cache::Contribution
+class Metasploit::Cache::Contribution < ActiveRecord::Base
+  #
+  # Associations
+  #
+
+  # Name of the contributor.
+  belongs_to :author,
+             class_name: 'Metasploit::Cache::Author',
+             inverse_of: :contributions
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/contribution.rb
+++ b/app/models/metasploit/cache/contribution.rb
@@ -14,5 +14,15 @@ class Metasploit::Cache::Contribution < ActiveRecord::Base
              class_name: 'Metasploit::Cache::EmailAddress',
              inverse_of: :contributions
 
+  #
+  # Validations
+  #
+
+  validates :author,
+            presence: true
+
+  validates :email_address,
+            presence: true
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/contribution.rb
+++ b/app/models/metasploit/cache/contribution.rb
@@ -9,5 +9,10 @@ class Metasploit::Cache::Contribution < ActiveRecord::Base
              class_name: 'Metasploit::Cache::Author',
              inverse_of: :contributions
 
+  # Email address {#author} used when writing this contribution.
+  belongs_to :email_address,
+             class_name: 'Metasploit::Cache::EmailAddress',
+             inverse_of: :contributions
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/contribution.rb
+++ b/app/models/metasploit/cache/contribution.rb
@@ -1,3 +1,4 @@
 # A contribution an `#author` made using a given `#email_address` to a polymorphic `#contributable`.
 class Metasploit::Cache::Contribution
+  Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit/cache/email_address.rb
+++ b/app/models/metasploit/cache/email_address.rb
@@ -19,11 +19,22 @@ class Metasploit::Cache::EmailAddress < ActiveRecord::Base
   has_many :module_authors, class_name: 'Metasploit::Cache::Module::Author', dependent: :destroy, inverse_of: :email_address
 
   #
+  # through: :contributions
+  #
+
+  # Authors that used this email address.
+  has_many :authors,
+           class_name: 'Metasploit::Cache::Author',
+           through: :contributions
+
+  #
   # through: :module_authors
   #
 
   # Authors that used this email address.
-  has_many :authors, class_name: 'Metasploit::Cache::Author', through: :module_authors
+  has_many :module_author_authors,
+           class_name: 'Metasploit::Cache::Author',
+           through: :module_authors
 
   # Modules where this email address was used.
   has_many :module_instances, class_name: 'Metasploit::Cache::Module::Instance', through: :module_authors

--- a/app/models/metasploit/cache/email_address.rb
+++ b/app/models/metasploit/cache/email_address.rb
@@ -9,6 +9,12 @@ class Metasploit::Cache::EmailAddress < ActiveRecord::Base
   # Associations
   #
 
+  # Credits where authors used this email address for their contributions.
+  has_many :contributions,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :email_address
+
   # Credits where {#authors} used this email address for {#module_instances modules}.
   has_many :module_authors, class_name: 'Metasploit::Cache::Module::Author', dependent: :destroy, inverse_of: :email_address
 

--- a/app/models/metasploit/cache/encoder/instance.rb
+++ b/app/models/metasploit/cache/encoder/instance.rb
@@ -6,6 +6,13 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   #
   #
 
+  # Code contributions to this Metasploit Module.
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
   # The class-level metadata for this instance metadata.
   #
   # @return [Metasploit::Cache::Encoder::Class]
@@ -45,6 +52,11 @@ class Metasploit::Cache::Encoder::Instance < ActiveRecord::Base
   #
   # Validations
   #
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :description,
             presence: true

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -6,6 +6,13 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
   #
   #
 
+  # Code contributions to this exploit Metasploit Module.
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
   # The default {#exploit_targets exploit target}.
   belongs_to :default_exploit_target,
              class_name: 'Metasploit::Cache::Exploit::Target',
@@ -78,6 +85,11 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
   #
   # Validations
   #
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :default_exploit_target,
             inclusion: {

--- a/app/models/metasploit/cache/nop/instance.rb
+++ b/app/models/metasploit/cache/nop/instance.rb
@@ -6,6 +6,13 @@ class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
   #
   #
 
+  # Code contributions to this nop Metasploit Module.
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
   # Joins {#licenses} to this auxiliary Metasploit Module.
   has_many :licensable_licenses,
            as: :licensable,
@@ -48,6 +55,11 @@ class Metasploit::Cache::Nop::Instance < ActiveRecord::Base
   #
   # Validations
   #
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :description,
             presence: true

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -6,6 +6,13 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   #
   #
 
+  # Code contributions to this single payload Metasploit Module
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
   # The connection handler
   belongs_to :handler,
              class_name: 'Metasploit::Cache::Payload::Handler',
@@ -60,6 +67,11 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   #
   # Validations
   #
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :description,
             presence: true

--- a/app/models/metasploit/cache/payload/stage/instance.rb
+++ b/app/models/metasploit/cache/payload/stage/instance.rb
@@ -6,7 +6,14 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   #
   #
 
-  # Joins {#licenses} to this auxiliary Metasploit Module.
+  # Code contributions ot this stage payload Metasploit Module
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
+  # Joins {#licenses} to this stage payoad Metasploit Module.
   has_many :licensable_licenses,
            as: :licensable,
            class_name: 'Metasploit::Cache::Licensable::License'
@@ -54,6 +61,11 @@ class Metasploit::Cache::Payload::Stage::Instance < ActiveRecord::Base
   #
   # Validations
   #
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :description,
             presence: true

--- a/app/models/metasploit/cache/payload/stager/instance.rb
+++ b/app/models/metasploit/cache/payload/stager/instance.rb
@@ -6,12 +6,19 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   #
   #
 
+  # Code contributions for stager payload Metasploit Module
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
   # The connection handler
   belongs_to :handler,
              class_name: 'Metasploit::Cache::Payload::Handler',
              inverse_of: :payload_stager_instances
 
-  # Joins {#licenses} to this auxiliary Metasploit Module.
+  # Joins {#licenses} to this stager payload Metasploit Module.
   has_many :licensable_licenses,
            as: :licensable,
            class_name: 'Metasploit::Cache::Licensable::License'
@@ -65,6 +72,11 @@ class Metasploit::Cache::Payload::Stager::Instance < ActiveRecord::Base
   #
   # Validations
   #
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :description,
             presence: true

--- a/app/models/metasploit/cache/post/instance.rb
+++ b/app/models/metasploit/cache/post/instance.rb
@@ -4,6 +4,13 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   # Associations
   #
 
+  # Code contributions to this post Metasploit Module.
+  has_many :contributions,
+           as: :contributable,
+           class_name: 'Metasploit::Cache::Contribution',
+           dependent: :destroy,
+           inverse_of: :contributable
+
   # The {Metasploit::Cache::License} objects that are associated with this instance
   #
   # @return[ActiveRecord::Relation<Metasploit::Cache::Licensable::License>]
@@ -54,6 +61,11 @@ class Metasploit::Cache::Post::Instance < ActiveRecord::Base
   #
   # Validations
   #
+
+  validates :contributions,
+            length: {
+                minimum: 1
+            }
 
   validates :description,
             presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,14 +7,20 @@ en:
             actions:
               does_not_contain_default_action: "does not contain default action"
               too_short: "has too few actions (minimum is %{count} action)"
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             licensable_licenses:
               too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/encoder/instance:
           attributes:
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             licensable_licenses:
               too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/exploit/instance:
           attributes:
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             default_exploit_target:
               inclusion: "is not included in exploit targets"
             exploit_targets:
@@ -23,22 +29,32 @@ en:
               too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/nop/instance:
           attributes:
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             licensable_licenses:
               too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/payload/single/instance:
           attributes:
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             licensable_licenses:
               too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/payload/stage/instance:
           attributes:
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             licensable_licenses:
               too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/payload/stager/instance:
           attributes:
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             licensable_licenses:
               too_short: "has too few licenses (minimum is %{count} license)"
         metasploit/cache/post/instance:
           attributes:
+            contributions:
+              too_short: "has too few contributions (minimum is %{count} contribution)"
             licensable_licenses:
               too_short: "has too few licenses (minimum is %{count} license)"
 

--- a/db/migrate/20150526204451_create_mc_contributions.rb
+++ b/db/migrate/20150526204451_create_mc_contributions.rb
@@ -27,10 +27,14 @@ class CreateMcContributions < ActiveRecord::Migration
 
       t.references :author,
                    null: false
+      t.references :email_address,
+                   null: false
     end
 
     change_table TABLE_NAME do |t|
       t.index :author_id,
+              unique: false
+      t.index :email_address_id,
               unique: false
     end
   end

--- a/db/migrate/20150526204451_create_mc_contributions.rb
+++ b/db/migrate/20150526204451_create_mc_contributions.rb
@@ -1,0 +1,37 @@
+class CreateMcContributions < ActiveRecord::Migration
+  #
+  # CONSTANTS
+  #
+  # Name of the table being created
+  TABLE_NAME = :mc_contributions
+
+  #
+  # Instance Methods
+  #
+
+  # Drop {TABLE_NAME}.
+  #
+  # @return [void]
+  def down
+    drop_table TABLE_NAME
+  end
+
+  # Create {TABLE_NAME}.
+  #
+  # @return [void]
+  def up
+    create_table TABLE_NAME do |t|
+      #
+      # References
+      #
+
+      t.references :author,
+                   null: false
+    end
+
+    change_table TABLE_NAME do |t|
+      t.index :author_id,
+              unique: false
+    end
+  end
+end

--- a/db/migrate/20150526204451_create_mc_contributions.rb
+++ b/db/migrate/20150526204451_create_mc_contributions.rb
@@ -27,13 +27,25 @@ class CreateMcContributions < ActiveRecord::Migration
 
       t.references :author,
                    null: false
+      t.references :contributable,
+                   null: false,
+                   polymorphic: true
       t.references :email_address,
-                   null: false
+                   null: true
     end
 
     change_table TABLE_NAME do |t|
       t.index :author_id,
               unique: false
+      t.index [:contributable_type, :contributable_id],
+              name: 'mc_contribution_contributables',
+              unique: false
+      t.index [:contributable_type, :contributable_id, :author_id],
+              name: 'unique_mc_contribution_authors',
+              unique: true
+      t.index [:contributable_type, :contributable_id, :email_address_id],
+              name: 'unique_mc_contribution_email_addresses',
+              unique: true
       t.index :email_address_id,
               unique: false
     end

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -33,6 +33,7 @@ module Metasploit
     autoload :Batch
     autoload :Cacheable
     autoload :Constant
+    autoload :Contribution
     autoload :Derivation
     autoload :Direct
     autoload :EmailAddress

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -9,9 +9,11 @@ module Metasploit
       # The major version number.
       MAJOR = 0
       # The minor version number, scoped to the {MAJOR} version number.
-      MINOR = 64
+      MINOR = 65
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 29
+      PATCH = 0
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'contribution'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/author_spec.rb
+++ b/spec/app/models/metasploit/cache/author_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Metasploit::Cache::Author do
   context 'associations' do
     it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:author) }
-    it { should have_many(:email_addresses).class_name('Metasploit::Cache::EmailAddress').through(:module_authors) }
+    it { is_expected.to have_many(:email_addresses).class_name('Metasploit::Cache::EmailAddress').through(:contributions) }
+    it { is_expected.to have_many(:module_author_email_addresses).class_name('Metasploit::Cache::EmailAddress').through(:module_authors) }
     it { should have_many(:module_authors).class_name('Metasploit::Cache::Module::Author').dependent(:destroy) }
     it { should have_many(:module_instances).class_name('Metasploit::Cache::Module::Instance').through(:module_authors) }
   end

--- a/spec/app/models/metasploit/cache/author_spec.rb
+++ b/spec/app/models/metasploit/cache/author_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Metasploit::Cache::Author do
   context 'associations' do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:author) }
     it { should have_many(:email_addresses).class_name('Metasploit::Cache::EmailAddress').through(:module_authors) }
     it { should have_many(:module_authors).class_name('Metasploit::Cache::Module::Author').dependent(:destroy) }
     it { should have_many(:module_instances).class_name('Metasploit::Cache::Module::Instance').through(:module_authors) }

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
                           factory: :metasploit_cache_auxiliary_instance
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_auxiliary_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_auxiliary_instance
 

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
   context 'associations' do
     it { is_expected.to belong_to(:auxiliary_class).class_name('Metasploit::Cache::Auxiliary::Class').inverse_of(:auxiliary_instance) }
     it { is_expected.to have_many(:actions).class_name('Metasploit::Cache::Actionable::Action').inverse_of(:actionable) }
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:default_action).class_name('Metasploit::Cache::Actionable::Action').inverse_of(:actionable) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
   context 'associations' do
     it { is_expected.to belong_to(:auxiliary_class).class_name('Metasploit::Cache::Auxiliary::Class').inverse_of(:auxiliary_instance) }
     it { is_expected.to have_many(:actions).class_name('Metasploit::Cache::Actionable::Action').inverse_of(:actionable) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
     it { is_expected.to belong_to(:default_action).class_name('Metasploit::Cache::Actionable::Action').inverse_of(:actionable) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -38,45 +38,9 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
   context 'validations' do
     it { is_expected.to validate_presence_of(:auxiliary_class) }
 
-    # validate_lenght_of from shoulda-matchers assumes attribute is String and doesn't work on associations
-    context 'validates length of actions is at least 1' do
-      let(:error) {
-        I18n.translate!(
-          'activerecord.errors.models.metasploit/cache/auxiliary/instance.attributes.actions.too_short',
-           count: 1
-        )
-      }
-
-      context 'without actions' do
-        subject(:auxiliary_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_auxiliary_instance,
-              actions_count: 0
-          )
-        }
-
-        it 'adds error on #actions' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:actions]).to include(error)
-        end
-      end
-
-      context 'with actions' do
-        subject(:auxiliary_instance) {
-          FactoryGirl.build(
-              :metasploit_cache_auxiliary_instance,
-              actions_count: 1
-          )
-        }
-
-        it 'does not add error on #actions' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:actions]).not_to include(error)
-        end
-      end
-    end
+    it_should_behave_like 'validates at least one in association',
+                          :actions,
+                          factory: :metasploit_cache_auxiliary_instance
 
     context "validates that there is at least one license for the module" do
       let(:error){
@@ -120,7 +84,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
             subject(:auxiliary_instance) {
               FactoryGirl.build(
                              :metasploit_cache_auxiliary_instance,
-                             actions_count: 1
+                             action_count: 1
               ).tap { |auxiliary_instance|
                 auxiliary_instance.default_action = auxiliary_instance.actions.first
               }
@@ -149,7 +113,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
             subject(:auxiliary_instance) {
               FactoryGirl.build(
                              :metasploit_cache_auxiliary_instance,
-                             actions_count: 1
+                             action_count: 1
               ).tap { |auxiliary_instance|
                 auxiliary_instance.default_action = FactoryGirl.build(
                     :metasploit_cache_auxiliary_action,
@@ -182,7 +146,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 1
+                action_count: 1
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = nil
             }
@@ -209,7 +173,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 0
+                action_count: 0
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = FactoryGirl.build(
                   :metasploit_cache_auxiliary_action,
@@ -237,7 +201,7 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
           subject(:auxiliary_instance) {
             FactoryGirl.build(
                 :metasploit_cache_auxiliary_instance,
-                actions_count: 0
+                action_count: 0
             ).tap { |auxiliary_instance|
               auxiliary_instance.default_action = nil
             }

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -42,34 +42,9 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
                           :actions,
                           factory: :metasploit_cache_auxiliary_instance
 
-    context "validates that there is at least one license for the module" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/auxiliary/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licenses" do
-        subject(:auxiliary_instance){ FactoryGirl.build(:metasploit_cache_auxiliary_instance, licenses_count:0) }
-
-        it 'adds error on #licenses' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licenses" do
-        subject(:auxiliary_instance){ FactoryGirl.build(:metasploit_cache_auxiliary_instance, licenses_count: 1) }
-
-        it 'does not add error on #licenses' do
-          auxiliary_instance.valid?
-
-          expect(auxiliary_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
-    end
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_auxiliary_instance
 
     context 'actions_contains_default_action' do
       let(:error) {

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -17,4 +17,9 @@ RSpec.describe Metasploit::Cache::Contribution do
       it { is_expected.to have_db_index(:email_address_id).unique(false) }
     end
   end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of :author }
+    it { is_expected.to validate_presence_of :email_address }
+  end
 end

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -2,16 +2,19 @@ RSpec.describe Metasploit::Cache::Contribution do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to belong_to(:email_address).class_name('Metasploit::Cache::EmailAddress').inverse_of(:contributions) }
     it { is_expected.to belong_to(:author).class_name('Metasploit::Cache::Author').inverse_of(:contributions) }
   end
 
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:author_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:email_address_id).of_type(:integer).with_options(null: false) }
     end
 
     context 'indices' do
       it { is_expected.to have_db_index(:author_id).unique(false) }
+      it { is_expected.to have_db_index(:email_address_id).unique(false) }
     end
   end
 end

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Metasploit::Cache::Contribution do
+end

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -1,2 +1,3 @@
 RSpec.describe Metasploit::Cache::Contribution do
+  it_should_behave_like 'Metasploit::Concern.run'
 end

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -1,3 +1,17 @@
 RSpec.describe Metasploit::Cache::Contribution do
   it_should_behave_like 'Metasploit::Concern.run'
+
+  context 'associations' do
+    it { is_expected.to belong_to(:author).class_name('Metasploit::Cache::Author').inverse_of(:contributions) }
+  end
+
+  context 'database' do
+    context 'columns' do
+      it { is_expected.to have_db_column(:author_id).of_type(:integer).with_options(null: false) }
+    end
+
+    context 'indices' do
+      it { is_expected.to have_db_index(:author_id).unique(false) }
+    end
+  end
 end

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -2,24 +2,169 @@ RSpec.describe Metasploit::Cache::Contribution do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
-    it { is_expected.to belong_to(:email_address).class_name('Metasploit::Cache::EmailAddress').inverse_of(:contributions) }
     it { is_expected.to belong_to(:author).class_name('Metasploit::Cache::Author').inverse_of(:contributions) }
+    it { is_expected.to belong_to(:contributable) }
+    it { is_expected.to belong_to(:email_address).class_name('Metasploit::Cache::EmailAddress').inverse_of(:contributions) }
   end
 
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:author_id).of_type(:integer).with_options(null: false) }
-      it { is_expected.to have_db_column(:email_address_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:contributable_id).of_type(:integer).with_options(null: false) }
+      it { is_expected.to have_db_column(:contributable_type).of_type(:string).with_options(null: false) }
+      it { is_expected.to have_db_column(:email_address_id).of_type(:integer).with_options(null: true) }
     end
 
     context 'indices' do
       it { is_expected.to have_db_index(:author_id).unique(false) }
+      it { is_expected.to have_db_index([:contributable_type, :contributable_id]).unique(false) }
+      it { is_expected.to have_db_index([:contributable_type, :contributable_id, :author_id]).unique(true) }
+      it { is_expected.to have_db_index([:contributable_type, :contributable_id, :email_address_id]).unique(true) }
       it { is_expected.to have_db_index(:email_address_id).unique(false) }
+    end
+  end
+  
+  context 'factories' do
+    context 'metasploit_cache_auxiliary_contribution' do
+      subject(:metasploit_cache_auxiliary_contribution) {
+        FactoryGirl.build(:metasploit_cache_auxiliary_contribution)
+      }
+      
+      it { is_expected.to be_valid }
+      
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_auxiliary_contribution.contributable
+        }
+        
+        it { is_expected.to be_a Metasploit::Cache::Auxiliary::Instance }
+      end
+    end
+    
+    context 'metasploit_cache_encoder_contribution' do
+      subject(:metasploit_cache_encoder_contribution) {
+        FactoryGirl.build(:metasploit_cache_encoder_contribution)
+      }
+      
+      it { is_expected.to be_valid }
+      
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_encoder_contribution.contributable
+        }
+        
+        it { is_expected.to be_a Metasploit::Cache::Encoder::Instance }
+      end
+    end   
+    
+    context 'metasploit_cache_exploit_contribution' do
+      subject(:metasploit_cache_exploit_contribution) {
+        FactoryGirl.build(:metasploit_cache_exploit_contribution)
+      }
+      
+      it { is_expected.to be_valid }
+      
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_exploit_contribution.contributable
+        }
+        
+        it { is_expected.to be_a Metasploit::Cache::Exploit::Instance }
+      end
+    end
+    
+    context 'metasploit_cache_nop_contribution' do
+      subject(:metasploit_cache_nop_contribution) {
+        FactoryGirl.build(:metasploit_cache_nop_contribution)
+      }
+      
+      it { is_expected.to be_valid }
+      
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_nop_contribution.contributable
+        }
+        
+        it { is_expected.to be_a Metasploit::Cache::Nop::Instance }
+      end
+    end
+
+    context 'metasploit_cache_payload_single_contribution' do
+      subject(:metasploit_cache_payload_single_contribution) {
+        FactoryGirl.build(:metasploit_cache_payload_single_contribution)
+      }
+
+      it { is_expected.to be_valid }
+
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_payload_single_contribution.contributable
+        }
+
+        it { is_expected.to be_a Metasploit::Cache::Payload::Single::Instance }
+      end
+    end
+
+    context 'metasploit_cache_payload_stage_contribution' do
+      subject(:metasploit_cache_payload_stage_contribution) {
+        FactoryGirl.build(:metasploit_cache_payload_stage_contribution)
+      }
+
+      it { is_expected.to be_valid }
+
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_payload_stage_contribution.contributable
+        }
+
+        it { is_expected.to be_a Metasploit::Cache::Payload::Stage::Instance }
+      end
+    end
+
+    context 'metasploit_cache_payload_stager_contribution' do
+      subject(:metasploit_cache_payload_stager_contribution) {
+        FactoryGirl.build(:metasploit_cache_payload_stager_contribution)
+      }
+
+      it { is_expected.to be_valid }
+
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_payload_stager_contribution.contributable
+        }
+
+        it { is_expected.to be_a Metasploit::Cache::Payload::Stager::Instance }
+      end
+    end
+
+    context 'metasploit_cache_post_contribution' do
+      subject(:metasploit_cache_post_contribution) {
+        FactoryGirl.build(:metasploit_cache_post_contribution)
+      }
+
+      it { is_expected.to be_valid }
+
+      context '#contributable' do
+        subject(:contributable) {
+          metasploit_cache_post_contribution.contributable
+        }
+
+        it { is_expected.to be_a Metasploit::Cache::Post::Instance }
+      end
     end
   end
 
   context 'validations' do
     it { is_expected.to validate_presence_of :author }
-    it { is_expected.to validate_presence_of :email_address }
+    it { is_expected.to validate_presence_of :contributable }
+
+    context 'with existing record' do
+      let!(:existing_contribution) {
+        FactoryGirl.create(:metasploit_cache_auxiliary_contribution, :metasploit_cache_contribution_email_address)
+      }
+
+      it { is_expected.to validate_uniqueness_of(:author).scoped_to(:contributable) }
+      it { is_expected.to validate_uniqueness_of(:email_address).scoped_to(:contributable).allow_blank }
+    end
   end
 end

--- a/spec/app/models/metasploit/cache/email_address_spec.rb
+++ b/spec/app/models/metasploit/cache/email_address_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Metasploit::Cache::EmailAddress do
   }
 
   context 'associations' do
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contributions').dependent(:destroy) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:email_address) }
     it { should have_many(:module_authors).class_name('Metasploit::Cache::Module::Author').dependent(:destroy) }
     it { should have_many(:module_instances).class_name('Metasploit::Cache::Module::Instance').through(:module_authors) }
   end

--- a/spec/app/models/metasploit/cache/email_address_spec.rb
+++ b/spec/app/models/metasploit/cache/email_address_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Metasploit::Cache::EmailAddress do
   }
 
   context 'associations' do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contributions').dependent(:destroy) }
     it { should have_many(:module_authors).class_name('Metasploit::Cache::Module::Author').dependent(:destroy) }
     it { should have_many(:module_instances).class_name('Metasploit::Cache::Module::Instance').through(:module_authors) }
   end

--- a/spec/app/models/metasploit/cache/email_address_spec.rb
+++ b/spec/app/models/metasploit/cache/email_address_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Metasploit::Cache::EmailAddress do
   }
 
   context 'associations' do
+    it { is_expected.to have_many(:authors).class_name('Metasploit::Cache::Author').through(:contributions) }
     it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:email_address) }
+    it { is_expected.to have_many(:module_author_authors).class_name('Metasploit::Cache::Author').through(:module_authors) }
     it { should have_many(:module_authors).class_name('Metasploit::Cache::Module::Author').dependent(:destroy) }
     it { should have_many(:module_instances).class_name('Metasploit::Cache::Module::Instance').through(:module_authors) }
   end

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
     it { is_expected.to validate_presence_of :name }
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_encoder_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_encoder_instance
   end

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
     it { is_expected.to belong_to(:encoder_class).class_name('Metasploit::Cache::Encoder::Class').inverse_of(:encoder_instance) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:encoder_class).class_name('Metasploit::Cache::Encoder::Class').inverse_of(:encoder_instance) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -34,38 +34,8 @@ RSpec.describe Metasploit::Cache::Encoder::Instance do
     it { is_expected.to validate_presence_of :encoder_class }
     it { is_expected.to validate_presence_of :name }
 
-    context "validate that there is at least one license per encoder" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/encoder/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licensable licenses" do
-        subject(:encoder_instance){
-          FactoryGirl.build(:metasploit_cache_encoder_instance, licenses_count: 0)
-        }
-
-        it "adds error on #licensable_licenses" do
-          encoder_instance.valid?
-
-          expect(encoder_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licensable licenses" do
-        subject(:encoder_instance){
-          FactoryGirl.build(:metasploit_cache_encoder_instance, licenses_count: 1)
-        }
-
-        it "does not add error on #licensable_licenses" do
-          encoder_instance.valid?
-
-          expect(encoder_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
-
-    end
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_encoder_instance
   end
 end

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
     it { is_expected.to validate_inclusion_of(:stance).in_array(Metasploit::Cache::Module::Stance::ALL) }
 
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_exploit_instance
+
     context 'validates inclusion of #default_exploit_target in #exploit_targets' do
       subject(:default_exploit_target_errors) {
         exploit_instance.errors[:default_exploit_target]
@@ -148,40 +152,6 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :exploit_class_id }
-    end
-
-    context "validate that there is at least one license per exploit" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/exploit/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licensable licenses" do
-        subject(:exploit_instance){
-          FactoryGirl.build(:metasploit_cache_exploit_instance, licenses_count: 0)
-        }
-
-        it "adds error on #licensable_licenses" do
-          exploit_instance.valid?
-
-          expect(exploit_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licensable licenses" do
-        subject(:exploit_instance){
-          FactoryGirl.build(:metasploit_cache_exploit_instance, licenses_count: 1)
-        }
-
-        it "does not add error on #licensable_licenses" do
-          exploit_instance.valid?
-
-          expect(exploit_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
-
     end
   end
 end

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -1,6 +1,15 @@
 RSpec.describe Metasploit::Cache::Exploit::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to belong_to(:default_exploit_target).class_name('Metasploit::Cache::Exploit::Target').inverse_of(:exploit_instance) }
+    it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance) }
+    it { is_expected.to have_many(:exploit_targets).class_name('Metasploit::Cache::Exploit::Target').dependent(:destroy).inverse_of(:exploit_instance) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:default_exploit_target_id).of_type(:integer).with_options(null: true) }
@@ -16,14 +25,6 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
       it { is_expected.to have_db_index(:default_exploit_target_id).unique(true) }
       it { is_expected.to have_db_index(:exploit_class_id).unique(true) }
     end
-  end
-
-  context 'associations' do
-    it { is_expected.to belong_to(:default_exploit_target).class_name('Metasploit::Cache::Exploit::Target').inverse_of(:exploit_instance) }
-    it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance) }
-    it { is_expected.to have_many(:exploit_targets).class_name('Metasploit::Cache::Exploit::Target').dependent(:destroy).inverse_of(:exploit_instance) }
-    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
-    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'factory' do

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
     it { is_expected.to validate_inclusion_of(:stance).in_array(Metasploit::Cache::Module::Stance::ALL) }
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_exploit_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_exploit_instance
 

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:default_exploit_target).class_name('Metasploit::Cache::Exploit::Target').inverse_of(:exploit_instance) }
     it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance) }
     it { is_expected.to have_many(:exploit_targets).class_name('Metasploit::Cache::Exploit::Target').dependent(:destroy).inverse_of(:exploit_instance) }

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :nop_class }
 
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_nop_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do
@@ -46,39 +50,5 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
 
       it { is_expected.to validate_uniqueness_of :nop_class_id }
     end
-
-    context "validate that there is at least one license per nop" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/nop/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licensable licenses" do
-        subject(:nop_instance){
-          FactoryGirl.build(:metasploit_cache_nop_instance, licenses_count: 0)
-        }
-
-        it "adds error on #licensable_licenses" do
-          nop_instance.valid?
-
-          expect(nop_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licensable licenses" do
-        subject(:nop_instance){
-          FactoryGirl.build(:metasploit_cache_nop_instance, licenses_count: 1)
-        }
-
-        it "does not add error on #licensable_licenses" do
-          nop_instance.valid?
-
-          expect(nop_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
-    end
-    
   end
 end

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
     it { is_expected.to validate_presence_of :nop_class }
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_nop_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_nop_instance
 

--- a/spec/app/models/metasploit/cache/nop/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/nop/instance_spec.rb
@@ -1,6 +1,13 @@
 RSpec.describe Metasploit::Cache::Nop::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context 'associations' do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
@@ -21,12 +28,6 @@ RSpec.describe Metasploit::Cache::Nop::Instance do
 
       it { is_expected.to be_valid }
     end
-  end
-
-  context 'associations' do
-    it { is_expected.to belong_to(:nop_class).class_name('Metasploit::Cache::Nop::Class').inverse_of(:nop_instance) }
-    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
-    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end
 
   context 'validations' do

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_payload_single_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_payload_single_instance
 

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
     it { is_expected.to validate_presence_of :payload_single_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_payload_single_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do
@@ -50,39 +54,6 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :payload_single_class_id }
-    end
-
-    context "validate that there is at least one license per single" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/payload/single/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licensable licenses" do
-        subject(:single_instance){
-          FactoryGirl.build(:metasploit_cache_payload_single_instance, licenses_count: 0)
-        }
-
-        it "adds error on #licensable_licenses" do
-          single_instance.valid?
-
-          expect(single_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licensable licenses" do
-        subject(:single_instance){
-          FactoryGirl.build(:metasploit_cache_payload_single_instance, licenses_count: 1)
-        }
-
-        it "does not add error on #licensable_licenses" do
-          single_instance.valid?
-
-          expect(single_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context "associations" do
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
   end

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
     it { is_expected.to validate_presence_of :payload_stage_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_payload_stage_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do
@@ -46,39 +50,6 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :payload_stage_class_id }
-    end
-
-    context "validate that there is at least one license per stage" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/payload/stage/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licensable licenses" do
-        subject(:stage_instance){
-          FactoryGirl.build(:metasploit_cache_payload_stage_instance, licenses_count: 0)
-        }
-
-        it "adds error on #licensable_licenses" do
-          stage_instance.valid?
-
-          expect(stage_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licensable licenses" do
-        subject(:stage_instance){
-          FactoryGirl.build(:metasploit_cache_payload_stage_instance, licenses_count: 1)
-        }
-
-        it "does not add error on #licensable_licenses" do
-          stage_instance.valid?
-
-          expect(stage_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  context "associations" do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
+  end
+
   context 'database' do
     context 'columns' do
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
@@ -11,11 +17,6 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
 
     context 'indices' do
       it { is_expected.to have_db_index(:payload_stage_class_id).unique(true) }
-    end
-
-    context "associations" do
-      it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
-      it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
     end
   end
 

--- a/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stage/instance_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Metasploit::Cache::Payload::Stage::Instance do
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_payload_stage_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_payload_stage_instance
 

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
-    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_stager_instances) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
     it { is_expected.to validate_presence_of :payload_stager_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_payload_stager_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do
@@ -52,39 +56,6 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :payload_stager_class_id }
-    end
-
-    context "validate that there is at least one license per stager" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/payload/stager/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licensable licenses" do
-        subject(:stager_instance){
-          FactoryGirl.build(:metasploit_cache_payload_stager_instance, licenses_count: 0)
-        }
-
-        it "adds error on #licensable_licenses" do
-          stager_instance.valid?
-
-          expect(stager_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licensable licenses" do
-        subject(:stager_instance){
-          FactoryGirl.build(:metasploit_cache_payload_stager_instance, licenses_count: 1)
-        }
-
-        it "does not add error on #licensable_licenses" do
-          stager_instance.valid?
-
-          expect(stager_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_payload_stager_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_payload_stager_instance
 

--- a/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/stager/instance_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Metasploit::Cache::Payload::Stager::Instance do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
+    it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_stager_instances) }
     it { is_expected.to have_many(:licensable_licenses).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     it { is_expected.to validate_presence_of :post_class }
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
+    it_should_behave_like 'validates at least one in association',
+                          :licensable_licenses,
+                          factory: :metasploit_cache_post_instance
+
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do
@@ -49,39 +53,6 @@ RSpec.describe Metasploit::Cache::Post::Instance do
       }
 
       it { is_expected.to validate_uniqueness_of :post_class_id }
-    end
-
-    context "validate that there is at least one license per post" do
-      let(:error){
-        I18n.translate!(
-            'activerecord.errors.models.metasploit/cache/post/instance.attributes.licensable_licenses.too_short',
-            count: 1
-        )
-      }
-
-      context "without licensable licenses" do
-        subject(:post_instance){
-          FactoryGirl.build(:metasploit_cache_post_instance, licenses_count: 0)
-        }
-
-        it "adds error on #licensable_licenses" do
-          post_instance.valid?
-
-          expect(post_instance.errors[:licensable_licenses]).to include(error)
-        end
-      end
-
-      context "with licensable licenses" do
-        subject(:post_instance){
-          FactoryGirl.build(:metasploit_cache_post_instance, licenses_count: 1)
-        }
-
-        it "does not add error on #licensable_licenses" do
-          post_instance.valid?
-
-          expect(post_instance.errors[:licensable_licenses]).to_not include(error)
-        end
-      end
     end
   end
 end

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Metasploit::Cache::Post::Instance do
     it { is_expected.to validate_inclusion_of(:privileged).in_array([false, true]) }
 
     it_should_behave_like 'validates at least one in association',
+                          :contributions,
+                          factory: :metasploit_cache_post_instance
+
+    it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
                           factory: :metasploit_cache_post_instance
 

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Metasploit::Cache::Post::Instance do
 
   context 'database' do
     context 'columns' do
-      it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
+      it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
       it { is_expected.to have_db_column(:disclosed_on).of_type(:date).with_options(null: false) }
       it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }

--- a/spec/app/models/metasploit/cache/post/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/post/instance_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Metasploit::Cache::Post::Instance do
 
   context 'database' do
     context 'columns' do
+      it { is_expected.to have_many(:contributions).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contribution) }
       it { is_expected.to have_db_column(:description).of_type(:text).with_options(null: false) }
       it { is_expected.to have_db_column(:disclosed_on).of_type(:date).with_options(null: false) }
       it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -62,10 +62,12 @@ ActiveRecord::Schema.define(:version => 20150526204451) do
   add_index "mc_auxiliary_instances", ["auxiliary_class_id"], :name => "index_mc_auxiliary_instances_on_auxiliary_class_id", :unique => true
 
   create_table "mc_contributions", :force => true do |t|
-    t.integer "author_id", :null => false
+    t.integer "author_id",        :null => false
+    t.integer "email_address_id", :null => false
   end
 
   add_index "mc_contributions", ["author_id"], :name => "index_mc_contributions_on_author_id"
+  add_index "mc_contributions", ["email_address_id"], :name => "index_mc_contributions_on_email_address_id"
 
   create_table "mc_direct_classes", :force => true do |t|
     t.integer "ancestor_id", :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -318,16 +318,6 @@ ActiveRecord::Schema.define(:version => 20150526204451) do
   add_index "mc_payload_stager_instances", ["handler_id"], :name => "index_mc_payload_stager_instances_on_handler_id"
   add_index "mc_payload_stager_instances", ["payload_stager_class_id"], :name => "index_mc_payload_stager_instances_on_payload_stager_class_id", :unique => true
 
-  create_table "mc_platformable_platforms", :force => true do |t|
-    t.integer "platformable_id",   :null => false
-    t.string  "platformable_type", :null => false
-    t.integer "platform_id",       :null => false
-  end
-
-  add_index "mc_platformable_platforms", ["platform_id"], :name => "index_mc_platformable_platforms_on_platform_id"
-  add_index "mc_platformable_platforms", ["platformable_type", "platformable_id", "platform_id"], :name => "unique_mc_platformable_platforms", :unique => true
-  add_index "mc_platformable_platforms", ["platformable_type", "platformable_id"], :name => "mc_platformable_platformables"
-
   create_table "mc_platforms", :force => true do |t|
     t.text    "fully_qualified_name", :null => false
     t.text    "relative_name",        :null => false
@@ -348,18 +338,6 @@ ActiveRecord::Schema.define(:version => 20150526204451) do
   end
 
   add_index "mc_post_instances", ["post_class_id"], :name => "index_mc_post_instances_on_post_class_id", :unique => true
-
-  create_table "mc_referencable_references", :force => true do |t|
-    t.integer  "referencable_id",   :null => false
-    t.string   "referencable_type", :null => false
-    t.integer  "reference_id",      :null => false
-    t.datetime "created_at",        :null => false
-    t.datetime "updated_at",        :null => false
-  end
-
-  add_index "mc_referencable_references", ["referencable_type", "referencable_id", "reference_id"], :name => "unique_mc_referencable_references", :unique => true
-  add_index "mc_referencable_references", ["referencable_type", "referencable_id"], :name => "mc_referencable_polymorphic"
-  add_index "mc_referencable_references", ["reference_id"], :name => "index_mc_referencable_references_on_reference_id"
 
   create_table "mc_references", :force => true do |t|
     t.string  "designation"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -62,11 +62,16 @@ ActiveRecord::Schema.define(:version => 20150526204451) do
   add_index "mc_auxiliary_instances", ["auxiliary_class_id"], :name => "index_mc_auxiliary_instances_on_auxiliary_class_id", :unique => true
 
   create_table "mc_contributions", :force => true do |t|
-    t.integer "author_id",        :null => false
-    t.integer "email_address_id", :null => false
+    t.integer "author_id",          :null => false
+    t.integer "contributable_id",   :null => false
+    t.string  "contributable_type", :null => false
+    t.integer "email_address_id"
   end
 
   add_index "mc_contributions", ["author_id"], :name => "index_mc_contributions_on_author_id"
+  add_index "mc_contributions", ["contributable_type", "contributable_id", "author_id"], :name => "unique_mc_contribution_authors", :unique => true
+  add_index "mc_contributions", ["contributable_type", "contributable_id", "email_address_id"], :name => "unique_mc_contribution_email_addresses", :unique => true
+  add_index "mc_contributions", ["contributable_type", "contributable_id"], :name => "mc_contribution_contributables"
   add_index "mc_contributions", ["email_address_id"], :name => "index_mc_contributions_on_email_address_id"
 
   create_table "mc_direct_classes", :force => true do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150518163003) do
+ActiveRecord::Schema.define(:version => 20150526204451) do
 
   create_table "mc_actionable_actions", :force => true do |t|
     t.string  "name",            :null => false
@@ -60,6 +60,12 @@ ActiveRecord::Schema.define(:version => 20150518163003) do
   end
 
   add_index "mc_auxiliary_instances", ["auxiliary_class_id"], :name => "index_mc_auxiliary_instances_on_auxiliary_class_id", :unique => true
+
+  create_table "mc_contributions", :force => true do |t|
+    t.integer "author_id", :null => false
+  end
+
+  add_index "mc_contributions", ["author_id"], :name => "index_mc_contributions_on_author_id"
 
   create_table "mc_direct_classes", :force => true do |t|
     t.integer "ancestor_id", :null => false
@@ -305,6 +311,16 @@ ActiveRecord::Schema.define(:version => 20150518163003) do
   add_index "mc_payload_stager_instances", ["handler_id"], :name => "index_mc_payload_stager_instances_on_handler_id"
   add_index "mc_payload_stager_instances", ["payload_stager_class_id"], :name => "index_mc_payload_stager_instances_on_payload_stager_class_id", :unique => true
 
+  create_table "mc_platformable_platforms", :force => true do |t|
+    t.integer "platformable_id",   :null => false
+    t.string  "platformable_type", :null => false
+    t.integer "platform_id",       :null => false
+  end
+
+  add_index "mc_platformable_platforms", ["platform_id"], :name => "index_mc_platformable_platforms_on_platform_id"
+  add_index "mc_platformable_platforms", ["platformable_type", "platformable_id", "platform_id"], :name => "unique_mc_platformable_platforms", :unique => true
+  add_index "mc_platformable_platforms", ["platformable_type", "platformable_id"], :name => "mc_platformable_platformables"
+
   create_table "mc_platforms", :force => true do |t|
     t.text    "fully_qualified_name", :null => false
     t.text    "relative_name",        :null => false
@@ -325,6 +341,18 @@ ActiveRecord::Schema.define(:version => 20150518163003) do
   end
 
   add_index "mc_post_instances", ["post_class_id"], :name => "index_mc_post_instances_on_post_class_id", :unique => true
+
+  create_table "mc_referencable_references", :force => true do |t|
+    t.integer  "referencable_id",   :null => false
+    t.string   "referencable_type", :null => false
+    t.integer  "reference_id",      :null => false
+    t.datetime "created_at",        :null => false
+    t.datetime "updated_at",        :null => false
+  end
+
+  add_index "mc_referencable_references", ["referencable_type", "referencable_id", "reference_id"], :name => "unique_mc_referencable_references", :unique => true
+  add_index "mc_referencable_references", ["referencable_type", "referencable_id"], :name => "mc_referencable_polymorphic"
+  add_index "mc_referencable_references", ["reference_id"], :name => "index_mc_referencable_references_on_reference_id"
 
   create_table "mc_references", :force => true do |t|
     t.string  "designation"

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
           class: Metasploit::Cache::Auxiliary::Instance do
     transient do
       action_count 1
+      contribution_count 1
       licensable_license_count 1
     end
 
@@ -33,6 +34,11 @@ FactoryGirl.define do
           :metasploit_cache_auxiliary_action,
           evaluator.action_count,
           actionable: auxiliary_instance
+      )
+      auxiliary_instance.contributions = build_list(
+          :metasploit_cache_auxiliary_contribution,
+          evaluator.contribution_count,
+          contributable: auxiliary_instance
       )
       auxiliary_instance.licensable_licenses = build_list(
           :metasploit_cache_auxiliary_license,

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
           class: Metasploit::Cache::Auxiliary::Instance do
     transient do
       action_count 1
-      licenses_count 1
+      licensable_license_count 1
     end
 
     description { generate :metasploit_cache_auxiliary_instance_description }
@@ -36,7 +36,7 @@ FactoryGirl.define do
       )
       auxiliary_instance.licensable_licenses = build_list(
           :metasploit_cache_auxiliary_license,
-          evaluator.licenses_count,
+          evaluator.licensable_license_count,
           licensable: auxiliary_instance
       )
     }

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   factory :metasploit_cache_auxiliary_instance,
           class: Metasploit::Cache::Auxiliary::Instance do
     transient do
-      actions_count 1
+      action_count 1
       licenses_count 1
     end
 
@@ -31,7 +31,7 @@ FactoryGirl.define do
     after(:build) { |auxiliary_instance, evaluator|
       auxiliary_instance.actions = build_list(
           :metasploit_cache_auxiliary_action,
-          evaluator.actions_count,
+          evaluator.action_count,
           actionable: auxiliary_instance
       )
       auxiliary_instance.licensable_licenses = build_list(

--- a/spec/factories/metasploit/cache/contributions.rb
+++ b/spec/factories/metasploit/cache/contributions.rb
@@ -1,0 +1,81 @@
+FactoryGirl.define do
+  #
+  # Factories
+  #
+
+  factory :metasploit_cache_auxiliary_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_auxiliary_instance
+  end
+
+  factory :metasploit_cache_encoder_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_encoder_instance
+  end
+
+  factory :metasploit_cache_exploit_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_exploit_instance
+  end
+
+  factory :metasploit_cache_nop_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_nop_instance
+  end
+
+  factory :metasploit_cache_payload_single_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_payload_single_instance
+  end
+
+  factory :metasploit_cache_payload_stage_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_payload_stage_instance
+  end
+
+  factory :metasploit_cache_payload_stager_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_payload_stager_instance
+  end
+
+  factory :metasploit_cache_post_contribution,
+          class: Metasploit::Cache::Contribution,
+          traits: [
+              :metasploit_cache_contribution
+          ] do
+    association :contributable, factory: :metasploit_cache_post_instance
+  end
+
+  #
+  # Traits
+  #
+
+  trait :metasploit_cache_contribution do
+    association :author, factory: :metasploit_cache_author
+  end
+
+  trait :metasploit_cache_contribution_email_address do
+    association :email_address, factory: :metasploit_cache_email_address
+  end
+end

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     name { generate :metasploit_cache_encoder_instance_name }
 
     transient do
+      contribution_count 1
       licensable_license_count 1
     end
 
@@ -23,6 +24,11 @@ FactoryGirl.define do
     #
 
     after(:build) do |encoder_instance, evaluator|
+      encoder_instance.contributions = build_list(
+        :metasploit_cache_encoder_contribution,
+        evaluator.contribution_count,
+        contributable: encoder_instance
+      )
       encoder_instance.licensable_licenses = build_list(
         :metasploit_cache_encoder_license,
         evaluator.licensable_license_count,

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
     name { generate :metasploit_cache_encoder_instance_name }
 
     transient do
-      licenses_count 1
+      licensable_license_count 1
     end
 
     #
@@ -25,7 +25,7 @@ FactoryGirl.define do
     after(:build) do |encoder_instance, evaluator|
       encoder_instance.licensable_licenses = build_list(
         :metasploit_cache_encoder_license,
-        evaluator.licenses_count,
+        evaluator.licensable_license_count,
         licensable: encoder_instance
       )
     end

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_exploit_instance,
           class: Metasploit::Cache::Exploit::Instance do
     transient do
+      contribution_count 1
       exploit_target_count 1
       licensable_license_count 1
     end
@@ -23,6 +24,12 @@ FactoryGirl.define do
     #
 
     after(:build) { |exploit_instance, evaluator|
+      exploit_instance.contributions = build_list(
+          :metasploit_cache_exploit_contribution,
+          evaluator.contribution_count,
+          contributable: exploit_instance
+      )
+
       exploit_instance.exploit_targets = build_list(
           :metasploit_cache_exploit_target,
           evaluator.exploit_target_count,

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
           class: Metasploit::Cache::Exploit::Instance do
     transient do
       exploit_target_count 1
-      licenses_count 1
+      licensable_license_count 1
     end
 
     description { generate :metasploit_cache_exploit_instance_description }
@@ -31,7 +31,7 @@ FactoryGirl.define do
 
       exploit_instance.licensable_licenses = build_list(
         :metasploit_cache_exploit_license,
-        evaluator.licenses_count,
+        evaluator.licensable_license_count,
         licensable: exploit_instance
       )
     }

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -45,10 +45,10 @@ FactoryGirl.define do
     association :licensable, factory: :metasploit_cache_payload_stager_instance
   end
 
-  factory :metasploit_cache_payload_post_license,
+  factory :metasploit_cache_post_license,
           class: Metasploit::Cache::Licensable::License,
           traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_payload_post_instance
+    association :licensable, factory: :metasploit_cache_post_instance
   end
 
   #

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_nop_instance,
           class: Metasploit::Cache::Nop::Instance do
     transient do
+      contribution_count 1
       licensable_license_count 1
     end
 
@@ -19,13 +20,19 @@ FactoryGirl.define do
     # Callbacks
     #
 
-    after(:build) { |nop_instance, evaluator|
-      nop_instance.licensable_licenses = build_list(
-        :metasploit_cache_nop_license,
-        evaluator.licensable_license_count,
-        licensable: nop_instance
+    after(:build) do |nop_instance, evaluator|
+      nop_instance.contributions = build_list(
+          :metasploit_cache_nop_contribution,
+          evaluator.contribution_count,
+          contributable: nop_instance
       )
-    }
+
+      nop_instance.licensable_licenses = build_list(
+          :metasploit_cache_nop_license,
+          evaluator.licensable_license_count,
+          licensable: nop_instance
+      )
+    end
 
   end
 

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_nop_instance,
           class: Metasploit::Cache::Nop::Instance do
     transient do
-      licenses_count 1
+      licensable_license_count 1
     end
 
 
@@ -22,7 +22,7 @@ FactoryGirl.define do
     after(:build) { |nop_instance, evaluator|
       nop_instance.licensable_licenses = build_list(
         :metasploit_cache_nop_license,
-        evaluator.licenses_count,
+        evaluator.licensable_license_count,
         licensable: nop_instance
       )
     }

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
           class: Metasploit::Cache::Payload::Single::Instance do
     transient do
+      contribution_count 1
       licensable_license_count 1
     end
 
@@ -20,11 +21,17 @@ FactoryGirl.define do
     # Callbacks
     #
 
-    after(:build) do |single_instance, evaluator|
-      single_instance.licensable_licenses = build_list(
+    after(:build) do |payload_single_instance, evaluator|
+      payload_single_instance.contributions = build_list(
+        :metasploit_cache_payload_single_contribution,
+        evaluator.contribution_count,
+        contributable: payload_single_instance
+      )
+
+      payload_single_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_single_license,
         evaluator.licensable_license_count,
-        licensable: single_instance
+        licensable: payload_single_instance
       )
     end
 

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
           class: Metasploit::Cache::Payload::Single::Instance do
     transient do
-      licenses_count 1
+      licensable_license_count 1
     end
 
     description { generate :metasploit_cache_payload_single_instance_description }
@@ -23,7 +23,7 @@ FactoryGirl.define do
     after(:build) do |single_instance, evaluator|
       single_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_single_license,
-        evaluator.licenses_count,
+        evaluator.licensable_license_count,
         licensable: single_instance
       )
     end

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_stage_instance,
           class: Metasploit::Cache::Payload::Stage::Instance do
     transient do
+      contribution_count 1
       licensable_license_count 1
     end
 
@@ -19,11 +20,17 @@ FactoryGirl.define do
     # Callbacks
     #
 
-    after(:build) do |stage_instance, evaluator|
-      stage_instance.licensable_licenses = build_list(
+    after(:build) do |payload_stage_instance, evaluator|
+      payload_stage_instance.contributions = build_list(
+          :metasploit_cache_payload_stage_contribution,
+          evaluator.contribution_count,
+          contributable: payload_stage_instance
+      )
+
+      payload_stage_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stage_license,
         evaluator.licensable_license_count,
-        licensable: stage_instance
+        licensable: payload_stage_instance
       )
     end
   end

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_stage_instance,
           class: Metasploit::Cache::Payload::Stage::Instance do
     transient do
-      licenses_count 1
+      licensable_license_count 1
     end
 
     description { generate :metasploit_cache_payload_stage_instance_description }
@@ -22,7 +22,7 @@ FactoryGirl.define do
     after(:build) do |stage_instance, evaluator|
       stage_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stage_license,
-        evaluator.licenses_count,
+        evaluator.licensable_license_count,
         licensable: stage_instance
       )
     end

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_stager_instance,
           class: Metasploit::Cache::Payload::Stager::Instance do
     transient do
-      licenses_count 1
+      licensable_license_count 1
     end
 
     description { generate :metasploit_cache_payload_stager_instance_description }
@@ -24,7 +24,7 @@ FactoryGirl.define do
     after(:build) do |stager_instance, evaluator|
       stager_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stager_license,
-        evaluator.licenses_count,
+        evaluator.licensable_license_count,
         licensable: stager_instance
       )
     end

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_stager_instance,
           class: Metasploit::Cache::Payload::Stager::Instance do
     transient do
+      contribution_count 1
       licensable_license_count 1
     end
 
@@ -21,11 +22,17 @@ FactoryGirl.define do
     # Callbacks
     #
 
-    after(:build) do |stager_instance, evaluator|
-      stager_instance.licensable_licenses = build_list(
+    after(:build) do |payload_stager_instance, evaluator|
+      payload_stager_instance.contributions = build_list(
+          :metasploit_cache_payload_stager_contribution,
+          evaluator.contribution_count,
+          contributable: payload_stager_instance
+      )
+
+      payload_stager_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stager_license,
         evaluator.licensable_license_count,
-        licensable: stager_instance
+        licensable: payload_stager_instance
       )
     end
 

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_post_instance,
           class: Metasploit::Cache::Post::Instance do
     transient do
+      contribution_count 1
       licensable_license_count 1
     end
 
@@ -21,8 +22,14 @@ FactoryGirl.define do
     #
 
     after(:build) do |post_instance, evaluator|
+      post_instance.contributions = build_list(
+        :metasploit_cache_post_contribution,
+        evaluator.contribution_count,
+        contributable: post_instance
+      )
+
       post_instance.licensable_licenses = build_list(
-        :metasploit_cache_payload_post_license,
+        :metasploit_cache_post_license,
         evaluator.licensable_license_count,
         licensable: post_instance
       )

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :metasploit_cache_post_instance,
           class: Metasploit::Cache::Post::Instance do
     transient do
-      licenses_count 1
+      licensable_license_count 1
     end
 
     description { generate :metasploit_cache_post_instance_description }
@@ -23,7 +23,7 @@ FactoryGirl.define do
     after(:build) do |post_instance, evaluator|
       post_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_post_license,
-        evaluator.licenses_count,
+        evaluator.licensable_license_count,
         licensable: post_instance
       )
     end

--- a/spec/support/shared/examples/validates_at_least_one_in_association.rb
+++ b/spec/support/shared/examples/validates_at_least_one_in_association.rb
@@ -1,0 +1,41 @@
+# validate_length_of from shoulda-matchers assumes attribute is String and doesn't work on associations
+RSpec.shared_examples_for 'validates at least one in association' do |association, factory:|
+  association_count_key = "#{association.to_s.singularize}_count".to_sym
+
+  let(:error) {
+    I18n.translate!(
+        "#{described_class.i18n_scope}.errors.models.#{described_class.model_name.i18n_key}.attributes.#{association}.too_short",
+        count: 1
+    )
+  }
+
+  context "without #{association}" do
+    subject(:instance) {
+      FactoryGirl.build(
+          factory,
+          association_count_key => 0
+      )
+    }
+
+    it "adds error on ###{association}" do
+      instance.valid?
+
+      expect(instance.errors[association]).to include(error)
+    end
+  end
+
+  context "with #{association}" do
+    subject(:instance) {
+      FactoryGirl.build(
+          factory,
+          association_count_key => 1
+      )
+    }
+
+    it "does not adds error on ###{association}" do
+      instance.valid?
+
+      expect(instance.errors[association]).not_to include(error)
+    end
+  end
+end


### PR DESCRIPTION
MSP-12436

`Metasploit::Cache::Contribution` models the author's name (`#author`'s `Metasploit::Cache:Author#name`) and email address (`#email_address`) used to make a contribution to a polymorphic `#contributable`.  Currently these `#contributable`s are all the Metasploit Module instance classes.

# Verification Steps

## Postgresql
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without sqlite3`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.73% coverage

### Documentation Coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [ ] VERIFY no undocumented objects

## Sqlite3
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without postgresql`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 99.69% coverage

### Documentation coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [ ] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [ ] Edit `lib/metasploit/cache/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`