### PR TITLE
Metasploit::Cache::Exploit::Instance::Ephemeral and Metasploit::Cache::Exploit::Instance::Load

### DIFF
--- a/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor/show.erb
@@ -1,0 +1,127 @@
+# Module Type: <%= exploit_class.ancestor.module_type %>
+# Reference Name: <%= exploit_class.ancestor.reference_name %>
+class <%= metasploit_class_relative_name %> < <%= superclass %>
+  #
+  # CONSTANTS
+  #
+
+  Rank = <%= exploit_class.rank.number %>
+
+  #
+  # Instance Methods
+  #
+
+  # Default architecture abbreviations for {#targets} that don't declare their own architecture abbreviations.
+  #
+  # @return [Array<String>]
+  def arch
+    []
+  end
+
+  def author
+    [
+<%- last_contribution_index = contributions.length - 1 -%>
+<%- contributions.each_with_index do |contribution, index| -%>
+  <%- email_address = contribution.email_address
+
+      if email_address
+        email = "'#{email_address.full}'"
+      else
+        email = "nil"
+      end
+
+      if index == last_contribution_index
+        separator = ''
+      else
+        separator = ','
+      end
+  -%>
+      OpenStruct.new(name: '<%= contribution.author.name %>', email: <%= email %>)<%= separator %>
+<%- end -%>
+    ]
+  end
+
+  def default_target
+<%- if default_exploit_target -%>
+    <%= default_exploit_target.index %>
+<%- else -%>
+    nil
+<%- end -%>
+  end
+
+  def description
+    '<%= description %>'
+  end
+
+  def license
+    [
+<%- last_licensable_license_index = licensable_licenses.length - 1 -%>
+<%- licensable_licenses.each_with_index do |licensable_license, index| -%>
+  <%- if index == last_licensable_license_index
+        separator = ''
+      else
+        separator = ','
+      end -%>
+      '<%= licensable_license.license.abbreviation %>'<%= separator %>
+<%- end -%>
+    ]
+  end
+
+  def name
+    '<%= name %>'
+  end
+
+  # Default platform list for {#targets} that don't declare their own platform list.
+  #
+  # @return [#platforms]
+  def platform
+    OpenStruct.new(
+      platforms: []
+    )
+  end
+
+  # Targets of this exploit.
+  #
+  # @return [Array<#arch, #name, #platform>]
+  def targets
+    [
+<%- last_exploit_target_index = exploit_targets.length - 1 -%>
+<%- exploit_targets.each_with_index do |exploit_target, exploit_target_index| -%>
+  <%- if last_exploit_target_index == last_exploit_target_index
+        exploit_target_separator = ''
+      else
+        exploit_target_separator = ','
+      end -%>
+      OpenStruct.new(
+        arch: [
+  <%- last_architecturable_architecture_index = exploit_target.architecturable_architectures.length - 1 -%>
+  <%- exploit_target.architecturable_architectures.each_with_index do |architecturable_architecture, architecturable_architecture_index| -%>
+    <%- if architecturable_architecture_index == last_architecturable_architecture_index
+          architecturable_architecture_separator = ''
+        else
+          architecturable_architecture_separator = ','
+        end -%>
+          '<%= architecturable_architecture.architecture.abbreviation %>'<%= architecturable_architecture_separator %>
+  <%- end -%>
+        ],
+        name: '<%= exploit_target.name %>',
+        platform: OpenStruct.new(
+                    platforms: [
+  <%- last_platformable_platform_index = exploit_target.platformable_platforms.length - 1 -%>
+  <%- exploit_target.platformable_platforms.each_with_index do |platformable_platform, platformable_platform_index| -%>
+    <%- if platformable_platform_index == last_platformable_platform_index
+          platformable_platform_separator = ''
+        else
+          platformable_platform_separator = ','
+        end -%>
+                      OpenStruct.new(
+                        realname: '<%= platformable_platform.platform.fully_qualified_name %>'
+                      )<%= platformable_platform_separator %>
+  <%- end -%>
+                    ]
+                  )
+      )<%= exploit_target_separator %>
+<%- end -%>
+    ]
+  end
+end

--- a/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor_cell.rb
+++ b/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor_cell.rb
@@ -1,0 +1,34 @@
+require 'cell/twin'
+
+# Cell for rendering {Metasploit::Cache::Exploit::Instance#exploit_class}
+# {Metasploit::Cache::Direct::Class#ancestor} {Metasploit::Cache::Module::Ancestor#contents}.
+#
+# In addition to content from {Metasploit::Cache::Module::AncestorCell} and
+# {Metasploit::Cache::Direct::Class::AncestorCell}, it also includes `#authors` for
+# {Metasploit::Cache::Exploit::Instance#contributions}, `#default_target` for
+# {Metasploit::Cache::Exploit::Instance#default_exploit_target} {Metasploit::Cache::Exploit:Target#index},
+# `#description` for {Metasploit::Cache::Exploit::Instance#description}, `#license` for
+# {Metasploit::Cache::Exploit::Instance#licensable_licenses} {Metasploit::Cache::Licensable::Licenses#license}s,
+# `#name` for {Metasploit::Cache::Exploit::Instance#name}, and `#targets` for
+# {Metasploit::Cache::Exploit::Instance#exploit_targets}.
+class Metasploit::Cache::Exploit::Instance::ExploitClass::AncestorCell < Cell::ViewModel
+  extend ActiveSupport::Autoload
+
+  include Cell::Twin::Properties
+
+  autoload :Twin
+
+  #
+  # Properties
+  #
+
+  properties Twin
+
+  #
+  # Instance Methods
+  #
+
+  def show
+    render
+  end
+end

--- a/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor_cell/twin.rb
+++ b/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor_cell/twin.rb
@@ -1,0 +1,23 @@
+require 'cell/twin'
+
+# Fields used in {Metasploit::Cache::Exploit::Instance::ExploitClass::AncestorCell} template.
+class Metasploit::Cache::Exploit::Instance::ExploitClass::AncestorCell::Twin < Cell::Twin
+  #
+  # Options
+  #
+
+  option :metasploit_class_relative_name
+  option :superclass
+
+  #
+  # Properties
+  #
+
+  property :exploit_class
+  property :exploit_targets
+  property :contributions
+  property :default_exploit_target
+  property :description
+  property :licensable_licenses
+  property :name
+end

--- a/app/models/metasploit/cache/exploit/class.rb
+++ b/app/models/metasploit/cache/exploit/class.rb
@@ -13,6 +13,7 @@ class Metasploit::Cache::Exploit::Class < Metasploit::Cache::Direct::Class
   has_one :exploit_instance,
           class_name: 'Metasploit::Cache::Exploit::Instance',
           dependent: :destroy,
+          foreign_key: :exploit_class_id,
           inverse_of: :exploit_class
 
   # Reliability of Metasploit Module.

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -1,5 +1,6 @@
 # Instance-level metadata for an exploit Metasploit Module
 class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
+  include Metasploit::Cache::Batch::Root
   #
   #
   # Associations

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -5,6 +5,7 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
   include Metasploit::Cache::Batch::Root
 
   autoload :Ephemeral
+  autoload :ExploitClass
 
   #
   #

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -1,6 +1,11 @@
 # Instance-level metadata for an exploit Metasploit Module
 class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
+  extend ActiveSupport::Autoload
+
   include Metasploit::Cache::Batch::Root
+
+  autoload :Ephemeral
+
   #
   #
   # Associations

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -28,6 +28,7 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
   # The class level metadata for this exploit Metasploit Module
   belongs_to :exploit_class,
              class_name: 'Metasploit::Cache::Exploit::Class',
+             foreign_key: :exploit_class_id,
              inverse_of: :exploit_instance
 
   # The targets that specialize this exploit for a given set of architectures and platforms.

--- a/app/models/metasploit/cache/exploit/instance.rb
+++ b/app/models/metasploit/cache/exploit/instance.rb
@@ -6,6 +6,7 @@ class Metasploit::Cache::Exploit::Instance < ActiveRecord::Base
 
   autoload :Ephemeral
   autoload :ExploitClass
+  autoload :Load
 
   #
   #

--- a/app/models/metasploit/cache/exploit/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/exploit/instance/ephemeral.rb
@@ -1,0 +1,118 @@
+# Ephemeral cache for connecting an in-memory exploit Metasploit Module's ruby instance to its persisted
+# {Metasploit::Cache::Exploit::Instance}.
+class Metasploit::Cache::Exploit::Instance::Ephemeral < Metasploit::Model::Base
+  extend ActiveSupport::Autoload
+  extend Metasploit::Cache::ResurrectingAttribute
+
+  autoload :ExploitTargets
+
+  #
+  # Attributes
+  #
+
+  # The in-memory exploit Metasploit Module instance being cached.
+  #
+  # @return [Object]
+  attr_accessor :exploit_metasploit_module_instance
+
+  # Tagged logger to which to log {#persist} errors.
+  #
+  # @return [ActiveSupport::TaggerLogger]
+  attr_accessor :logger
+
+  #
+  # Resurrecting Attributes
+  #
+
+  # Cached metadata for this {#exploit_metasploit_module_instance}.
+  #
+  # @return [Metasploit::Cache::Exploit::Instance]
+  resurrecting_attr_accessor(:exploit_instance) {
+    ActiveRecord::Base.connection_pool.with_connection {
+      Metasploit::Cache::Exploit::Instance.joins(
+          exploit_class: :ancestor
+      ).where(
+           Metasploit::Cache::Module::Ancestor.arel_table[:real_path_sha1_hex_digest].eq(real_path_sha1_hex_digest)
+      ).readonly(false).first
+    }
+  }
+
+  #
+  # Validations
+  #
+
+  validates :exploit_metasploit_module_instance,
+            presence: true
+  validates :logger,
+            presence: true
+
+  #
+  # Instance Methods
+  #
+
+  # @note This ephemeral cache should be validated with `#valid?` prior to calling {#persist} to ensure that {#logger}
+  #   is present in case of error.
+  # @note Validation errors for `exploit_instance` will be logged as errors tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
+  #
+  # @param to [Metasploit::Cache::Exploit::Instance] Sve cacheable data to {Metasploit::Cache::Exploit::Instance}.
+  #   Giving `to` saves a database lookup if {#exploit_instance} is not loaded.
+  # @return [Metasploit::Cache:Exploit::Instance] `#persisted?` will be `false` if saving fails.
+  def persist(to: exploit_instance)
+    [:description, :name].each do |attribute|
+      to.send("#{attribute}=", exploit_metasploit_module_instance.send(attribute))
+    end
+
+    synchronizers = [
+        Metasploit::Cache::Contributable::Ephemeral::Contributions,
+        self.class::ExploitTargets,
+        Metasploit::Cache::Licensable::Ephemeral::LicensableLicenses
+    ]
+
+    synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
+      synchronizer.synchronize(
+          destination: block_destination,
+          source: exploit_metasploit_module_instance
+      )
+    }
+
+    saved = ActiveRecord::Base.connection_pool.with_connection {
+      synchronized.batched_save
+    }
+
+    unless saved
+      log_error(synchronized) {
+        "Could not be persisted to #{synchronized.class}: #{synchronized.errors.full_messages.to_sentence}"
+      }
+    end
+
+    synchronized
+  end
+
+  private
+
+  # Logs errors to {#logger} with `exploit_instance`'s {Metasploit::Cache::Exploit::Instance#exploit_class}'s
+  # {Metasploit::Cache::Direct::Class#ancestor}'s {Metasploit::Cache::Module::Ancestor#real_pathname}.
+  #
+  # @yield Block called when logger severity is error or worse.
+  # @yieldreturn [String] Message to print to log as error if logger severity level allows for print of ERROR messages.
+  # @return [void]
+  def log_error(exploit_instance, &block)
+    if logger.error?
+      real_path = ActiveRecord::Base.connection_pool.with_connection {
+        exploit_instance.exploit_class.ancestor.real_pathname.to_s
+      }
+
+      logger.tagged(real_path) do |tagged|
+        tagged.error(&block)
+      end
+    end
+  end
+
+  # {Metasploit::Cache::Module::Ancestor#real_path_sha1_hex_digest} used to resurrect {#auxiliary_instance}.
+  #
+  # @return [String]
+  def real_path_sha1_hex_digest
+    exploit_metasploit_module_instance.class.ephemeral_cache_by_source[:ancestor].real_path_sha1_hex_digest
+  end
+end

--- a/lib/metasploit/cache/ephemeral/attribute_set.rb
+++ b/lib/metasploit/cache/ephemeral/attribute_set.rb
@@ -41,4 +41,13 @@ module Metasploit::Cache::Ephemeral::AttributeSet
   def self.removed(destination:, source:)
     destination - source
   end
+
+  # The set of attributes for records to either maintained or updated on destination.
+  #
+  # @param destination [Set] set of attributes from destination persisted cache
+  # @param source [Set] set of attributes from in-memory Metasploit Module instance
+  # @return [Set]
+  def self.retained(destination:, source:)
+    destination & source
+  end
 end

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -196,8 +196,8 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # {Metasploit::Cache::Exploit::Target#platformable_platforms}.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  # @param destination_attributes_set [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
-  # @param source_attributes_set [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
+  # @param destination_attributes_by_name [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
+  # @param source_attributes_by_name [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
   # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets] `destination`
   def self.update_changed(destination:, destination_attributes_by_name:, source_attributes_by_name:)
     unless destination.new_record?

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -77,7 +77,7 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
     end
   end
   
-  # Destroys {#targets} on `destination` that are persisted to `destination`, but don't exist in `source`.
+  # Marks for destruction {#targets} on `destination` that are persisted to `destination`, but don't exist in `source`.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
   # @param destination_attributes_by_name [Hash{String => Object}]
@@ -85,7 +85,7 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # @param source_attributes_by_name [Hash{String => Object}]
   #   Hash with `target.name` of exploit Metasploit Module instance target keys.
   # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  def self.destroy_removed(destination:, destination_attributes_by_name:, source_attributes_by_name:)
+  def self.mark_removed_for_destruction(destination:, destination_attributes_by_name:, source_attributes_by_name:)
     unless destination.new_record?
       destination_name_set = name_set(destination_attributes_by_name)
       source_name_set = name_set(source_attributes_by_name)
@@ -95,10 +95,11 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
       )
 
       unless removed_name_set.empty?
-        destination.exploit_targets.where(
-            # AREL cannot visit Set
-            name: removed_name_set.to_a
-        ).destroy_all
+        destination.exploit_targets.each do |exploit_target|
+          if removed_name_set.include? exploit_target.name
+            exploit_target.mark_for_destruction
+          end
+        end
       end
     end
 
@@ -174,7 +175,7 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
       cached_destination_attributes_by_name = destination_attributes_by_name(destination)
       cached_source_attributes_by_name = source_attributes_by_name(source)
 
-      reduced = [:destroy_removed, :update_changed, :build_added].reduce(destination) { |block_destination, method|
+      reduced = [:mark_removed_for_destruction, :update_changed, :build_added].reduce(destination) { |block_destination, method|
         public_send(
             method,
             destination: block_destination,

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -138,16 +138,16 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
     source_platform_fully_qualified_name_set = nil
 
     source.targets.each_with_index.each_with_object({}) do |(target, index), attributes_by_name|
-      # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L136
-      if target.platform.nil?
+      # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L141-L144
+      if target.arch.nil?
         source_architecture_abbreviation_set ||= Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(source)
         architecture_abbreviation_set = source_architecture_abbreviation_set
       else
         architecture_abbreviation_set = Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(target)
       end
 
-      # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L141-L144
-      if target.arch.nil?
+      # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L136
+      if target.platform.nil?
         source_platform_fully_qualified_name_set ||= Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.source_attribute_set(source)
         platform_fully_qualified_name_set = source_platform_fully_qualified_name_set
       else
@@ -174,23 +174,16 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
       cached_destination_attributes_by_name = destination_attributes_by_name(destination)
       cached_source_attributes_by_name = source_attributes_by_name(source)
 
-      reduced = destroy_removed(
-          destination: destination,
-          destination_attributes_by_name: cached_destination_attributes_by_name,
-          source_attributes_by_name: cached_source_attributes_by_name
-      )
-      updated = update_changed(
-          destination: reduced,
-          destination_attributes_by_name: cached_destination_attributes_by_name,
-          source_attributes_by_name: cached_source_attributes_by_name
-      )
-      expanded = build_added(
-          destination: updated,
-          destination_attributes_by_name: cached_destination_attributes_by_name,
-          source_attributes_by_name: cached_source_attributes_by_name
-      )
+      reduced = [:destroy_removed, :update_changed, :build_added].reduce(destination) { |block_destination, method|
+        public_send(
+            method,
+            destination: block_destination,
+            destination_attributes_by_name: cached_destination_attributes_by_name,
+            source_attributes_by_name: cached_source_attributes_by_name
+        )
+      }
       update_default_exploit_target(
-          destination: expanded,
+          destination: reduced,
           source: source
       )
     }
@@ -215,17 +208,23 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
       )
 
       unless retained_name_set.empty?
-        destination = retained_name_set.reduce(destination) { |block_destination, retained_name|
+        exploit_target_by_name = destination.exploit_targets.each_with_object({}) { |exploit_target, hash|
+          hash[exploit_target.name] = exploit_target
+        }
+
+        retained_name_set.each { |retained_name|
           destination_attributes = destination_attributes_by_name.fetch(retained_name)
           source_attributes = source_attributes_by_name.fetch(retained_name)
 
-          destination.index = destination_attributes.fetch(:index)
+          exploit_target = exploit_target_by_name.fetch(retained_name)
+
+          exploit_target.index = source_attributes.fetch(:index)
 
           destination_architecture_abbreviation_set = destination_attributes.fetch(:architecture_abbreviation_set)
           source_architecture_abbreviation_set = source_attributes.fetch(:architecture_abbreviation_set)
 
-          architecturable_architectures_reduced = Metasploit::Cache::Architectureable::Ephemeral::ArchitecturableArchitectures.reduce(
-              destination: block_destination,
+          Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.reduce(
+              destination: exploit_target,
               destination_attribute_set: destination_architecture_abbreviation_set,
               source_attribute_set: source_architecture_abbreviation_set
           )
@@ -234,7 +233,7 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
           source_platform_fully_qualified_name_set = source_attributes.fetch(:platform_fully_qualified_name_set)
 
           Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.reduce(
-              destination: architecturable_architectures_reduced,
+              destination: exploit_target,
               destination_attribute_set: destination_platform_fully_qualified_name_set,
               source_attribute_set: source_platform_fully_qualified_name_set
           )
@@ -251,12 +250,12 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # @param source [#default_target] exploit Metasploit Module instance
   # @return [Metasploit::Cache::Exploit::Instance, #default_exploit_target] `destination`
   def self.update_default_exploit_target(destination:, source:)
+    # reset to `nil` because `source_default_exploit_target_index` may be invalid and point to a non-existent index
+    destination.default_exploit_target = nil
+
     cached_source_default_exploit_target_index = source_default_exploit_target_index(source)
 
     if cached_source_default_exploit_target_index
-      # reset to `nil` because `source_default_exploit_target_index` may be invalid and point to a non-existent index
-      destination.default_exploit_target = nil
-
       destination.exploit_targets.each do |exploit_target|
         if exploit_target.index == cached_source_default_exploit_target_index
           destination.default_exploit_target = exploit_target

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -8,28 +8,26 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # Builds new {Metasploit::Cache::Exploit::Instance#exploit_targets} on `destination`.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  # @param destination_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
-  #   Set of {Metasploit::Cache::Exploit::Instance#exploit_targets} attributes of `destination`.
-  # @param source_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
-  #   Set of exploit Metasploit Module instance target attributes.
+  # @param destination_attributes_by_name [Hash{String => Object}] Hash with {Metasploit::Cache::Exploit::Target#name}
+  #   of `destination` keys.
+  # @param source_attributes_by_name [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
+  #   Maps `target.name` to exploit Metasploit Module instance target attributes.
   # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  def self.build_added(destination:, destination_attributes_set:, source_attributes_set:)
-    destination_name_set = name_set(destination_attributes_set)
-    source_name_set = name_set(source_attributes_set)
+  def self.build_added(destination:, destination_attributes_by_name:, source_attributes_by_name:)
+    destination_name_set = name_set(destination_attributes_by_name)
+    source_name_set = name_set(source_attributes_by_name)
     added_name_set = Metasploit::Cache::Ephemeral::AttributeSet.added(
         destination: destination_name_set,
         source: source_name_set
     )
 
     unless added_name_set.empty?
-      source_attributes_by_name = by_name(source_attributes_set)
-
       added_name_set.each do |name|
         attributes = source_attributes_by_name.fetch(name)
 
         target = destination.exploit_targets.build(
             index: attributes.fetch(:index),
-            name: attributes.fetch(:name)
+            name: name
         )
         Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.build_added(
             destination: target,
@@ -47,27 +45,18 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
     destination
   end
 
-  # Maps `:name` values in each attributes Hash in `attribute_set` to that attributes Hash.
-  #
-  # @param attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
-  # @return [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}}]
-  def self.by_name(attributes_set)
-    attributes_set.each_with_object({}) do |attributes, attributes_by_name|
-      attributes_by_name[attributes.fetch(:name)] = attributes
-    end
-  end
-
-  # The set of {Metasploit::Cache::Exploit::Target} attributes currently persisted.
+  # Maps {Metasploit::Cache::Exploit::Target#name} to {Metasploit::Cache::Exploit::Target} attributes currently
+  # persisted for {Metasploit::Cache::Exploit::Target}.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets] Persistent cache of exploit Metasploit
   #   Module instance.
-  # @return [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
-  #   Set of target hashes.
-  def self.destination_attributes_set(destination)
+  # @return [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
+  #   Maps {Metasploit::Cache::Exploit::Target#name} to other attributes.
+  def self.destination_attributes_by_name(destination)
     if destination.new_record?
-      Set.new
+      {}
     else
-      destination.exploit_targets.each_with_object(Set.new) do |exploit_target, set|
+      destination.exploit_targets.each_with_object({}) do |exploit_target, attributes_by_name|
         architecture_abbreviation_set = Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.destination_attribute_set(
             exploit_target
         )
@@ -75,14 +64,15 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
             exploit_target
         )
 
-        target_attributes = {
+        name = exploit_target.name
+
+        attributes = {
             architecture_abbreviation_set: architecture_abbreviation_set,
             index: exploit_target.index,
-            name: exploit_target.name,
             platform_fully_qualified_name_set: platform_fully_qualified_name_set
         }
 
-        set.add target_attributes
+        attributes_by_name[name] = attributes
       end
     end
   end
@@ -90,15 +80,15 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # Destroys {#targets} on `destination` that are persisted to `destination`, but don't exist in `source`.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  # @param destination_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
-  #   Set of {Metasploit::Cache::Exploit::Instance#exploit_targets} attributes of `destination`.
-  # @param source_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
-  #   Set of exploit Metasploit Module instance target attributes.
+  # @param destination_attributes_by_name [Hash{String => Object}]
+  #   Hash with {Metasploit::Cache::Exploit::Target#name} of `destination` keys.
+  # @param source_attributes_by_name [Hash{String => Object}]
+  #   Hash with `target.name` of exploit Metasploit Module instance target keys.
   # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  def self.destroy_removed(destination:, destination_attributes_set:, source_attributes_set:)
+  def self.destroy_removed(destination:, destination_attributes_by_name:, source_attributes_by_name:)
     unless destination.new_record?
-      destination_name_set = name_set(destination_attributes_set)
-      source_name_set = name_set(source_attributes_set)
+      destination_name_set = name_set(destination_attributes_by_name)
+      source_name_set = name_set(source_attributes_by_name)
       removed_name_set = Metasploit::Cache::Ephemeral::AttributeSet.removed(
           destination: destination_name_set,
           source: source_name_set
@@ -115,13 +105,13 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
     destination
   end
 
-  # Set of names from attribute Hashes Set.
+  # Set of names from `attributes_by_name` Hash
   #
-  # @param attributes_set [Set<Hash<{name: String}>>]
+  # @param attributes_by_name [Hash<{String: Object}>]
   # @return [Set<String>]
-  def self.name_set(attributes_set)
-    attributes_set.each_with_object(Set.new) do |attributes, set|
-      set.add attributes.fetch(:name)
+  def self.name_set(attributes_by_name)
+    attributes_by_name.each_key.each_with_object(Set.new) do |name, set|
+      set.add name
     end
   end
 
@@ -135,17 +125,19 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
     source.default_target
   end
 
-  # The set of attributes from the `#targets` from the `source` exploit Metasploit Module instance.  Targets inherit
-  # their `:architecture_abbreviation_set` from the `source` `#arch` if the target has no architecture.  Targets inherit
-  # their :platform_fully_qualified_name_set` from the `source` `#platform` if the target has no platforms.
+  # Maps target name to other attributes from the `#targets` from the `source` exploit Metasploit Module instance.
+  # Targets inherit their `:architecture_abbreviation_set` from the `source` `#arch` if the target has no architecture.
+  # Targets inherit their :platform_fully_qualified_name_set` from the `source` `#platform` if the target has no
+  # platforms.
   #
   # @param source [#targets] exploit Metasploit Module instance
-  # @return [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>] Set of target Hashes.
-  def self.source_attributes_set(source)
+  # @return [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
+  #   Maps target name to other attributes.
+  def self.source_attributes_by_name(source)
     source_architecture_abbreviation_set = nil
     source_platform_fully_qualified_name_set = nil
 
-    source.targets.each_with_index.each_with_object(Set.new) do |(target, index), set|
+    source.targets.each_with_index.each_with_object({}) do |(target, index), attributes_by_name|
       # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L136
       if target.platform.nil?
         source_architecture_abbreviation_set ||= Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(source)
@@ -162,14 +154,11 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
         platform_fully_qualified_name_set = Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.source_attribute_set(target)
       end
 
-      target_attributes = {
+      attributes_by_name[target.name] = {
           architecture_abbreviation_set: architecture_abbreviation_set,
           index: index,
-          name: target.name,
           platform_fully_qualified_name_set: platform_fully_qualified_name_set
       }
-
-      set.add target_attributes
     end
   end
 
@@ -182,23 +171,23 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # @return [Metasploit::Cache::Exploit::Instance, #default_exploit_target, #exploit_targets] `destination`
   def self.synchronize(destination:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
-      cached_destination_attributes_set = destination_attributes_set(destination)
-      cached_source_attributes_set = source_attributes_set(source)
+      cached_destination_attributes_by_name = destination_attributes_by_name(destination)
+      cached_source_attributes_by_name = source_attributes_by_name(source)
 
       reduced = destroy_removed(
           destination: destination,
-          destination_attributes_set: cached_destination_attributes_set,
-          source_attributes_set: cached_source_attributes_set
+          destination_attributes_by_name: cached_destination_attributes_by_name,
+          source_attributes_by_name: cached_source_attributes_by_name
       )
       updated = update_changed(
           destination: reduced,
-          destination_attributes_set: cached_destination_attributes_set,
-          source_attributes_set: cached_source_attributes_set
+          destination_attributes_by_name: cached_destination_attributes_by_name,
+          source_attributes_by_name: cached_source_attributes_by_name
       )
       expanded = build_added(
           destination: updated,
-          destination_attributes_set: cached_destination_attributes_set,
-          source_attributes_set: cached_source_attributes_set
+          destination_attributes_by_name: cached_destination_attributes_by_name,
+          source_attributes_by_name: cached_source_attributes_by_name
       )
       update_default_exploit_target(
           destination: expanded,
@@ -213,22 +202,19 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # {Metasploit::Cache::Exploit::Target#platformable_platforms}.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  # @param destination_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
-  # @param source_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  # @param destination_attributes_set [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
+  # @param source_attributes_set [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
   # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets] `destination`
-  def self.update_changed(destination:, destination_attributes_set:, source_attributes_set:)
+  def self.update_changed(destination:, destination_attributes_by_name:, source_attributes_by_name:)
     unless destination.new_record?
-      destination_name_set = name_set(destination_attributes_set)
-      source_name_set = name_set(source_attributes_set)
+      destination_name_set = name_set(destination_attributes_by_name)
+      source_name_set = name_set(source_attributes_by_name)
       retained_name_set = Metasploit::Cache::Ephemeral::AttributeSet.retained(
           destination: destination_name_set,
           source: source_name_set
       )
 
       unless retained_name_set.empty?
-        destination_attributes_by_name = by_name(destination_attributes_set)
-        source_attributes_by_name = by_name(source_attributes_set)
-
         destination = retained_name_set.reduce(destination) { |block_destination, retained_name|
           destination_attributes = destination_attributes_by_name.fetch(retained_name)
           source_attributes = source_attributes_by_name.fetch(retained_name)

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -1,0 +1,285 @@
+# Synchronizes the persisten chace of {Metasploit::Cache::Exploit::Instance#exploit_targets} with the in-memory
+# `#targets` on an exploit Metasploit Module instance.
+module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
+  #
+  # Module Methods
+  #
+
+  # Builds new {Metasploit::Cache::Exploit::Instance#exploit_targets} on `destination`.
+  #
+  # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
+  # @param destination_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  #   Set of {Metasploit::Cache::Exploit::Instance#exploit_targets} attributes of `destination`.
+  # @param source_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  #   Set of exploit Metasploit Module instance target attributes.
+  # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets]
+  def self.build_added(destination:, destination_attributes_set:, source_attributes_set:)
+    destination_name_set = name_set(destination_attributes_set)
+    source_name_set = name_set(source_attributes_set)
+    added_name_set = Metasploit::Cache::Ephemeral::AttributeSet.added(
+        destination: destination_name_set,
+        source: source_name_set
+    )
+
+    unless added_name_set.empty?
+      source_attributes_by_name = by_name(source_attributes_set)
+
+      added_name_set.each do |name|
+        attributes = source_attributes_by_name.fetch(name)
+
+        target = destination.exploit_targets.build(
+            index: attributes.fetch(:index),
+            name: attributes.fetch(:name)
+        )
+        Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.build_added(
+            destination: target,
+            destination_attribute_set: Set.new,
+            source_attribute_set: attributes.fetch(:architecture_abbreviation_set)
+        )
+        Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.build_added(
+            destination: target,
+            destination_attribute_set: Set.new,
+            source_attribute_set: attributes.fetch(:platform_fully_qualified_name_set)
+        )
+      end
+    end
+
+    destination
+  end
+
+  # Maps `:name` values in each attributes Hash in `attribute_set` to that attributes Hash.
+  #
+  # @param attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  # @return [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}}]
+  def self.by_name(attributes_set)
+    attributes_set.each_with_object({}) do |attributes, attributes_by_name|
+      attributes_by_name[attributes.fetch(:name)] = attributes
+    end
+  end
+
+  # The set of {Metasploit::Cache::Exploit::Target} attributes currently persisted.
+  #
+  # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets] Persistent cache of exploit Metasploit
+  #   Module instance.
+  # @return [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  #   Set of target hashes.
+  def self.destination_attributes_set(destination)
+    if destination.new_record?
+      Set.new
+    else
+      destination.exploit_targets.each_with_object(Set.new) do |exploit_target, set|
+        architecture_abbreviation_set = Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.destination_attribute_set(
+            exploit_target
+        )
+        platform_fully_qualified_name_set = Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.destination_attribute_set(
+            exploit_target
+        )
+
+        target_attributes = {
+            architecture_abbreviation_set: architecture_abbreviation_set,
+            index: exploit_target.index,
+            name: exploit_target.name,
+            platform_fully_qualified_name_set: platform_fully_qualified_name_set
+        }
+
+        set.add target_attributes
+      end
+    end
+  end
+  
+  # Destroys {#targets} on `destination` that are persisted to `destination`, but don't exist in `source`.
+  #
+  # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
+  # @param destination_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  #   Set of {Metasploit::Cache::Exploit::Instance#exploit_targets} attributes of `destination`.
+  # @param source_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  #   Set of exploit Metasploit Module instance target attributes.
+  # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets]
+  def self.destroy_removed(destination:, destination_attributes_set:, source_attributes_set:)
+    unless destination.new_record?
+      destination_name_set = name_set(destination_attributes_set)
+      source_name_set = name_set(source_attributes_set)
+      removed_name_set = Metasploit::Cache::Ephemeral::AttributeSet.removed(
+          destination: destination_name_set,
+          source: source_name_set
+      )
+
+      unless removed_name_set.empty?
+        destination.exploit_targets.where(
+            # AREL cannot visit Set
+            name: removed_name_set.to_a
+        ).destroy_all
+      end
+    end
+
+    destination
+  end
+
+  # Set of names from attribute Hashes Set.
+  #
+  # @param attributes_set [Set<Hash<{name: String}>>]
+  # @return [Set<String>]
+  def self.name_set(attributes_set)
+    attributes_set.each_with_object(Set.new) do |attributes, set|
+      set.add attributes.fetch(:name)
+    end
+  end
+
+  # The index of the default target on the `source` exploit Metasploit Module instance.
+  #
+  # @param source [#default_target]
+  # @return [nil] if no default target index
+  # @return [Integer] if default target index
+  def self.source_default_exploit_target_index(source)
+    # The API in metasploit-framework just calls it `default_target` even though it is just an `Integer` index
+    source.default_target
+  end
+
+  # The set of attributes from the `#targets` from the `source` exploit Metasploit Module instance.  Targets inherit
+  # their `:architecture_abbreviation_set` from the `source` `#arch` if the target has no architecture.  Targets inherit
+  # their :platform_fully_qualified_name_set` from the `source` `#platform` if the target has no platforms.
+  #
+  # @param source [#targets] exploit Metasploit Module instance
+  # @return [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>] Set of target Hashes.
+  def self.source_attributes_set(source)
+    source_architecture_abbreviation_set = nil
+    source_platform_fully_qualified_name_set = nil
+
+    source.targets.each_with_index.each_with_object(Set.new) do |(target, index), set|
+      # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L136
+      if target.platform.nil?
+        source_architecture_abbreviation_set ||= Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(source)
+        architecture_abbreviation_set = source_architecture_abbreviation_set
+      else
+        architecture_abbreviation_set = Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(target)
+      end
+
+      # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L141-L144
+      if target.arch.nil?
+        source_platform_fully_qualified_name_set ||= Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.source_attribute_set(source)
+        platform_fully_qualified_name_set = source_platform_fully_qualified_name_set
+      else
+        platform_fully_qualified_name_set = Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.source_attribute_set(target)
+      end
+
+      target_attributes = {
+          architecture_abbreviation_set: architecture_abbreviation_set,
+          index: index,
+          name: target.name,
+          platform_fully_qualified_name_set: platform_fully_qualified_name_set
+      }
+
+      set.add target_attributes
+    end
+  end
+
+  # Synchronizes `#targets` and `#default_target` from Metasploit Module instance `source` to persisted
+  # {Metasploit::Cache::Exploit::Instance#exploit_targets} and
+  # {Metasploit::Cache::Exploit::Instance#default_exploit_target} on `destination`.
+  #
+  # @param destination [Metasploit::Cache::Exploit::Instance, #default_exploit_target, #exploit_targets]
+  # @param source [#default_target, #targets] an exploit Metasploit Module instance
+  # @return [Metasploit::Cache::Exploit::Instance, #default_exploit_target, #exploit_targets] `destination`
+  def self.synchronize(destination:, source:)
+    Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
+      cached_destination_attributes_set = destination_attributes_set(destination)
+      cached_source_attributes_set = source_attributes_set(source)
+
+      reduced = destroy_removed(
+          destination: destination,
+          destination_attributes_set: cached_destination_attributes_set,
+          source_attributes_set: cached_source_attributes_set
+      )
+      updated = update_changed(
+          destination: reduced,
+          destination_attributes_set: cached_destination_attributes_set,
+          source_attributes_set: cached_source_attributes_set
+      )
+      expanded = build_added(
+          destination: updated,
+          destination_attributes_set: cached_destination_attributes_set,
+          source_attributes_set: cached_source_attributes_set
+      )
+      update_default_exploit_target(
+          destination: expanded,
+          source: source
+      )
+    }
+  end
+
+  # Updates {Metasploit::Cache::Exploit::Instance#exploit_targets} on `destination` that have the same
+  # {Metasploit::Cache::Exploit::Target#name} as `#targets` on source, but different
+  # {Metasploit::Cache::Exploit::Target#architecturable_architectures}, {Metasploit::Cache::Exploit::Target#index}, or
+  # {Metasploit::Cache::Exploit::Target#platformable_platforms}.
+  #
+  # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
+  # @param destination_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  # @param source_attributes_set [Set<Hash{architecture_abbreviation_set: Set<String>, index: Integer, name: String, platform_fully_qualified_name_set: Set<String>}>]
+  # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets] `destination`
+  def self.update_changed(destination:, destination_attributes_set:, source_attributes_set:)
+    unless destination.new_record?
+      destination_name_set = name_set(destination_attributes_set)
+      source_name_set = name_set(source_attributes_set)
+      retained_name_set = Metasploit::Cache::Ephemeral::AttributeSet.retained(
+          destination: destination_name_set,
+          source: source_name_set
+      )
+
+      unless retained_name_set.empty?
+        destination_attributes_by_name = by_name(destination_attributes_set)
+        source_attributes_by_name = by_name(source_attributes_set)
+
+        destination = retained_name_set.reduce(destination) { |block_destination, retained_name|
+          destination_attributes = destination_attributes_by_name.fetch(retained_name)
+          source_attributes = source_attributes_by_name.fetch(retained_name)
+
+          destination.index = destination_attributes.fetch(:index)
+
+          destination_architecture_abbreviation_set = destination_attributes.fetch(:architecture_abbreviation_set)
+          source_architecture_abbreviation_set = source_attributes.fetch(:architecture_abbreviation_set)
+
+          architecturable_architectures_reduced = Metasploit::Cache::Architectureable::Ephemeral::ArchitecturableArchitectures.reduce(
+              destination: block_destination,
+              destination_attribute_set: destination_architecture_abbreviation_set,
+              source_attribute_set: source_architecture_abbreviation_set
+          )
+
+          destination_platform_fully_qualified_name_set = destination_attributes.fetch(:platform_fully_qualified_name_set)
+          source_platform_fully_qualified_name_set = source_attributes.fetch(:platform_fully_qualified_name_set)
+
+          Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.reduce(
+              destination: architecturable_architectures_reduced,
+              destination_attribute_set: destination_platform_fully_qualified_name_set,
+              source_attribute_set: source_platform_fully_qualified_name_set
+          )
+        }
+      end
+    end
+
+    destination
+  end
+
+  # Updates the {Metasploit::Cache::Exploit::Instance#default_exploit_target} on `destination`.
+  #
+  # @param destination [Metasploit::Cache::Exploit::Instance, #default_exploit_target]
+  # @param source [#default_target] exploit Metasploit Module instance
+  # @return [Metasploit::Cache::Exploit::Instance, #default_exploit_target] `destination`
+  def self.update_default_exploit_target(destination:, source:)
+    cached_source_default_exploit_target_index = source_default_exploit_target_index(source)
+
+    if cached_source_default_exploit_target_index
+      # reset to `nil` because `source_default_exploit_target_index` may be invalid and point to a non-existent index
+      destination.default_exploit_target = nil
+
+      destination.exploit_targets.each do |exploit_target|
+        if exploit_target.index == cached_source_default_exploit_target_index
+          destination.default_exploit_target = exploit_target
+
+          break
+        end
+      end
+    end
+
+    destination
+  end
+end

--- a/lib/metasploit/cache/exploit/instance/exploit_class.rb
+++ b/lib/metasploit/cache/exploit/instance/exploit_class.rb
@@ -1,0 +1,6 @@
+# Namespace for cells for {Metasploit::Cache::Exploit::Instance#exploit_class} and its associations.
+module Metasploit::Cache::Exploit::Instance::ExploitClass
+  extend ActiveSupport::Autoload
+
+  autoload :AncestorCell
+end

--- a/lib/metasploit/cache/exploit/instance/load.rb
+++ b/lib/metasploit/cache/exploit/instance/load.rb
@@ -1,0 +1,139 @@
+# Loads a {Metasploit::Cache::Exploit::Instance}.
+class Metasploit::Cache::Exploit::Instance::Load < Metasploit::Model::Base
+  #
+  # Attributes
+  #
+
+  # The exploit instance being loaded.
+  #
+  # @return [Metasploit::Cache::Exploit::Instance]
+  attr_accessor :exploit_instance
+
+  # Tagged logger to which to log loading errors.
+  #
+  # @return [ActiveSupport::TaggedLogging]
+  attr_accessor :logger
+
+  # `Metasploit<n>` ruby `Class` declared in {Metasploit::Cache::Module::Ancestor#contents}.
+  #
+  # @return [Class, #ephemeral_cache_by_source] Must have `ephemeral_cache_by_source[:class]`
+  attr_accessor :exploit_metasploit_module_class
+  
+  # Exception raised when `new` is called on {#exploit_metasploit_module_class}.
+  #
+  # @return [nil] if {#exploit_metasploit_module_instance} has not run yet.
+  # @return [nil] if no exception was raised.
+  # @return [Exception] if exception was raised.
+  attr_reader :exploit_metasploit_module_class_new_exception
+
+  #
+  #
+  # Validations
+  #
+  #
+
+  #
+  # Method Validations
+  #
+
+  validate :exploit_metasploit_module_class_new_valid,
+           unless: :loading_context?
+
+  #
+  # Attribute Validations
+  #
+
+  validates :exploit_instance,
+            presence: true
+  validates :exploit_metasploit_module_instance,
+            presence: {
+                unless: :loading_context?
+            }
+  validates :exploit_metasploit_module_class,
+            presence: true
+  validates :logger,
+            presence: true
+
+  #
+  # Instance Methods
+  #
+
+  # Instance of {#exploit_metasploit_module_class} loaded into the cache.
+  #
+  # @return [Metasploit::Cache::Cacheable] if new instance of {#exploit_metasploit_module_class} could be loaded into
+  #   the cache.
+  # @return [nil] if new instance of {#exploit_metasploit_module_class} could not be created.
+  # @return [nil] if new instance of {#exploit_metasploit_module_class} could not be persisted to cache.
+  def exploit_metasploit_module_instance
+    unless instance_variable_defined? :@exploit_metasploit_module_instance
+      if valid?(:loading)
+        @exploit_metasploit_module_instance = nil
+
+        instance = exploit_metasploit_module_class_new
+
+        if instance
+          instance.extend Metasploit::Cache::Cacheable
+          ephemeral_cache = Metasploit::Cache::Exploit::Instance::Ephemeral.new(
+              exploit_metasploit_module_instance: instance,
+              logger: logger
+          )
+          instance.ephemeral_cache_by_source[:instance] = ephemeral_cache
+
+          if ephemeral_cache.valid?
+            ephemeral_cache.persist(to: exploit_instance)
+
+            if exploit_instance.persisted?
+              @exploit_metasploit_module_instance = instance
+            end
+          end
+        end
+      end
+    end
+
+    @exploit_metasploit_module_instance
+  end
+
+  private
+
+  # Attempts to instantiate {#exploit_metasploit_module_class}.
+  #
+  # @return [Object] instance of {#exploit_metasploit_module_class}
+  # @return [nil] if not valid for loading
+  # @return [nil] if exception is raise when `exploit_metasploit_module.new` is called.
+  #   Exception is saved to `exploit_metasploit_module_class_new_exception`.
+  def exploit_metasploit_module_class_new
+    begin
+      exploit_metasploit_module_class.new
+    rescue Interrupt
+      # handle Interrupt as pass-through unlike other Exceptions so users can bail with Ctrl+C
+      raise
+    rescue Exception => exception
+      @exploit_metasploit_module_class_new_exception = exception
+
+      nil
+    end
+  end
+  
+  # Copies error in {#exploit_metasploit_module_class_new_exception} to validation error on
+  # `:exploit_metasploit_module_class`.
+  #
+  # @return [void]
+  def exploit_metasploit_module_class_new_valid
+    if exploit_metasploit_module_class_new_exception
+      errors.add(
+                :exploit_metasploit_module_class_new,
+                "#{exploit_metasploit_module_class_new_exception.class} " \
+                "#{exploit_metasploit_module_class_new_exception}:\n" \
+                "#{exploit_metasploit_module_class_new_exception.backtrace.join("\n")}"
+      )
+    end
+  end
+
+  # Whether the current `#validation_context` is `:loading`.
+  #
+  # @return [true] if `#validation_context` is `:loading`.
+  # @return [false] otherwise
+  def loading_context?
+    validation_context == :loading
+  end
+end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,9 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 67
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 2
+      PATCH = 3
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version.
-      PRERELEASE = 'load-encoder-instance-from-metasploit-framework'
+      PRERELEASE = 'exploit-instance-ephemeral-and-load'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/exploit/class_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/class_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Metasploit::Cache::Exploit::Class do
 
   context 'associations' do
     it { is_expected.to belong_to(:ancestor).class_name('Metasploit::Cache::Exploit::Ancestor') }
-    it { is_expected.to have_one(:exploit_instance).class_name('Metasploit::Cache::Exploit::Instance').dependent(:destroy).inverse_of(:exploit_class) }
+    it { is_expected.to have_one(:exploit_instance).class_name('Metasploit::Cache::Exploit::Instance').dependent(:destroy).inverse_of(:exploit_class).with_foreign_key(:exploit_class_id) }
     it { is_expected.to belong_to(:rank).class_name('Metasploit::Cache::Module::Rank') }
   end
 

--- a/spec/app/models/metasploit/cache/exploit/instance/ephemeral_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance/ephemeral_spec.rb
@@ -1,0 +1,261 @@
+RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral do
+  context 'resurrecting attributes' do
+    context '#exploit_instance' do
+      subject(:exploit_instance) {
+        exploit_instance_ephemeral.exploit_instance
+      }
+
+      #
+      # lets
+      #
+
+      let(:exploit_instance_ephemeral) {
+        described_class.new(
+            exploit_metasploit_module_instance: exploit_metasploit_module_instance
+        )
+      }
+
+      let(:metasploit_class) {
+        double(
+            'exploit Metasploit Module class',
+            ephemeral_cache_by_source: {},
+            real_path_sha1_hex_digest: existing_exploit_instance.exploit_class.ancestor.real_path_sha1_hex_digest
+        )
+      }
+
+      let(:exploit_metasploit_module_instance) {
+        double('exploit Metasploit Module instance').tap { |instance|
+          allow(instance).to receive(:class).and_return(metasploit_class)
+        }
+      }
+
+      #
+      # let!s
+      #
+
+      let!(:existing_exploit_instance) {
+        FactoryGirl.create(:metasploit_cache_exploit_instance)
+      }
+
+      #
+      # Callbacks
+      #
+
+      before(:each) do
+        metasploit_class.ephemeral_cache_by_source[:ancestor] = metasploit_class
+      end
+
+      it { is_expected.to be_a Metasploit::Cache::Exploit::Instance }
+
+      it 'has #exploit_class matching pre-existing Metasploit::Cache::Exploit::Class' do
+        expect(exploit_instance.exploit_class).to eq(existing_exploit_instance.exploit_class)
+      end
+    end
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of(:logger) }
+    it { is_expected.to validate_presence_of(:exploit_metasploit_module_instance) }
+  end
+
+  context '#persist' do
+    subject(:persist) {
+      exploit_instance_ephemeral.persist(*args)
+    }
+
+    let(:exploit_instance_ephemeral) {
+      described_class.new(
+          logger: logger,
+          exploit_metasploit_module_instance: exploit_metasploit_module_instance
+      )
+    }
+
+    let(:exploit_metasploit_module_instance) {
+      double('exploit Metasploit Module instance').tap { |instance|
+        allow(instance).to receive(:class).and_return(metasploit_class)
+
+        architecture_abbreviation = FactoryGirl.generate :metasploit_cache_architecture_abbreviation
+
+        allow(instance).to receive(:arch).and_return([architecture_abbreviation])
+
+        author = double('Metasploit Module instance author')
+        author_name = FactoryGirl.generate :metasploit_cache_author_name
+        email_address_domain = FactoryGirl.generate :metasploit_cache_email_address_domain
+        email_address_local = FactoryGirl.generate :metasploit_cache_email_address_local
+        email_address_full = "#{email_address_local}@#{email_address_domain}"
+
+        allow(author).to receive(:name).and_return(author_name)
+        allow(author).to receive(:email).and_return(email_address_full)
+
+        allow(instance).to receive(:author).and_return([author])
+
+        allow(instance).to receive(:default_target).and_return(nil)
+
+        description = FactoryGirl.generate :metasploit_cache_exploit_instance_description
+
+        allow(instance).to receive(:description).and_return(description)
+
+        name = FactoryGirl.generate :metasploit_cache_exploit_instance_name
+
+        allow(instance).to receive(:name).and_return(name)
+
+        license_abbreviation = FactoryGirl.generate :metasploit_cache_license_abbreviation
+
+        allow(instance).to receive(:license).and_return(license_abbreviation)
+
+        platform = double('Platform', realname: 'Windows XP')
+        platform_list = double('Platform List', platforms: [platform])
+
+        allow(instance).to receive(:platform).and_return(platform_list)
+
+        target_architecture_abbreviation = FactoryGirl.generate :metasploit_cache_architecture_abbreviation
+
+        target_name = FactoryGirl.generate :metasploit_cache_exploit_target_name
+
+        target_platform = double('Platform', realname: 'Unix')
+        target_platform_list = double(
+            'exploit Metasploit Module instance target platform list',
+            platforms: [target_platform]
+        )
+
+        target = double(
+            "exploit Metasploit Module instance target",
+            arch: [target_architecture_abbreviation],
+            name: target_name,
+            platform: target_platform_list
+        )
+
+        allow(instance).to receive(:targets).and_return([target])
+      }
+    }
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(string_io)
+      )
+    }
+
+    let(:string_io) {
+      StringIO.new
+    }
+
+    context 'with :to' do
+      let(:args) {
+        [
+            {
+                to: exploit_instance
+            }
+        ]
+      }
+
+      let(:exploit_instance) {
+        FactoryGirl.build(
+            :metasploit_cache_exploit_instance,
+            contribution_count: 0,
+            description: nil,
+            exploit_target_count: 0,
+            licensable_license_count: 0,
+            name: nil
+        )
+      }
+
+      let(:metasploit_class) {
+        double(
+            'exploit Metasploit Module class',
+            ephemeral_cache_by_source: {}
+        )
+      }
+
+      it 'does not access default #exploit_instance' do
+        expect(exploit_instance_ephemeral).not_to receive(:exploit_instance)
+
+        persist
+      end
+
+      it 'uses :to' do
+        expect(exploit_instance).to receive(:batched_save).and_call_original
+
+        persist
+      end
+
+      context 'batched save' do
+        context 'failure' do
+          before(:each) do
+            exploit_instance.valid?
+
+            expect(exploit_instance).to receive(:batched_save).and_return(false)
+          end
+
+          it 'tags log with Metasploit::Cache::Module::Ancestor#real_path' do
+            persist
+
+            expect(string_io.string).to include("[#{exploit_instance.exploit_class.ancestor.real_pathname.to_s}]")
+          end
+
+          it 'logs validation errors' do
+            persist
+
+            full_error_messages = exploit_instance.errors.full_messages.to_sentence
+
+            expect(full_error_messages).not_to be_blank
+            expect(string_io.string).to include("Could not be persisted to #{exploit_instance.class}: #{full_error_messages}")
+          end
+        end
+
+        context 'success' do
+          specify {
+            expect {
+              persist
+            }.to change(Metasploit::Cache::Exploit::Instance, :count).by(1)
+          }
+        end
+      end
+    end
+
+    context 'without :to' do
+      #
+      # lets
+      #
+
+      let(:args) {
+        []
+      }
+
+      let(:metasploit_class) {
+        double(
+            'exploit Metasploit Module class',
+            ephemeral_cache_by_source: {},
+            real_path_sha1_hex_digest: existing_exploit_instance.exploit_class.ancestor.real_path_sha1_hex_digest
+        )
+      }
+
+      #
+      # let!s
+      #
+
+      let!(:existing_exploit_instance) {
+        FactoryGirl.create(:metasploit_cache_exploit_instance)
+      }
+
+      #
+      # Callbacks
+      #
+
+      before(:each) do
+        metasploit_class.ephemeral_cache_by_source[:ancestor] = metasploit_class
+      end
+
+      it 'defaults to #exploit_instance' do
+        expect(exploit_instance_ephemeral).to receive(:exploit_instance).and_call_original
+
+        persist
+      end
+
+      it 'uses #batched_save' do
+        expect(exploit_instance_ephemeral.exploit_instance).to receive(:batched_save).and_call_original
+
+        persist
+      end
+    end
+  end
+end

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
   context 'associations' do
     it { is_expected.to have_many(:contributions).autosave(true).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:default_exploit_target).class_name('Metasploit::Cache::Exploit::Target').inverse_of(:exploit_instance) }
-    it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance) }
+    it { is_expected.to belong_to(:exploit_class).class_name('Metasploit::Cache::Exploit::Class').inverse_of(:exploit_instance).with_foreign_key(:exploit_class_id) }
     it { is_expected.to have_many(:exploit_targets).autosave(true).class_name('Metasploit::Cache::Exploit::Target').dependent(:destroy).inverse_of(:exploit_instance) }
     it { is_expected.to have_many(:licensable_licenses).autosave(true).class_name('Metasploit::Cache::Licensable::License')}
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -36,6 +36,103 @@ RSpec.describe Metasploit::Cache::Exploit::Instance do
       }
 
       it { is_expected.to be_valid }
+      
+      context 'metasploit_cache_exploit_instance_exploit_class_ancestor_contents trait' do
+        subject(:metasploit_cache_exploit_instance) {
+          FactoryGirl.build(
+              :metasploit_cache_exploit_instance,
+              exploit_class: exploit_class
+          )
+        }
+
+        context 'with #exploit_class' do
+          let(:exploit_class) {
+            FactoryGirl.build(
+                :metasploit_cache_exploit_class,
+                ancestor: exploit_ancestor,
+                ancestor_contents?: false
+            )
+          }
+
+          context 'with Metasploit::Cache::Direct::Class#ancestor' do
+            let(:exploit_ancestor) {
+              FactoryGirl.build(
+                  :metasploit_cache_exploit_ancestor,
+                  content?: false,
+                  relative_path: relative_path
+              )
+            }
+
+            context 'with Metasploit::Cache::Module::Ancestor#real_pathname' do
+              let(:reference_name) {
+                FactoryGirl.generate :metasploit_cache_module_ancestor_reference_name
+              }
+
+              let(:relative_path) {
+                "exploit/#{reference_name}#{Metasploit::Cache::Module::Ancestor::EXTENSION}"
+              }
+
+              it 'writes exploit Metasploit Module to #real_pathname' do
+                metasploit_cache_exploit_instance
+
+                expect(exploit_ancestor.real_pathname).to exist
+              end
+            end
+
+            context 'without Metasploit::Cache::Module::Ancestor#real_pathname' do
+              let(:relative_path) {
+                nil
+              }
+
+              it 'raises ArgumentError' do
+                expect {
+                  metasploit_cache_exploit_instance
+                }.to raise_error(
+                         ArgumentError,
+                         "Metasploit::Cache::Exploit::Ancestor#real_pathname is `nil` and content cannot be " \
+                         "written.  If this is expected, set `exploit_class_ancestor_contents?: false` " \
+                         "when using the :metasploit_cache_exploit_instance_exploit_class_ancestor_contents trait."
+                     )
+              end
+            end
+          end
+
+          context 'without Metasploit::Cache::Direct::Class#ancestor' do
+            let(:exploit_ancestor) {
+              nil
+            }
+
+            it 'raises ArgumentError' do
+              expect {
+                metasploit_cache_exploit_instance
+              }.to raise_error(
+                       ArgumentError,
+                       "Metasploit::Cache::Exploit::Class#ancestor is `nil` and content cannot be written.  " \
+                       "If this is expected, set `exploit_ancestor_contents?: false` " \
+                       "when using the :metasploit_cache_exploit_instance_exploit_class_ancestor_contents trait."
+                   )
+            end
+          end
+        end
+
+        context 'without #exploit_class' do
+          let(:exploit_class) {
+            nil
+          }
+
+          it 'raises ArgumentError' do
+            expect {
+              metasploit_cache_exploit_instance
+            }.to raise_error(
+                     ArgumentError,
+                     "Metasploit::Cache::Exploit::Instance#exploit_class is `nil` and it can't be used to look " \
+                     "up Metasploit::Cache::Direct::Class#ancestor to write content. " \
+                     "If this is expected, set `exploit_class_ancestor_contents?: false` " \
+                     "when using the :metasploit_cache_exploit_instance_exploit_class_ancestor_contents trait."
+                 )
+          end
+        end
+      end
     end
   end
 

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :metasploit_cache_exploit_instance,
-          class: Metasploit::Cache::Exploit::Instance do
+          class: Metasploit::Cache::Exploit::Instance,
+          traits: [
+              :metasploit_cache_exploit_instance_exploit_class_ancestor_contents
+          ] do
     transient do
       contribution_count 1
       exploit_target_count 1
@@ -68,4 +71,64 @@ FactoryGirl.define do
   end
 
   sequence :metasploit_cache_exploit_instance_privileged, Metasploit::Cache::Spec.sample_stream([false, true])
+  
+  #
+  # Traits
+  #
+
+  trait :metasploit_cache_exploit_instance_exploit_class_ancestor_contents do
+    transient do
+      exploit_class_ancestor_contents? true
+      exploit_class_ancestor_metasploit_class_relative_name { generate :metasploit_cache_module_ancestor_metasploit_module_relative_name }
+      exploit_class_ancestor_superclass { 'Metasploit::Cache::Direct::Class::Superclass' }
+    end
+
+    after(:build) do |exploit_instance, evaluator|
+      if evaluator.exploit_class_ancestor_contents?
+        exploit_class = exploit_instance.exploit_class
+
+        if exploit_class.nil?
+          raise ArgumentError,
+                "#{exploit_instance.class}#exploit_class is `nil` and it can't be used to look up " \
+                "Metasploit::Cache::Direct::Class#ancestor to write content. " \
+                "If this is expected, set `exploit_class_ancestor_contents?: false` " \
+                "when using the :metasploit_cache_exploit_instance_exploit_class_ancestor_contents trait."
+        end
+
+        exploit_ancestor = exploit_class.ancestor
+
+        if exploit_ancestor.nil?
+          raise ArgumentError,
+                "#{exploit_class.class}#ancestor is `nil` and content cannot be written.  " \
+                "If this is expected, set `exploit_ancestor_contents?: false` " \
+                "when using the :metasploit_cache_exploit_instance_exploit_class_ancestor_contents trait."
+        end
+
+        real_pathname = exploit_ancestor.real_pathname
+
+        unless real_pathname
+          raise ArgumentError,
+                "#{exploit_ancestor.class}#real_pathname is `nil` and content cannot be written.  " \
+                "If this is expected, set `exploit_class_ancestor_contents?: false` " \
+                "when using the :metasploit_cache_exploit_instance_exploit_class_ancestor_contents trait."
+        end
+
+        # make directory
+        real_pathname.parent.mkpath
+
+        context = Object.new
+        cell = Cell::Base.cell_for(
+            'metasploit/cache/exploit/instance/exploit_class/ancestor',
+            context,
+            exploit_instance,
+            metasploit_class_relative_name: evaluator.exploit_class_ancestor_metasploit_class_relative_name,
+            superclass: evaluator.exploit_class_ancestor_superclass
+        )
+
+        real_pathname.open('wb') do |f|
+          f.write(cell.call)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
+++ b/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
@@ -267,10 +267,6 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
       Set.new [FactoryGirl.generate(:metasploit_cache_architecture_abbreviation)]
     }
 
-    let(:source) {
-      double('Metasploit Module instance', arch: [])
-    }
-
     it 'calls build_added' do
       expect(described_class).to receive(:build_added).with(
                                      hash_including(

--- a/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
+++ b/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
@@ -246,6 +246,55 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
     end
   end
 
+  context 'reduce' do
+    subject(:reduce) {
+      described_class.reduce(
+          destination: destination,
+          destination_attribute_set: destination_attribute_set,
+          source_attribute_set: source_attribute_set
+      )
+    }
+
+    let(:destination) {
+      Metasploit::Cache::Encoder::Instance.new
+    }
+
+    let(:destination_attribute_set) {
+      Set.new
+    }
+
+    let(:source_attribute_set) {
+      Set.new [FactoryGirl.generate(:metasploit_cache_architecture_abbreviation)]
+    }
+
+    let(:source) {
+      double('Metasploit Module instance', arch: [])
+    }
+
+    it 'calls build_added' do
+      expect(described_class).to receive(:build_added).with(
+                                     hash_including(
+                                         destination: destination,
+                                         destination_attribute_set: destination_attribute_set,
+                                         source_attribute_set: source_attribute_set
+                                     )
+                                 ).and_call_original
+
+      reduce
+    end
+
+    it 'calls mark_removed_for_destruction' do
+      expect(described_class).to receive(:mark_removed_for_destruction).with(
+                                     hash_including(
+                                         destination: destination,
+                                         destination_attribute_set: destination_attribute_set,
+                                         source_attribute_set: source_attribute_set                                     )
+                                 ).and_call_original
+
+      reduce
+    end
+  end
+
   context 'source_attribute_set' do
     subject(:source_attribute_set) {
       described_class.source_attribute_set(source)
@@ -298,16 +347,8 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
       double('Metasploit Module instance', arch: [])
     }
 
-    it 'calls build_added' do
-      expect(described_class).to receive(:build_added).with(
-                                     hash_including(destination: destination)
-                                 )
-
-      synchronize
-    end
-
-    it 'calls mark_removed_for_destruction' do
-      expect(described_class).to receive(:mark_removed_for_destruction).with(
+    it 'calls reduce' do
+      expect(described_class).to receive(:reduce).with(
                                      hash_including(destination: destination)
                                  )
 

--- a/spec/lib/metasploit/cache/ephemeral/attribute_set_spec.rb
+++ b/spec/lib/metasploit/cache/ephemeral/attribute_set_spec.rb
@@ -122,4 +122,25 @@ RSpec.describe Metasploit::Cache::Ephemeral::AttributeSet do
       expect(removed).to eq(Set.new [:removed])
     end
   end
+
+  context 'retained' do
+    subject(:retained) do
+      described_class.retained(
+          destination: destination,
+          source: source
+      )
+    end
+
+    let(:destination) {
+      Set.new ['only in destination', 'common']
+    }
+
+    let(:source) {
+      Set.new ['only in source', 'common']
+    }
+
+    it 'is intersection of destination and source' do
+      expect(retained).to eq Set.new ['common']
+    end
+  end
 end

--- a/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
@@ -1,0 +1,779 @@
+RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets do
+  context 'build_added' do
+    subject(:build_added) {
+      described_class.build_added(
+          destination: destination,
+          destination_attributes_by_name: destination_attributes_by_name,
+          source_attributes_by_name: source_attributes_by_name
+      )
+    }
+
+    let(:destination) {
+      Metasploit::Cache::Exploit::Instance.new
+    }
+
+    let(:destination_attributes_by_name) {
+      {}
+    }
+
+    context 'with added names' do
+      let(:architecture_abbreviation_set) {
+        Set.new [FactoryGirl.generate(:metasploit_cache_architecture_abbreviation)]
+      }
+
+      let(:index) {
+        5
+      }
+
+      let(:name) {
+        FactoryGirl.generate :metasploit_cache_exploit_target_name
+      }
+
+      let(:platform_fully_qualified_name_set) {
+        Set.new [FactoryGirl.generate(:metasploit_cache_platform_fully_qualified_name)]
+      }
+
+      let(:source_attributes_by_name) {
+        {
+           name => {
+               index: index,
+               architecture_abbreviation_set: architecture_abbreviation_set,
+               platform_fully_qualified_name_set: platform_fully_qualified_name_set
+           }
+        }
+      }
+      
+      it 'adds element to #exploit_targets' do
+        expect {
+          build_added
+        }.to change {
+               destination.exploit_targets.length
+             }.by(1)
+      end
+      
+      context 'added Metasploit::Cache:Exploit::Target' do
+        subject(:exploit_target) {
+          build_added
+          
+          destination.exploit_targets.last
+        }
+        
+        it 'sets Metasploit::Cache::Exploit::Target#architecturable_architectures using :architecture_abbreviation_set' do
+          expect(exploit_target.architecturable_architectures.length).to eq(architecture_abbreviation_set.length)
+          
+          exploit_target_architecture_abbreviation_set = exploit_target.architecturable_architectures.each_with_object(Set.new) { |architecturable_architecture, set|
+            set.add architecturable_architecture.architecture.abbreviation
+          }
+          
+          expect(exploit_target_architecture_abbreviation_set).to eq(architecture_abbreviation_set)
+        end
+
+        it 'sets Metasploit::Cache::Exploit::Target#index using :index' do
+          expect(exploit_target.index).to eq(index)
+        end
+        
+        it 'sets Metasploit::Cache::Exploit::Target#platformable_platforms using :platform_fully_qualified_name_set' do
+          expect(exploit_target.platformable_platforms.length).to eq(platform_fully_qualified_name_set.length)
+          
+          exploit_target_platform_fully_qualified_name_set = exploit_target.platformable_platforms.each_with_object(Set.new) { |architecturable_platform, set|
+            set.add architecturable_platform.platform.fully_qualified_name
+          }
+          
+          expect(exploit_target_platform_fully_qualified_name_set).to eq(platform_fully_qualified_name_set)
+        end
+      end
+    end
+
+    context 'without added names' do
+      let(:source_attributes_by_name) {
+        destination_attributes_by_name
+      }
+
+      it 'does not add #exploit_targets to destination' do
+        expect {
+          build_added
+        }.not_to change {
+                   destination.exploit_targets.length
+                 }
+      end
+
+      it 'returns destination' do
+        expect(build_added).to eq(destination)
+      end
+    end
+  end
+
+  context 'destination_attributes_by_name' do
+    subject(:destination_attributes_by_name) {
+      described_class.destination_attributes_by_name(destination)
+    }
+
+    context 'with new destination' do
+      let(:destination) {
+        Metasploit::Cache::Exploit::Instance.new
+      }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'with persisted destination' do
+      let(:destination) {
+        FactoryGirl.create(:metasploit_cache_exploit_instance)
+      }
+
+      let(:exploit_target) {
+        destination.exploit_targets.first
+      }
+
+      it 'has Metasploit::Cache::Exploit::Target#name as key' do
+        expect(destination_attributes_by_name).to have_key(exploit_target.name)
+      end
+
+      context 'attributes for Metasploit::Cache::Exploit::Target#name key' do
+        subject(:attributes) {
+          destination_attributes_by_name.fetch(exploit_target.name)
+        }
+
+        it 'has Metasploit::Cache::Exploit::Target#index as :index' do
+          expect(attributes).to have_key(:index)
+          expect(attributes[:index]).to eq(exploit_target.index)
+        end
+      end
+    end
+  end
+
+  context 'destroy_removed' do
+    subject(:destroy_removed) {
+      described_class.destroy_removed(
+          destination: destination,
+          destination_attributes_by_name: destination_attributes_by_name,
+          source_attributes_by_name: source_attributes_by_name
+      )
+    }
+
+    context 'with new destination' do
+      let(:destination) {
+        Metasploit::Cache::Exploit::Instance.new
+      }
+
+      let(:destination_attributes_by_name) {
+        {}
+      }
+
+      let(:source_attributes_by_name) {
+
+      }
+
+      it 'returns destination' do
+        expect(destroy_removed).to eq(destination)
+      end
+    end
+
+    context 'with persisted destination' do
+      let(:destination) {
+        FactoryGirl.create(
+            :metasploit_cache_exploit_instance,
+            exploit_target_count: 2
+        )
+      }
+
+      let(:first_exploit_target) {
+        destination.exploit_targets.first
+      }
+
+      let(:second_exploit_target) {
+        destination.exploit_targets.second
+      }
+
+      let(:destination_attributes_by_name) {
+        {
+            first_exploit_target.name => {
+                index: first_exploit_target.index,
+                architecture_abbreviation_set: Set.new([first_exploit_target.architecturable_architectures.first.architecture.abbreviation]),
+                platform_fully_qualified_name_set: Set.new([first_exploit_target.platformable_platforms.first.platform.fully_qualified_name])
+            },
+            second_exploit_target.name => {
+                index: second_exploit_target.index,
+                architecture_abbreviation_set: Set.new([second_exploit_target.architecturable_architectures.first.architecture.abbreviation]),
+                platform_fully_qualified_name_set: Set.new([second_exploit_target.platformable_platforms.first.platform.fully_qualified_name])
+            }
+        }
+      }
+
+      context 'with empty removed name set' do
+        let(:source_attributes_by_name) {
+          destination_attributes_by_name
+        }
+
+        it 'does not destroy any #exploit_targets' do
+          expect {
+            destroy_removed
+          }.not_to change(destination.exploit_targets, :count)
+        end
+
+        it 'returns destination' do
+          expect(destroy_removed).to eq(destination)
+        end
+      end
+
+      context 'with present removed name set' do
+        let(:source_attributes_by_name) {
+          destination_attributes_by_name.except(first_exploit_target.name)
+        }
+
+        it 'destroys removed target' do
+          expect {
+            destroy_removed
+          }.to change(destination.exploit_targets, :count).by(-1)
+
+          expect(destination.exploit_targets(true).first.name).to eq(second_exploit_target.name)
+        end
+
+        it 'returns destination' do
+          expect(destroy_removed).to eq(destination)
+        end
+      end
+    end
+  end
+
+  context 'name_set' do
+    subject(:name_set) {
+      described_class.name_set(attributes_by_name)
+    }
+
+    context 'with empty attributes_by_name' do
+      let(:attributes_by_name) {
+        {}
+      }
+
+      it { is_expected.to eq Set.new }
+    end
+
+    context 'with present attributes_by_name' do
+      let(:attributes_by_name) {
+        {
+            first_name => nil,
+            second_name => nil
+        }
+      }
+
+      let(:first_name) {
+        FactoryGirl.generate :metasploit_cache_exploit_target_name
+      }
+
+      let(:second_name) {
+        FactoryGirl.generate :metasploit_cache_exploit_target_name
+      }
+
+      it 'is set of keys' do
+        expect(name_set).to eq Set.new([first_name, second_name])
+      end
+    end
+  end
+
+  context 'source_default_exploit_target_index' do
+    subject(:source_default_exploit_target_index) {
+      described_class.source_default_exploit_target_index(source)
+    }
+
+    let(:index) {
+      FactoryGirl.generate :metasploit_cache_exploit_target_index
+    }
+
+    let(:source) {
+      double('exploit Metasploit Module instance', default_target: index)
+    }
+
+    it 'is source #default_target' do
+      expect(source_default_exploit_target_index).to eq(source.default_target)
+    end
+  end
+
+  context 'source_attributes_by_name' do
+    subject(:source_attributes_by_name) {
+      described_class.source_attributes_by_name(source)
+    }
+
+    let(:source) {
+      double(
+          'exploit Metasploit Module instance',
+          arch: [source_architecture_abbreviation],
+          platform: double(
+                        'exploit Metasploit Module instance platform list',
+                        platforms: [
+                            double(
+                                'exploit Metasploit Module instance platform',
+                                realname: source_platform_fully_qualified_name
+                            )
+                        ]
+          ),
+          targets: targets
+      )
+    }
+
+    let(:source_architecture_abbreviation) {
+      FactoryGirl.generate :metasploit_cache_architecture_abbreviation
+    }
+
+    let(:source_platform_fully_qualified_name) {
+      FactoryGirl.generate :metasploit_cache_platform_fully_qualified_name
+    }
+
+    context 'without source.targets' do
+      let(:targets) {
+        []
+      }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'with source.targets' do
+      let(:name) {
+        FactoryGirl.generate :metasploit_cache_exploit_target_name
+      }
+
+      let(:target) {
+        double(
+            'exploit Metasploit Module instance target',
+            arch: arch,
+            name: name,
+            platform: platform
+        )
+      }
+
+      let(:targets) {
+        [
+            target
+        ]
+      }
+
+      context 'with target.arch' do
+        let(:arch) {
+          [target_architecture_abbreviation]
+        }
+
+        let(:target_architecture_abbreviation) {
+          FactoryGirl.generate :metasploit_cache_architecture_abbreviation
+        }
+
+        context 'with target.platform' do
+          let(:platform) {
+            double(
+                'exploit Metasploit Module instance target platform list',
+                platforms: [
+                    double(
+                        'exploit Metasploit Module instance target platform',
+                        realname: target_platform_fully_qualified_name
+                    )
+                ]
+            )
+          }
+
+          let(:target_platform_fully_qualified_name) {
+            FactoryGirl.generate :metasploit_cache_platform_fully_qualified_name
+          }
+
+          it 'sets key to target.name' do
+            expect(source_attributes_by_name).to have_key(target.name)
+          end
+
+          context 'attributes for target.name' do
+            subject(:attributes) {
+              source_attributes_by_name[target.name]
+            }
+
+            it 'sets :architecture_abbreviation_set to Set of target.arch' do
+              expect(attributes[:architecture_abbreviation_set]).to eq(Set.new([target_architecture_abbreviation]))
+            end
+
+            it 'sets :index to index of target in source.targets' do
+              expect(attributes[:index]).to eq 0
+            end
+
+            it 'sets :platform_fully_qualified_name_set to Set of target.platform.platforms' do
+              expect(attributes[:platform_fully_qualified_name_set]).to eq(Set.new([target_platform_fully_qualified_name]))
+            end
+          end
+        end
+
+        context 'without target.platform' do
+          let(:platform) {
+            nil
+          }
+
+          it 'sets key to target.name' do
+            expect(source_attributes_by_name).to have_key(target.name)
+          end
+
+          context 'attributes for target.name' do
+            subject(:attributes) {
+              source_attributes_by_name[target.name]
+            }
+
+            it 'sets :architecture_abbreviation_set to Set of target.arch' do
+              expect(attributes[:architecture_abbreviation_set]).to eq(Set.new([target_architecture_abbreviation]))
+            end
+
+            it 'sets :index to index of target in source.targets' do
+              expect(attributes[:index]).to eq 0
+            end
+
+            it 'sets :platform_fully_qualified_name_set to Set of source.platform.platforms' do
+              expect(attributes[:platform_fully_qualified_name_set]).to eq(Set.new([source_platform_fully_qualified_name]))
+            end
+          end
+        end
+      end
+
+      context 'without target.arch' do
+        let(:arch) {
+          nil
+        }
+
+        context 'with target.platform' do
+          let(:platform) {
+            double(
+                'exploit Metasploit Module instance target platform list',
+                platforms: [
+                    double(
+                        'exploit Metasploit Module instance target platform',
+                        realname: target_platform_fully_qualified_name
+                    )
+                ]
+            )
+          }
+
+          let(:target_platform_fully_qualified_name) {
+            FactoryGirl.generate :metasploit_cache_platform_fully_qualified_name
+          }
+
+          it 'sets key to target.name' do
+            expect(source_attributes_by_name).to have_key(target.name)
+          end
+
+          context 'attributes for target.name' do
+            subject(:attributes) {
+              source_attributes_by_name[target.name]
+            }
+
+            it 'sets :architecture_abbreviation_set to Set of source.arch' do
+              expect(attributes[:architecture_abbreviation_set]).to eq(Set.new([source_architecture_abbreviation]))
+            end
+
+            it 'sets :index to index of target in source.targets' do
+              expect(attributes[:index]).to eq 0
+            end
+
+            it 'sets :platform_fully_qualified_name_set to Set of target.platform.platforms' do
+              expect(attributes[:platform_fully_qualified_name_set]).to eq(Set.new([target_platform_fully_qualified_name]))
+            end
+          end
+        end
+
+        context 'without target.platform' do
+          let(:platform) {
+            nil
+          }
+
+          it 'sets key to target.name' do
+            expect(source_attributes_by_name).to have_key(target.name)
+          end
+
+          context 'attributes for target.name' do
+            subject(:attributes) {
+              source_attributes_by_name[target.name]
+            }
+
+            it 'sets :architecture_abbreviation_set to Set of source.arch' do
+              expect(attributes[:architecture_abbreviation_set]).to eq(Set.new([source_architecture_abbreviation]))
+            end
+
+            it 'sets :index to index of target in source.targets' do
+              expect(attributes[:index]).to eq 0
+            end
+
+            it 'sets :platform_fully_qualified_name_set to Set of source.platform.platforms' do
+              expect(attributes[:platform_fully_qualified_name_set]).to eq(Set.new([source_platform_fully_qualified_name]))
+            end
+          end
+        end
+      end
+    end
+  end
+  
+  context 'synchronize' do
+    subject(:synchronize) {
+      described_class.synchronize(
+          destination: destination,
+          source: source
+      )
+    }
+    
+    let(:destination) {
+      Metasploit::Cache::Exploit::Instance.new
+    }
+    
+    let(:source) {
+      double(
+          'exploit Metasploit Module instance',
+          default_target: nil,
+          targets: []
+      )
+    }
+    
+    it 'calls build_added' do
+      expect(described_class).to receive(:build_added).with(
+                                     hash_including(destination: destination)
+                                 ).and_call_original
+
+      synchronize
+    end
+
+    it 'calls destroy_removed' do
+      expect(described_class).to receive(:destroy_removed).with(
+                                     hash_including(destination: destination)
+                                 ).and_call_original
+
+      synchronize
+    end
+    
+    it 'calls update_changed' do
+      expect(described_class).to receive(:update_changed).with(
+                                     hash_including(destination: destination)
+                                 ).and_call_original
+
+      synchronize
+    end
+
+    it 'calls update_default_exploit_target' do
+      expect(described_class).to receive(:update_default_exploit_target).with(
+                                     hash_including(
+                                         destination: destination,
+                                         source: source
+                                     )
+                                 ).and_call_original
+
+      synchronize
+    end
+  end
+
+  context 'update_changed' do
+    subject(:update_changed) {
+      described_class.update_changed(
+          destination: destination,
+          destination_attributes_by_name: destination_attributes_by_name,
+          source_attributes_by_name: source_attributes_by_name
+      )
+    }
+
+    context 'with new destination' do
+      let(:destination) {
+        Metasploit::Cache::Exploit::Instance.new
+      }
+
+      let(:destination_attributes_by_name) {
+        {}
+      }
+
+      let(:source_attributes_by_name) {
+        {}
+      }
+
+      it 'does not change destination.exploit_targets' do
+        expect {
+          update_changed
+        }.not_to change(destination, :exploit_targets)
+      end
+    end
+
+    context 'with persisted destination' do
+      let(:destination) {
+        FactoryGirl.create(:metasploit_cache_exploit_instance)
+      }
+
+      let(:destination_attributes_by_name) {
+        {
+            exploit_target.name => {
+                architecture_abbreviation_set: Set.new([removed_architecture_abbreviation]),
+                index: exploit_target.index,
+                platform_fully_qualified_name_set: Set.new([removed_platform_fully_qualified_name])
+            }
+        }
+      }
+
+      let(:exploit_target) {
+        destination.exploit_targets.first
+      }
+
+      let(:removed_architecture_abbreviation) {
+        exploit_target.architecturable_architectures.first.architecture.abbreviation
+      }
+
+      let(:removed_platform_fully_qualified_name) {
+        exploit_target.platformable_platforms.first.platform.fully_qualified_name
+      }
+
+      context 'with retained name set' do
+        let(:added_architecture_abbreviation) {
+          FactoryGirl.generate :metasploit_cache_architecture_abbreviation
+        }
+
+        let(:source_attributes_by_name) {
+          {
+              exploit_target.name => {
+                  architecture_abbreviation_set: Set.new([added_architecture_abbreviation]),
+                  index: source_index,
+                  platform_fully_qualified_name_set: Set.new([added_platform_fully_qualified_name])
+              }
+          }
+        }
+
+        let(:source_index) {
+          FactoryGirl.generate :metasploit_cache_exploit_target_index
+        }
+
+        let(:added_platform_fully_qualified_name) {
+          FactoryGirl.generate :metasploit_cache_platform_fully_qualified_name
+        }
+
+        it 'does not change number of destination.exploit_targets' do
+          expect {
+            update_changed
+          }.not_to change {
+                     destination.exploit_targets.length
+                   }
+        end
+
+        context 'changed Metasploit::Cache::Exploit::Target' do
+          subject(:changed_exploit_target) {
+            updated = update_changed
+            updated.save!
+
+            updated.reload.exploit_targets.first
+          }
+
+          it 'updates #index' do
+            expect(changed_exploit_target.index).to eq(source_index)
+          end
+
+          context '#architecturable_architectures' do
+            subject(:changed_architecture_abbreviations) {
+              changed_exploit_target.architecturable_architectures.map { |architecturable_architecture|
+                architecturable_architecture.architecture.abbreviation
+              }
+            }
+
+            it 'does not include removed architecture' do
+              expect(changed_architecture_abbreviations).not_to include(removed_architecture_abbreviation)
+            end
+
+            it 'includes added architecture' do
+              expect(changed_architecture_abbreviations).to include(added_architecture_abbreviation)
+            end
+          end
+
+          context '#platformable_platforms' do
+            subject(:changed_platform_fully_qualified_names) {
+              changed_exploit_target.platformable_platforms.map { |platformable_platform|
+                platformable_platform.platform.fully_qualified_name
+              }
+            }
+
+            it 'does not include removed platform' do
+              expect(changed_platform_fully_qualified_names).not_to include(removed_platform_fully_qualified_name)
+            end
+
+            it 'includes added platform' do
+              expect(changed_platform_fully_qualified_names).to include(added_platform_fully_qualified_name)
+            end
+          end
+        end
+      end
+
+      context 'without retained name set' do
+        let(:source_attributes_by_name) {
+          {
+              FactoryGirl.generate(:metasploit_cache_exploit_target_name) => {
+                  architecture_abbreviation_set: Set.new([FactoryGirl.generate(:metasploit_cache_architecture_abbreviation)]),
+                  index: FactoryGirl.generate(:metasploit_cache_exploit_target_index),
+                  platform_fully_qualified_name_set: Set.new([FactoryGirl.generate(:metasploit_cache_platform_fully_qualified_name)])
+              }
+          }
+        }
+
+        it 'does not change destination.exploit_targets' do
+          expect {
+            update_changed
+          }.not_to change(destination, :exploit_targets)
+        end
+      end
+    end
+  end
+
+  context 'update_default_exploit_target' do
+    subject(:update_default_exploit_target) {
+      described_class.update_default_exploit_target(
+          destination: destination,
+          source: source
+      )
+    }
+
+    let(:destination) {
+      FactoryGirl.build(
+          :metasploit_cache_exploit_instance,
+          exploit_target_count: 2
+      ).tap { |exploit_instance|
+        exploit_instance.default_exploit_target = exploit_instance.exploit_targets.min_by(&:index)
+
+        exploit_instance.save!
+      }
+    }
+
+    context 'with source_default_exploit_target_index' do
+      context 'matching a Metasploit::Cache::Exploit::Target#index' do
+        let(:source) {
+          double(
+              'exploit Metasploit Module instance',
+              default_target: destination.exploit_targets.map(&:index).max
+          )
+        }
+
+        it 'changes destination.default_exploit_target' do
+          expect {
+            update_default_exploit_target
+          }.to change(destination, :default_exploit_target)
+        end
+      end
+
+      context 'not matching a Metasploit::Cache::Exploit::Target#index' do
+        let(:source) {
+          double(
+              'exploit Metasploit Module instance',
+              default_target: destination.exploit_targets.map(&:index).max + 1
+          )
+        }
+
+        it 'sets destination.default_exploit_target to nil' do
+          expect {
+            update_default_exploit_target
+          }.to change(destination, :default_exploit_target).to(nil)
+        end
+      end
+    end
+
+    context 'without source_default_epxloit_target_index' do
+      let(:source) {
+        double(
+            'exploit Metasploit Module Instance',
+            default_target: nil
+        )
+      }
+
+      it 'set destination.default_exploit_target to nil' do
+        expect {
+          update_default_exploit_target
+        }.to change(destination, :default_exploit_target).to(nil)
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
@@ -142,9 +142,9 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
     end
   end
 
-  context 'destroy_removed' do
-    subject(:destroy_removed) {
-      described_class.destroy_removed(
+  context 'mark_removed_for_destruction' do
+    subject(:mark_removed_for_destruction) {
+      described_class.mark_removed_for_destruction(
           destination: destination,
           destination_attributes_by_name: destination_attributes_by_name,
           source_attributes_by_name: source_attributes_by_name
@@ -165,7 +165,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
       }
 
       it 'returns destination' do
-        expect(destroy_removed).to eq(destination)
+        expect(mark_removed_for_destruction).to eq(destination)
       end
     end
 
@@ -205,14 +205,32 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
           destination_attributes_by_name
         }
 
+        it 'does not mark for destruction any #exploit_targets' do
+          expect {
+            mark_removed_for_destruction
+          }.not_to change {
+                     destination.exploit_targets.each.count(&:marked_for_destruction?)
+                   }
+        end
+
         it 'does not destroy any #exploit_targets' do
           expect {
-            destroy_removed
+            mark_removed_for_destruction
           }.not_to change(destination.exploit_targets, :count)
         end
 
         it 'returns destination' do
-          expect(destroy_removed).to eq(destination)
+          expect(mark_removed_for_destruction).to eq(destination)
+        end
+
+        context 'with destination saved' do
+          it 'does not destroy any #exploit_targets' do
+            mark_removed_for_destruction
+
+            expect {
+              destination.save!
+            }.not_to change(destination.exploit_targets, :count)
+          end
         end
       end
 
@@ -221,16 +239,34 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
           destination_attributes_by_name.except(first_exploit_target.name)
         }
 
-        it 'destroys removed target' do
+        it 'marks for destruction #exploit_targets with matching name' do
           expect {
-            destroy_removed
-          }.to change(destination.exploit_targets, :count).by(-1)
+            mark_removed_for_destruction
+          }.to change {
+                 destination.exploit_targets.each.count(&:marked_for_destruction?)
+               }.by(1)
+        end
 
-          expect(destination.exploit_targets(true).first.name).to eq(second_exploit_target.name)
+        it 'does not destroy any #exploit_targets' do
+          expect {
+            mark_removed_for_destruction
+          }.not_to change(destination.exploit_targets, :count)
         end
 
         it 'returns destination' do
-          expect(destroy_removed).to eq(destination)
+          expect(mark_removed_for_destruction).to eq(destination)
+        end
+
+        context 'with destination saved' do
+          it 'destroys removed target' do
+            mark_removed_for_destruction
+
+            expect {
+              destination.save!
+            }.to change(destination.exploit_targets, :count).by(-1)
+
+            expect(destination.exploit_targets(true).first.name).to eq(second_exploit_target.name)
+          end
         end
       end
     end
@@ -529,8 +565,8 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
       synchronize
     end
 
-    it 'calls destroy_removed' do
-      expect(described_class).to receive(:destroy_removed).with(
+    it 'calls mark_removed_for_destruction' do
+      expect(described_class).to receive(:mark_removed_for_destruction).with(
                                      hash_including(destination: destination)
                                  ).and_call_original
 

--- a/spec/lib/metasploit/cache/exploit/instance/load_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/load_spec.rb
@@ -1,0 +1,548 @@
+RSpec.describe Metasploit::Cache::Exploit::Instance::Load, type: :model do
+  include_context 'Metasploit::Cache::Spec::Unload.unload'
+
+  let(:logger) {
+    ActiveSupport::TaggedLogging.new(
+        Logger.new(log_string_io)
+    )
+  }
+
+  let(:log_string_io) {
+    StringIO.new
+  }
+
+  context 'validations' do
+    let(:exploit_instance_load) {
+      described_class.new
+    }
+
+    let(:error) {
+      I18n.translate!('errors.messages.blank')
+    }
+
+    it 'validates presence of #exploit_instance' do
+      exploit_instance_load.exploit_instance = nil
+
+      expect(exploit_instance_load).not_to be_valid
+      expect(exploit_instance_load.errors[:exploit_instance]).to include(error)
+    end
+
+    it 'validates presence of #exploit_metasploit_module_class' do
+      exploit_instance_load.exploit_metasploit_module_class = nil
+
+      expect(exploit_instance_load).not_to be_valid
+      expect(exploit_instance_load.errors[:exploit_metasploit_module_class]).to include(error)
+    end
+
+    it 'validates presence of #logger' do
+      exploit_instance_load.logger = nil
+
+      expect(exploit_instance_load).not_to be_valid
+      expect(exploit_instance_load.errors[:logger]).to include(error)
+    end
+
+    context 'on #exploit_metasploit_module_instance' do
+      context 'presence' do
+        #
+        # lets
+        #
+
+        let(:error) {
+          I18n.translate!('errors.messages.blank')
+        }
+
+        #
+        # Callbacks
+        #
+
+        before(:each) do
+          allow(exploit_instance_load).to receive(
+            :exploit_metasploit_module_instance
+          ).and_return(
+            exploit_metasploit_module_instance
+          )
+
+          exploit_instance_load.valid?(validation_context)
+        end
+
+        context 'with :loading validation context' do
+          let(:validation_context) {
+            :loading
+          }
+
+          context 'with nil' do
+            let(:exploit_metasploit_module_instance) {
+              nil
+            }
+
+            it 'does not add error on :exploit_metasploit_module_instance' do
+              expect(exploit_instance_load.errors[:exploit_metasploit_module_instance]).not_to include(error)
+            end
+          end
+        end
+
+        context 'without :loading validation context' do
+          let(:validation_context) {
+            nil
+          }
+
+          context 'with nil' do
+            let(:exploit_metasploit_module_instance) {
+              nil
+            }
+
+            it 'adds error on :exploit_metasploit_module_instance' do
+              expect(exploit_instance_load.errors[:exploit_metasploit_module_instance]).to include(error)
+            end
+          end
+        end
+      end
+    end
+
+    context '#exploit_metasploit_module_class_new_valid' do
+      #
+      # lets
+      #
+
+      let(:exploit_instance) {
+        FactoryGirl.build(:metasploit_cache_exploit_instance)
+      }
+
+      let(:exploit_instance_load) {
+        described_class.new(
+            exploit_instance: exploit_instance,
+            exploit_metasploit_module_class: exploit_metasploit_module_class,
+            logger: logger
+        )
+      }
+
+      let(:exploit_metasploit_module_class) {
+        Class.new.tap { |klass|
+          # Uncovered because all targets have arch
+          # :nocov:
+          klass.send(:define_method, :arch) {
+            []
+          }
+          # :nocov:
+
+          authors = exploit_instance.contributions.map { |contribution|
+            double(
+                'Metasploit Module author',
+                name: contribution.author.name,
+                email: contribution.try(:email_address).try(:full)
+            )
+          }
+
+          klass.send(:define_method, :author) {
+            authors
+          }
+
+          klass.send(:define_method, :default_target) {
+            nil
+          }
+
+          description = exploit_instance.description
+
+          klass.send(:define_method, :description) {
+            description
+          }
+
+          license = exploit_instance.licensable_licenses.map(&:license).map(&:abbreviation)
+
+          klass.send(:define_method, :license) {
+            license
+          }
+
+          name = exploit_instance.name
+
+          klass.send(:define_method, :name) {
+            name
+          }
+
+          # Not covered because all targets have platform
+          # :nocov:
+          klass.send(:define_method, :platform) {
+            double('exploit Metasploit Module instance', platforms: [])
+          }
+          # :nocov:
+
+          targets = exploit_instance.exploit_targets.map { |exploit_target|
+            double(
+                'exploit Metasploit Module instance target',
+                arch: exploit_target.architecturable_architectures.map(&:architecture).map(&:abbreviation),
+                name: exploit_target.name,
+                platform: double(
+                    'exploit Metasploit Module instance target platform list',
+                    platforms: exploit_target.platformable_platforms.map { |platformable_platform|
+                                 double(
+                                     'exploit Metapsloit Module instance target platform list platform',
+                                     realname: platformable_platform.platform.fully_qualified_name
+                                 )
+                               }
+                )
+            )
+          }
+
+          klass.send(:define_method, :targets) {
+            targets
+          }
+        }
+      }
+
+      let(:exploit_metasploit_module_class_new_errors) {
+        exploit_instance_load.valid?
+
+        exploit_instance_load.errors[:exploit_metasploit_module_class_new]
+      }
+
+      #
+      # Callbacks
+      #
+
+      before(:each) {
+        # memoize with methods with filled values from exploit_instance.
+        exploit_metasploit_module_class
+
+        # reset all associations and attributes, so load has to fill them
+        exploit_instance.contributions = []
+        exploit_instance.description = nil
+        exploit_instance.exploit_targets = []
+        exploit_instance.licensable_licenses = []
+        exploit_instance.name = nil
+
+        allow(exploit_instance_load).to receive(
+          :exploit_metasploit_module_class_new_exception
+        ).and_return(
+          exploit_metasploit_module_class_new_exception
+        )
+
+        exploit_instance_load.valid?
+      }
+
+      context 'with #exploit_metasploit_module_class_new_exception' do
+        let(:exploit_metasploit_module_class_new_exception) {
+          Exception.new("error message").tap { |exception|
+            exception.set_backtrace(
+                [
+                    "line 1",
+                    "line 2"
+                ]
+            )
+          }
+        }
+
+        it 'adds error' do
+          expect(exploit_metasploit_module_class_new_errors).to include(
+                                                                      "Exception error message:\n" \
+                                                                      "line 1\n" \
+                                                                      "line 2"
+                                                                  )
+        end
+      end
+
+      context 'without #exploit_metasploit_module_class_new_exception' do
+        let(:exploit_metasploit_module_class_new_exception) {
+          nil
+        }
+
+        it 'does not add error' do
+          expect(exploit_metasploit_module_class_new_errors).to be_empty
+        end
+      end
+    end
+  end
+
+  context '#exploit_metasploit_module_class_new' do
+    subject(:exploit_metasploit_module_class_new) {
+      exploit_instance_load.send(:exploit_metasploit_module_class_new)
+    }
+
+    let(:exploit_instance_load) {
+      described_class.new(
+          exploit_metasploit_module_class: exploit_metasploit_module_class
+      )
+    }
+
+    let(:exploit_metasploit_module_class) {
+      double('exploit Metasploit Module class')
+    }
+
+    context 'with Exception' do
+      before(:each) do
+        expect(exploit_metasploit_module_class).to receive(:new).and_raise(exception)
+      end
+
+      context 'with Interrupt' do
+        let(:exception) {
+          Interrupt.new
+        }
+
+        specify {
+          expect {
+            exploit_metasploit_module_class_new
+          }.to raise_error(Interrupt)
+        }
+      end
+
+      context 'without Interrupt' do
+        let(:exception) {
+          Exception.new("expected exception")
+        }
+
+        it 'does not raise exception' do
+          expect {
+            exploit_metasploit_module_class_new
+          }.not_to raise_error
+        end
+
+        it { is_expected.to be_nil }
+
+        it 'stores exception in #exploit_metasploit_module_class_new_exception' do
+          exploit_metasploit_module_class_new
+
+          expect(exploit_instance_load.exploit_metasploit_module_class_new_exception).to eq(exception)
+        end
+      end
+    end
+
+    context 'without Exception' do
+      #
+      # lets
+      #
+
+      let(:exploit_metasploit_module_instance) {
+        double('exploit Metasploit Module instance')
+      }
+
+      #
+      # Callbacks
+      #
+
+      before(:each) do
+        allow(exploit_metasploit_module_class).to receive(:new).and_return(exploit_metasploit_module_instance)
+      end
+
+      it 'returns new exploit Metasploit Module instance' do
+        expect(exploit_metasploit_module_class_new).to eq(exploit_metasploit_module_instance)
+      end
+    end
+  end
+
+  context '#exploit_metasploit_module_instance' do
+    subject(:exploit_metasploit_module_instance) {
+      exploit_instance_load.exploit_metasploit_module_instance
+    }
+
+    context 'with valid for loading' do
+      let(:exploit_instance_load) {
+        described_class.new(
+            exploit_instance: exploit_instance,
+            exploit_metasploit_module_class: exploit_metasploit_module_class,
+            logger: logger
+        )
+      }
+
+      context 'with exploit Metasploit Module instance' do
+        context 'with exploit instance persisted' do
+          #
+          # lets
+          #
+
+          let(:exploit_instance) {
+            FactoryGirl.build(
+                :metasploit_cache_exploit_instance,
+                :metasploit_cache_exploit_instance_exploit_class_ancestor_contents
+            ).tap { |block_exploit_instance|
+              # Clear out exploit attributes and associations so exploit_instance_load needs to set them.
+              block_exploit_instance.contributions = []
+              block_exploit_instance.description = nil
+              block_exploit_instance.licensable_licenses = []
+              block_exploit_instance.exploit_targets = []
+              block_exploit_instance.name = nil
+            }
+          }
+
+          let(:exploit_instance_load) {
+            expect(direct_class_load).to be_valid
+
+            described_class.new(
+                exploit_instance: exploit_instance,
+                logger: logger,
+                exploit_metasploit_module_class: direct_class_load.metasploit_class
+            )
+          }
+
+          let(:direct_class_load) {
+            expect(module_ancestor_load).to be_valid
+
+            Metasploit::Cache::Direct::Class::Load.new(
+                direct_class: exploit_instance.exploit_class,
+                logger: logger,
+                metasploit_module: module_ancestor_load.metasploit_module
+            )
+          }
+
+          let(:module_ancestor_load) {
+            Metasploit::Cache::Module::Ancestor::Load.new(
+                # This should match the major version number of metasploit-framework
+                maximum_version: 4,
+                module_ancestor: exploit_instance.exploit_class.ancestor,
+                logger: logger
+            )
+          }
+
+          it 'logs no errors' do
+            exploit_metasploit_module_instance
+
+            expect(log_string_io.string).to be_blank
+          end
+
+          it 'makes valid #exploit_instance' do
+            # Doesn't use change so that be_valid's printing is better
+            expect(exploit_instance).not_to be_valid
+
+            exploit_metasploit_module_instance
+
+            expect(exploit_instance).to be_valid
+          end
+
+          it 'persists #exploit_instance' do
+            expect {
+              exploit_metasploit_module_instance
+            }.to change(Metasploit::Cache::Exploit::Instance, :count).by(1)
+          end
+
+          it 'returns instance of exploit_metasploit_module_class' do
+            expect(exploit_metasploit_module_instance).to be_a direct_class_load.metasploit_class
+          end
+        end
+
+        context 'without exploit instance persisted' do
+          #
+          # lets
+          #
+
+          let(:exploit_instance) {
+            exploit_class.build_exploit_instance
+          }
+
+          let(:exploit_metasploit_module_class) {
+            Class.new do
+              #
+              # Attributes
+              #
+
+              attr_reader :default_target
+              attr_reader :description
+              attr_reader :license
+              attr_reader :name
+
+              #
+              # Instance Methods
+              #
+
+              # Uncovered because all targets have arch
+              # :nocov:
+              def arch
+                []
+              end
+              # :nocov:
+
+              def author
+                []
+              end
+
+              # Uncovered becasue all targets have platform
+              # :nocov:
+              def platform
+                OpenStruct.new(platforms: [])
+              end
+              # :nocov:
+
+              def targets
+                []
+              end
+            end
+          }
+
+          #
+          # let!s
+          #
+
+          let!(:exploit_class) {
+            FactoryGirl.create(:metasploit_cache_exploit_class)
+          }
+
+          it 'logs errors' do
+            exploit_metasploit_module_instance
+
+            expect(log_string_io.string).not_to be_blank
+          end
+
+          it { is_expected.to be_nil }
+        end
+      end
+
+      context 'without exploit Metasploit Module intance' do
+        let(:exploit_instance) {
+          Metasploit::Cache::Exploit::Instance.new
+        }
+
+        let(:exploit_metasploit_module_class) {
+          Class.new.tap { |klass|
+            klass.send(:define_method, :initialize) {
+              raise Exception
+            }
+          }
+        }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context 'without valid for loading' do
+      let(:exploit_instance_load) {
+        described_class.new
+      }
+
+      it { is_expected.to be_nil }
+
+      it 'is not memoized so it can run when valid for loading' do
+        expect(exploit_instance_load).to receive(:valid?).with(:loading).twice
+
+        exploit_instance_load.exploit_metasploit_module_instance
+        exploit_instance_load.exploit_metasploit_module_instance
+      end
+    end
+  end
+
+  context '#loading_context?' do
+    subject(:loading_context?) do
+      exploit_instance_load.send(:loading_context?)
+    end
+
+    let(:exploit_instance_load) {
+      described_class.new
+    }
+
+    context 'with :loading validation_context' do
+      it 'should be true' do
+        expect(exploit_instance_load).to receive(:run_validations!) do
+          expect(loading_context?).to eq(true)
+        end
+
+        exploit_instance_load.valid?(:loading)
+      end
+    end
+
+    context 'without validation_context' do
+      it 'should be false' do
+        expect(exploit_instance_load).to receive(:run_validations!) do
+          expect(loading_context?).to eq(false)
+        end
+
+        exploit_instance_load.valid?
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/platformable/ephemeral/platformable_platforms_spec.rb
+++ b/spec/lib/metasploit/cache/platformable/ephemeral/platformable_platforms_spec.rb
@@ -262,6 +262,51 @@ RSpec.describe Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
     end
   end
 
+  context 'reduce' do
+    subject(:reduce) {
+      described_class.reduce(
+          destination: destination,
+          destination_attribute_set: destination_attribute_set,
+          source_attribute_set: source_attribute_set
+      )
+    }
+
+    let(:destination) {
+      Metasploit::Cache::Encoder::Instance.new
+    }
+
+    let(:destination_attribute_set) {
+      Set.new
+    }
+
+    let(:source_attribute_set) {
+      Set.new [FactoryGirl.generate(:metasploit_cache_platform_fully_qualified_name)]
+    }
+
+    it 'calls build_added' do
+      expect(described_class).to receive(:build_added).with(
+                                     hash_including(
+                                         destination: destination,
+                                         destination_attribute_set: destination_attribute_set,
+                                         source_attribute_set: source_attribute_set
+                                     )
+                                 ).and_call_original
+
+      reduce
+    end
+
+    it 'calls mark_removed_for_destruction' do
+      expect(described_class).to receive(:mark_removed_for_destruction).with(
+                                     hash_including(
+                                         destination: destination,
+                                         destination_attribute_set: destination_attribute_set,
+                                         source_attribute_set: source_attribute_set                                     )
+                                 ).and_call_original
+
+      reduce
+    end
+  end
+
   context 'source_attribute_set' do
     subject(:source_attribute_set) {
       described_class.source_attribute_set(source)
@@ -325,16 +370,8 @@ RSpec.describe Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
       )
     }
 
-    it 'calls build_added' do
-      expect(described_class).to receive(:build_added).with(
-                                     hash_including(destination: destination)
-                                 )
-
-      synchronize
-    end
-
-    it 'calls mark_removed_for_destruction' do
-      expect(described_class).to receive(:mark_removed_for_destruction).with(
+    it 'calls reduce' do
+      expect(described_class).to receive(:reduce).with(
                                      hash_including(destination: destination)
                                  )
 


### PR DESCRIPTION
MSP-12443

`Metasploit::Cache::Exploit::Instance::Load` attaches a `ephemeral_cache_by_source` to the exploit Metasploit Module instance and populates `ephemeral_cache_by_source[:instance]` with a `Metasploit::Cache::Exploit::Instance::Ephemeral` before calling `Metasploit::Cache::Exploit::Instance::Ephemeral.persist` to create the `Metasploit::Cache::Exploit::Instance` in the database.

# Verification Steps

## Postgresql
- [x] `rm Gemfile.lock`
- [x] `bundle install --without sqlite3`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 100% coverage

### Documentation Coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
- [x] VERIFY no undocumented objects

## Sqlite3
- [x] `rm Gemfile.lock`
- [x] `bundle install --without postgresql`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 100% coverage

### Documentation coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [x] VERIFY no undocumented objects