### PR TITLE
Load Metasploit::Cache::Encoder::Instance from metasploit-framework

### DIFF
--- a/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
@@ -55,7 +55,7 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
     OpenStruct.new(
       platforms: [
 <%- platformable_platforms.each do |platformable_platform| -%>
-        OpenStruct.new(full_name: '<%= platformable_platform.platform.fully_qualified_name %>')
+        OpenStruct.new(realname: '<%= platformable_platform.platform.fully_qualified_name %>')
 <%- end -%>
       ]
     )

--- a/app/models/metasploit/cache/platform.rb
+++ b/app/models/metasploit/cache/platform.rb
@@ -142,9 +142,11 @@ class Metasploit::Cache::Platform < ActiveRecord::Base
   # Class Methods
   #
 
-  # List of valid {#fully_qualified_name} derived from {Metasploit::Cache::Platform::Seed::RELATIVE_NAME_TREE}.
+  # @note Use {root_fully_qualified_name_set} to get just the the covering set of {#fully_qualified_name}.
   #
-  # @return [Array<String>]
+  # Set of valid {#fully_qualified_name} derived from {Metasploit::Cache::Platform::Seed::RELATIVE_NAME_TREE}.
+  #
+  # @return [Set<String>]
   def self.fully_qualified_name_set
     unless instance_variable_defined? :@fully_qualified_name_set
       @fully_qualified_name_set = Set.new
@@ -169,6 +171,21 @@ class Metasploit::Cache::Platform < ActiveRecord::Base
     end
 
     @fully_qualified_name_set
+  end
+
+  # @note Use {fully_qualified_name_set} to get the expanded set of {#fully_qualified_name}.
+  #
+  # Set of valid {#fully_qualified_name} derived from roots of {Metasploit::Cache::Platform::Seed::RELATIVE_NAME_TREE}.
+  #
+  # @return [Set<String>]
+  def self.root_fully_qualified_name_set
+    unless instance_variable_defined? :@root_fully_qualified_name_set
+      @root_fully_qualified_name_set = self::Seed::RELATIVE_NAME_TREE.each_key.each_with_object(Set.new) do |root_fully_qualified_name, set|
+        set.add root_fully_qualified_name
+      end
+    end
+
+    @root_fully_qualified_name_set
   end
 
   #

--- a/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
+++ b/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
@@ -2,6 +2,17 @@
 # instances
 module Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures
   #
+  # CONSTANTS
+  #
+
+  CANONICAL_ABBREVIATIONS_BY_SOURCE_ABBREVIATION = {
+      'mips' => [
+          'mipsbe',
+          'mipsle'
+      ]
+  }
+
+  #
   # Module Methods
   #
 
@@ -85,8 +96,15 @@ module Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectur
   # @param source [#arch] Metasploit Module instance
   # @return [Set<String>] Set of architecture abbreviations
   def self.source_attribute_set(source)
-    # It's always Enumerable, but not pluralized
-    Set.new source.arch
+    source.arch.each_with_object(Set.new) { |abbreviation, set|
+      canonical_abbreviations = CANONICAL_ABBREVIATIONS_BY_SOURCE_ABBREVIATION[abbreviation]
+
+      if canonical_abbreviations
+        set.merge(canonical_abbreviations)
+      else
+        set.add abbreviation
+      end
+    }
   end
 
   # Synchronizes `#arch` from Metasploit Module instance `source` to persisted `#architecturable_architectures` on

--- a/lib/metasploit/cache/platform/seed.rb
+++ b/lib/metasploit/cache/platform/seed.rb
@@ -76,7 +76,7 @@ module Metasploit::Cache::Platform::Seed
           },
           '7' => nil
       },
-      'UNIX' => nil
+      'Unix' => nil
   }
 
   #

--- a/lib/metasploit/cache/platformable/ephemeral/platformable_platforms.rb
+++ b/lib/metasploit/cache/platformable/ephemeral/platformable_platforms.rb
@@ -2,8 +2,23 @@
 # Metasploit Module instances.
 module Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
   #
+  # CONSTANTS
+  #
+
+  # `#realname` use for source platforms to indicate all platforms are supported.
+  SOURCE_ANY_PLATFORM_REALNAME = ''
+
+  #
   # Module Methods
   #
+
+  # Whether the `source_platforms` represents the source support any platform.
+  #
+  # @return [true] any platform is supported.
+  # @return [false] only specific platforms are supported.
+  def self.any_source_platform?(source_platforms)
+    source_platforms.length == 1 && source_platforms[0].realname == SOURCE_ANY_PLATFORM_REALNAME
+  end
 
   # Builds new {Metasploit::Cache::Platformable::Platform} as `#platformable_platforms` on `destination`
   #
@@ -79,15 +94,26 @@ module Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
     destination
   end
 
+  # @note If `source` `#platform` `#platforms` contains a single entry that is just `''`, then it is assumed to mean all
+  #   platforms and the {Metasploit::Cache::Platform.root_fully_qualified_name_set} will be returned.
+  #
   # The set of platform fully qualified names from `#platforms` on `#platform` on the `source` Metasploit Module
   # instance.
   #
   # @param source [#platform] Metasploit Module instance
   # @return [Set<String>] Set of platform fully-qualified names
   def self.source_attribute_set(source)
-    source.platform.platforms.each_with_object(Set.new) { |platform, set|
-      set.add platform.realname
-    }
+    source_platforms = source.platform.platforms
+
+    if any_source_platform?(source_platforms)
+      platform_fully_qualified_name_set = Metasploit::Cache::Platform.root_fully_qualified_name_set
+    else
+      platform_fully_qualified_name_set = source_platforms.each_with_object(Set.new) { |platform, set|
+        set.add platform.realname
+      }
+    end
+
+    platform_fully_qualified_name_set
   end
 
   # Synchronizes `#platforms` from `#platform` from Metasploit Module instance `source` to persisted

--- a/lib/metasploit/cache/platformable/ephemeral/platformable_platforms.rb
+++ b/lib/metasploit/cache/platformable/ephemeral/platformable_platforms.rb
@@ -10,7 +10,7 @@ module Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
   # @param destination [#platformable_platforms]
   # @param destination_attribute_set [Set<String>] Set of {Metasploit::Cache::Platform#platform} on
   #   `#platformable_platforms` on `destination`.
-  # @param source_attribute_set [Set<String>] Set of `#name` of `#platforms` of `#platform` of `source`.
+  # @param source_attribute_set [Set<String>] Set of `#realname` of `#platforms` of `#platform` of `source`.
   # @return [#platformable_platforms] `destination`
   def self.build_added(destination:, destination_attribute_set:, source_attribute_set:)
     cached_added_attribute_set = Metasploit::Cache::Ephemeral::AttributeSet.added(
@@ -39,7 +39,7 @@ module Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
   # currently persisted as `#platformable_platforms` on `destination`.
   #
   # @param destination [#platformable_platforms]
-  # @return [Set<String>] Set of {Metasplit::Cache::Platform#fully_qualified_name}
+  # @return [Set<String>] Set of {Metasploit::Cache::Platform#fully_qualified_name}
   def self.destination_attribute_set(destination)
     if destination.new_record?
       Set.new
@@ -86,7 +86,7 @@ module Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
   # @return [Set<String>] Set of platform fully-qualified names
   def self.source_attribute_set(source)
     source.platform.platforms.each_with_object(Set.new) { |platform, set|
-      set.add platform.full_name
+      set.add platform.realname
     }
   end
 

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -13,7 +13,7 @@ module Metasploit
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 2
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version.
-      PRERELEASE = 'encoder-instance-ephemeral-and-load'
+      PRERELEASE = 'load-encoder-instance-from-metasploit-framework'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/encoder/instance/ephemeral_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance/ephemeral_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Metasploit::Cache::Encoder::Instance::Ephemeral do
 
         allow(instance).to receive(:license).and_return(license_abbreviation)
 
-        platform = double('Platform', full_name: 'Windows XP')
+        platform = double('Platform', realname: 'Windows XP')
         platform_list = double('Platform List', platforms: [platform])
 
         allow(instance).to receive(:platform).and_return(platform_list)

--- a/spec/app/models/metasploit/cache/module/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/module/instance_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Metasploit::Cache::Module::Instance do
 
     context 'with unrelated platform' do
       let(:other_platform_fully_qualified_name) do
-        'UNIX'
+        'Unix'
       end
 
       it 'does not include Metasploit::Cache::Module::Instance' do

--- a/spec/app/models/metasploit/cache/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platform_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Metasploit::Cache::Platform do
 
     it { should include 'Windows 7' }
 
-    it { should include 'UNIX' }
+    it { should include 'Unix' }
   end
 
   context '#derived_fully_qualified_name' do

--- a/spec/lib/metasploit/cache/encoder/instance/load_spec.rb
+++ b/spec/lib/metasploit/cache/encoder/instance/load_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Metasploit::Cache::Encoder::Instance::Load, type: :model do
           }
 
           platforms = encoder_instance.platformable_platforms.map { |platformable_platform|
-            double('Platform', full_name: platformable_platform.platform.fully_qualified_name)
+            double('Platform', realname: platformable_platform.platform.fully_qualified_name)
           }
           platform_list = double('Platform List', platforms: platforms)
 

--- a/spec/lib/metasploit/cache/encoder/instance/load_spec.rb
+++ b/spec/lib/metasploit/cache/encoder/instance/load_spec.rb
@@ -514,4 +514,62 @@ RSpec.describe Metasploit::Cache::Encoder::Instance::Load, type: :model do
       end
     end
   end
+  
+  # :nocov:
+  # Can't just use the tag on the context because the below code will still run even if tag is filtered out
+  unless Bundler.settings.without.include? 'content'
+    context 'metasploit-framework', :content do
+      module_path_real_paths = Metasploit::Framework::Engine.paths['modules'].existent_directories
+
+      module_path_real_paths.each do |module_path_real_path|
+        module_path_real_pathname = Pathname.new(module_path_real_path)
+        module_path_relative_pathname = module_path_real_pathname.relative_path_from(Metasploit::Framework::Engine.root)
+
+        # use relative pathname so that context name is not dependent on build directory
+        context module_path_relative_pathname.to_s do
+          #
+          # Shared examples
+          #
+
+          #
+          # lets
+          #
+
+          let(:module_path) do
+            FactoryGirl.create(
+                :metasploit_cache_module_path,
+                gem: 'metasploit-framework',
+                name: 'modules',
+                real_path: module_path_real_path
+            )
+          end
+
+          it_should_behave_like 'Metasploit::Cache::*::Instance::Load from relative_path_prefix',
+                                module_path_real_pathname,
+                                'encoders' do
+            let(:direct_class) {
+              module_ancestor.build_encoder_class
+            }
+
+            let(:module_ancestors) {
+              module_path.encoder_ancestors
+            }
+
+            let(:module_instance) {
+              direct_class.build_encoder_instance
+            }
+
+            let(:module_instance_load) {
+              described_class.new(
+                  encoder_instance: module_instance,
+                  encoder_metasploit_module_class: direct_class_load.metasploit_class,
+                  logger: logger
+              )
+            }
+          end
+        end
+      end
+    end
+  end
+  # :nocov:
 end

--- a/spec/lib/metasploit/cache/platform/seed_spec.rb
+++ b/spec/lib/metasploit/cache/platform/seed_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Metasploit::Cache::Platform::Seed do
         it { should include('7') }
       end
 
-      it { should include('UNIX') }
+      it { should include('Unix') }
     end
   end
 end

--- a/spec/lib/metasploit/cache/platformable/ephemeral/platformable_platforms_spec.rb
+++ b/spec/lib/metasploit/cache/platformable/ephemeral/platformable_platforms_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
     context 'with present platform.platforms' do
       let(:platforms) {
         [
-            double('Platform', full_name: platform_fully_qualified_name)
+            double('Platform', realname: platform_fully_qualified_name)
         ]
       }
 
@@ -246,7 +246,7 @@ RSpec.describe Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
         FactoryGirl.generate :metasploit_cache_platform_fully_qualified_name
       }
 
-      it 'includes platform.platforms #full_name' do
+      it 'includes platform.platforms #realname' do
         expect(source_attribute_set).to include(platform_fully_qualified_name)
       end
     end

--- a/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
+++ b/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
@@ -43,6 +43,9 @@ shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_pre
           expect(direct_class_load).to be_valid
           expect(direct_class).to be_persisted
 
+          module_instance_load.valid?
+
+          expect(module_instance).to be_valid
           expect(module_instance_load).to be_valid
           expect(module_instance).to be_persisted
         end


### PR DESCRIPTION
MSP-12442

# Changelog
* Enhancements
  * Errors messages from `'Metasploit::Cache::*::Instance::Load from relative_path_prefix` will show `Metasploit::Cache::*::Instance` validation messages before `Metasploit::Cache::*::Instance::Load` validation messages because `Metasploit::Cache::*::Instance` validation messages are more detailed.
* Bug Fixes
  * Use `#realname` instead of `#fullname` on source platforms as metasploit-framework does not populate `#fullname`.
  * Map `'mips'` platform fully-qualified name from metasploit-framework to `'mipsbe'` and `'mipsle'`.
  * Correct capitalization of `'UNIX'` to `'Unix'` to match metasploit-framework.
  * Treat single, platform with empty name (`''`) as any/all platforms.

# Pre-verification steps
- [x] Merge #56 

# Verification Steps

## Postgresql
- [x] `rm Gemfile.lock`
- [x] `bundle install --without sqlite3`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 100% coverage

### Documentation Coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
- [x] VERIFY no undocumented objects

## Sqlite3
- [x] `rm Gemfile.lock`
- [x] `bundle install --without postgresql`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 100% coverage

### Documentation coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [x] Edit `lib/metasploit/cache/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`