### PR TITLE
Unset Metasploit::Cache::*::Instance#default_action when Metasploit Module instance #default_action is nil

### DIFF
--- a/lib/metasploit/cache/actionable/ephemeral/actions.rb
+++ b/lib/metasploit/cache/actionable/ephemeral/actions.rb
@@ -113,13 +113,13 @@ module Metasploit::Cache::Actionable::Ephemeral::Actions
   # @param source (see #source_attribute_set)
   # @return [#default_action] `destination`
   def self.update_default_action(destination:, source:)
+    # reset to `nil` because if source_default_action_name may be invalid and name an undeclared action not in
+    # destination.actions or there may just be no default action anymore.
+    destination.default_action = nil
+
     cached_source_default_action_name = source_default_action_name(source)
 
     if cached_source_default_action_name
-      # reset to `nil` because if source_default_action_name may be invalid and name an undeclared action not in
-      # destination.actions.
-      destination.default_action = nil
-
       destination.actions.each do |action|
         if action.name == cached_source_default_action_name
           destination.default_action = action

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,7 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 68
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'unset-default-action'
 
 
       #

--- a/spec/lib/metasploit/cache/actionable/ephemeral/actions_spec.rb
+++ b/spec/lib/metasploit/cache/actionable/ephemeral/actions_spec.rb
@@ -557,7 +557,15 @@ RSpec.describe Metasploit::Cache::Actionable::Ephemeral::Actions do
     end
 
     context 'without #source_default_action_name' do
+      let(:source_default_action_name) {
+        nil
+      }
 
+      it 'sets destination.default_action to nil' do
+        expect {
+          update_default_action
+        }.to change(destination, :default_action).to(nil)
+      end
     end
   end
 end

--- a/spec/lib/metasploit/cache/actionable/ephemeral/actions_spec.rb
+++ b/spec/lib/metasploit/cache/actionable/ephemeral/actions_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe Metasploit::Cache::Actionable::Ephemeral::Actions do
     it 'calls mark_removed_for_destruction' do
       expect(described_class).to receive(:mark_removed_for_destruction).with(
                                      hash_including(destination: destination)
-                                 )
+                                 ).and_call_original
 
       synchronize
     end
@@ -485,7 +485,7 @@ RSpec.describe Metasploit::Cache::Actionable::Ephemeral::Actions do
     it 'calls build_added' do
       expect(described_class).to receive(:build_added).with(
                                      hash_including(destination: destination)
-                                 )
+                                 ).and_call_original
 
       synchronize
     end
@@ -493,7 +493,7 @@ RSpec.describe Metasploit::Cache::Actionable::Ephemeral::Actions do
     it 'calls update_default_action' do
       expect(described_class).to receive(:update_default_action).with(
                                      hash_including(destination: destination)
-                                 )
+                                 ).and_call_original
 
       synchronize
     end


### PR DESCRIPTION
MSP-13022

In `Metasploit::Cache::Actionable::Ephemeral::Actions.update_default_action`, `Metasploit::Cache::*::Instance#default_action` was only reset to `nil` if `source_default_action_name` did NOT return `nil`, which meant that if a Metasploit Module instance used to have a `#default_action` and then doesn't, the cache would not make the transition.

Now, always reset the `Metasploit::Cache::*::Instance#default_action` to `nil`.

# Verification Steps

## Postgresql
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without sqlite3`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 100% coverage

### Documentation Coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
- [ ] VERIFY no undocumented objects

## Sqlite3
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without postgresql`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 100% coverage

### Documentation coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [ ] VERIFY no undocumented objects