### PR TITLE
Separate collection elements with commas in cells

### DIFF
--- a/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor/show.erb
@@ -13,15 +13,15 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
 
   def actions
     [
-<%- actions.each do |action| -%>
-      OpenStruct.new(name: '<%= action.name %>'),
+<%- separate(actions, ',') do |action, separator| -%>
+      OpenStruct.new(name: '<%= action.name %>')<%= separator %>
 <%- end -%>
     ].freeze
   end
 
   def author
     [
-<%- contributions.each do |contribution| -%>
+<%- separate(contributions, ',') do |contribution, separator| -%>
   <%- email_address = contribution.email_address
 
       if email_address
@@ -30,7 +30,7 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
         email = "nil"
       end
   -%>
-      OpenStruct.new(name: '<%= contribution.author.name %>', email: <%= email %>)
+      OpenStruct.new(name: '<%= contribution.author.name %>', email: <%= email %>)<%= separator %>
 <%- end -%>
     ]
   end
@@ -49,8 +49,8 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
 
   def license
     [
-<%- licensable_licenses.each do |licensable_license| -%>
-      '<%= licensable_license.license.abbreviation %>'
+<%- separate(licensable_licenses, ',') do |licensable_license, separator| -%>
+      '<%= licensable_license.license.abbreviation %>'<%= separator %>
 <%- end -%>
     ]
   end

--- a/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor_cell.rb
+++ b/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor_cell.rb
@@ -16,6 +16,7 @@ class Metasploit::Cache::Auxiliary::Instance::AuxiliaryClass::AncestorCell < Cel
   extend ActiveSupport::Autoload
 
   include Cell::Twin::Properties
+  include Metasploit::Cache::AncestorCell
 
   autoload :Twin
 

--- a/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
@@ -13,15 +13,15 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
 
   def arch
     [
-<%- architecturable_architectures.each do |architecturable_architecture| -%>
-      '<%= architecturable_architecture.architecture.abbreviation %>'
+<%- separate(architecturable_architectures, ',') do |architecturable_architecture, separator| -%>
+      '<%= architecturable_architecture.architecture.abbreviation %>'<%= separator %>
 <%- end -%>
     ]
   end
 
   def author
     [
-<%- contributions.each do |contribution| -%>
+<%- separate(contributions, ',') do |contribution, separator| -%>
   <%- email_address = contribution.email_address
 
       if email_address
@@ -30,7 +30,7 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
         email = "nil"
       end
   -%>
-      OpenStruct.new(name: '<%= contribution.author.name %>', email: <%= email %>)
+      OpenStruct.new(name: '<%= contribution.author.name %>', email: <%= email %>)<%= separator %>
 <%- end -%>
     ]
   end
@@ -41,8 +41,8 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
 
   def license
     [
-<%- licensable_licenses.each do |licensable_license| -%>
-      '<%= licensable_license.license.abbreviation %>'
+<%- separate(licensable_licenses, ',') do |licensable_license, separator| -%>
+      '<%= licensable_license.license.abbreviation %>'<%= separator %>
 <%- end -%>
     ]
   end
@@ -54,8 +54,8 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   def platform
     OpenStruct.new(
       platforms: [
-<%- platformable_platforms.each do |platformable_platform| -%>
-        OpenStruct.new(realname: '<%= platformable_platform.platform.fully_qualified_name %>')
+<%- separate(platformable_platforms, ',') do |platformable_platform, separator| -%>
+        OpenStruct.new(realname: '<%= platformable_platform.platform.fully_qualified_name %>')<%= separator %>
 <%- end -%>
       ]
     )

--- a/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor_cell.rb
+++ b/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor_cell.rb
@@ -16,6 +16,7 @@ class Metasploit::Cache::Encoder::Instance::EncoderClass::AncestorCell < Cell::V
   extend ActiveSupport::Autoload
 
   include Cell::Twin::Properties
+  include Metasploit::Cache::AncestorCell
 
   autoload :Twin
 

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -26,6 +26,7 @@ module Metasploit
     extend ActiveSupport::Autoload
 
     autoload :Actionable
+    autoload :AncestorCell
     autoload :Architecture
     autoload :Architecturable
     autoload :Association

--- a/lib/metasploit/cache/ancestor_cell.rb
+++ b/lib/metasploit/cache/ancestor_cell.rb
@@ -1,0 +1,33 @@
+# Helpers for `Metasploit::Cache::*::AncestorCell`s
+module Metasploit::Cache::AncestorCell
+  # Enumerates `enumerable` giving `separator` for each element except the last so that comma separated lists can be
+  # rendered more easily
+  #
+  # @example separate actions to form a ruby array
+  #     [
+  #     <%- separate(actions, ',') do |action, separator| -%>
+  #       OpenStruct.new(name: '<%= action.name %>')<%= separator %>
+  #     <%- end -%>
+  #     ]
+  #
+  # @param enumerable [Enumerable, #length, #each_with_index]
+  # @param separator [String] separator to yield for every element except the last
+  # @yield [element, element_separator]
+  # @yieldparam element [Object] element of `enumerable`.
+  # @yieldparam element_separator [String] `separator` if `element` is not the last element; otherwise, `''`
+  # @yieldreturn [void]
+  # @return [void]
+  def separate(enumerable, separator)
+    last_index = enumerable.length - 1
+
+    enumerable.each_with_index do |element, index|
+      if index == last_index
+        element_separator = ''.freeze
+      else
+        element_separator = separator
+      end
+
+      yield element, element_separator
+    end
+  end
+end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,8 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 68
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
-
+      PATCH = 1
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'cell-comma-separation'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/actionable/action_spec.rb
+++ b/spec/app/models/metasploit/cache/actionable/action_spec.rb
@@ -29,42 +29,6 @@ RSpec.describe Metasploit::Cache::Actionable::Action do
         expect(metasploit_cache_actionable_action.actionable).to be_nil
       end
     end
-
-    context 'metasploit_cache_auxiliary_action' do
-      subject(:metasploit_cache_auxiliary_action) {
-        FactoryGirl.build(:metasploit_cache_auxiliary_action)
-      }
-
-      it { is_expected.to be_valid }
-
-      it { is_expected.to be_a described_class }
-
-      context '#actionable' do
-        subject(:actionable) {
-          metasploit_cache_auxiliary_action.actionable
-        }
-
-        it { is_expected.to be_a Metasploit::Cache::Auxiliary::Instance }
-      end
-    end
-
-    context 'metasploit_cache_post_action' do
-      subject(:metasploit_cache_post_action) {
-        FactoryGirl.build(:metasploit_cache_post_action)
-      }
-
-      it { is_expected.to be_valid }
-
-      it { is_expected.to be_a described_class }
-
-      context '#actionable' do
-        subject(:actionable) {
-          metasploit_cache_post_action.actionable
-        }
-
-        it { is_expected.to be_a Metasploit::Cache::Post::Instance }
-      end
-    end
   end
 
   context 'validations' do
@@ -95,7 +59,7 @@ RSpec.describe Metasploit::Cache::Actionable::Action do
 
       let!(:existing_actionable_action) {
         FactoryGirl.create(
-            :metasploit_cache_auxiliary_action,
+            :metasploit_cache_actionable_action,
             actionable: existing_actionable,
             name: existing_name
         )
@@ -106,7 +70,7 @@ RSpec.describe Metasploit::Cache::Actionable::Action do
           context 'with same #name' do
             let(:new_actionable_action) {
               FactoryGirl.build(
-                  :metasploit_cache_auxiliary_action,
+                  :metasploit_cache_actionable_action,
                   actionable: existing_actionable,
                   name: existing_name
               )
@@ -141,7 +105,7 @@ RSpec.describe Metasploit::Cache::Actionable::Action do
           context 'with different #name' do
             let(:new_actionable_action) {
               FactoryGirl.build(
-                  :metasploit_cache_auxiliary_action,
+                  :metasploit_cache_actionable_action,
                   actionable: existing_actionable
               )
             }
@@ -157,14 +121,15 @@ RSpec.describe Metasploit::Cache::Actionable::Action do
         context 'with different #actionable_id' do
           let!(:new_actionable) {
             FactoryGirl.build(
-                :metasploit_cache_auxiliary_action
+                :metasploit_cache_actionable_action,
+                actionable: FactoryGirl.build(:metasploit_cache_auxiliary_instance)
             )
           }
 
           context 'with same #name' do
             let(:new_actionable_action) {
               FactoryGirl.build(
-                  :metasploit_cache_auxiliary_action,
+                  :metasploit_cache_actionable_action,
                   actionable: new_actionable,
                   name: existing_name
               )
@@ -180,7 +145,7 @@ RSpec.describe Metasploit::Cache::Actionable::Action do
           context 'with different #name' do
             let(:new_actionable_action) {
               FactoryGirl.build(
-                  :metasploit_cache_auxiliary_action,
+                  :metasploit_cache_actionable_action,
                   actionable: new_actionable
               )
             }

--- a/spec/app/models/metasploit/cache/actionable/action_spec.rb
+++ b/spec/app/models/metasploit/cache/actionable/action_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Metasploit::Cache::Actionable::Action do
   end
 
   context 'factories' do
+    context 'metapsloit_cache_actionable_action' do
+      subject(:metasploit_cache_actionable_action) {
+        FactoryGirl.build(:metasploit_cache_actionable_action)
+      }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has nil #actioanble' do
+        expect(metasploit_cache_actionable_action.actionable).to be_nil
+      end
+    end
+
     context 'metasploit_cache_auxiliary_action' do
       subject(:metasploit_cache_auxiliary_action) {
         FactoryGirl.build(:metasploit_cache_auxiliary_action)

--- a/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe Metasploit::Cache::Architecturable::Architecture do
   end
 
   context 'factories' do
+    context 'metasploit_cache_architecturable_architecture' do
+      subject(:metasploit_cache_architecturable_architecture) {
+        FactoryGirl.build(:metasploit_cache_architecturable_architecture)
+      }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has nil #architecturable' do
+        expect(metasploit_cache_architecturable_architecture.architecturable).to be_nil
+      end
+    end
+
     context 'metasploit_cache_encoder_architecture' do
       subject(:metasploit_cache_encoder_architecture) {
         FactoryGirl.build(:metasploit_cache_encoder_architecture)

--- a/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
+++ b/spec/app/models/metasploit/cache/architecturable/architecture_spec.rb
@@ -30,62 +30,6 @@ RSpec.describe Metasploit::Cache::Architecturable::Architecture do
         expect(metasploit_cache_architecturable_architecture.architecturable).to be_nil
       end
     end
-
-    context 'metasploit_cache_encoder_architecture' do
-      subject(:metasploit_cache_encoder_architecture) {
-        FactoryGirl.build(:metasploit_cache_encoder_architecture)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_exploit_target_architecture' do
-      subject(:metasploit_cache_exploit_target_architecture) {
-        FactoryGirl.build(:metasploit_cache_exploit_target_architecture)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_nop_architecture' do
-      subject(:metasploit_cache_nop_architecture) {
-        FactoryGirl.build(:metasploit_cache_nop_architecture)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_payload_single_architecture' do
-      subject(:metasploit_cache_payload_single_architecture) {
-        FactoryGirl.build(:metasploit_cache_payload_single_architecture)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_payload_stage_architecture' do
-      subject(:metasploit_cache_payload_stage_architecture) {
-        FactoryGirl.build(:metasploit_cache_payload_stage_architecture)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_payload_stager_architecture' do
-      subject(:metasploit_cache_payload_stager_architecture) {
-        FactoryGirl.build(:metasploit_cache_payload_stager_architecture)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_post_architecture' do
-      subject(:metasploit_cache_post_architecture) {
-        FactoryGirl.build(:metasploit_cache_post_architecture)
-      }
-
-      it { is_expected.to be_valid }
-    end
   end
 
   context 'validations' do
@@ -94,7 +38,10 @@ RSpec.describe Metasploit::Cache::Architecturable::Architecture do
 
     context 'with pre-existing record' do
       let!(:existing_architecturable_architecture) {
-        FactoryGirl.create(:metasploit_cache_encoder_architecture)
+        FactoryGirl.create(
+            :metasploit_cache_architecturable_architecture,
+            architecturable: FactoryGirl.build(:metasploit_cache_encoder_instance)
+        )
       }
 
       it { is_expected.to validate_uniqueness_of(:architecture_id).scoped_to(:architecturable_type, :architecturable_id) }

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
               end
 
               context 'with multiple elements in each association' do
+                include_context 'Metasploit::Cache::Spec::Unload.unload'
+
                 subject(:metasploit_cache_auxiliary_instance) {
                   FactoryGirl.build(
                       :metasploit_cache_auxiliary_instance,
@@ -153,12 +155,12 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
                   module_instance_load.valid?
 
                   expect(metasploit_cache_auxiliary_instance).to be_valid
-                  expect(metasploit_cache_auxiliary_instance_load).to be_valid
+                  expect(module_instance_load).to be_valid
                   expect(metasploit_cache_auxiliary_instance).to be_persisted
 
                   expect(metasploit_cache_auxiliary_instance.actions.count).to eq(action_count)
                   expect(metasploit_cache_auxiliary_instance.contributions.count).to eq(contribution_count)
-                  expect(metasploit_cache_auxiliary_instance.licensable_liceneses.count).to eq(licensable_license_count)
+                  expect(metasploit_cache_auxiliary_instance.licensable_licenses.count).to eq(licensable_license_count)
                 end
               end
             end

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe Metasploit::Cache::Contribution do
   end
   
   context 'factories' do
+    context 'metasploit_cache_contribution' do
+      subject(:metasploit_cache_contribution) {
+        FactoryGirl.build(:metasploit_cache_contribution)
+      }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has nil #contributable' do
+        expect(metasploit_cache_contribution.contributable).to be_nil
+      end
+    end
+
     context 'metasploit_cache_auxiliary_contribution' do
       subject(:metasploit_cache_auxiliary_contribution) {
         FactoryGirl.build(:metasploit_cache_auxiliary_contribution)

--- a/spec/app/models/metasploit/cache/contribution_spec.rb
+++ b/spec/app/models/metasploit/cache/contribution_spec.rb
@@ -36,134 +36,6 @@ RSpec.describe Metasploit::Cache::Contribution do
         expect(metasploit_cache_contribution.contributable).to be_nil
       end
     end
-
-    context 'metasploit_cache_auxiliary_contribution' do
-      subject(:metasploit_cache_auxiliary_contribution) {
-        FactoryGirl.build(:metasploit_cache_auxiliary_contribution)
-      }
-      
-      it { is_expected.to be_valid }
-      
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_auxiliary_contribution.contributable
-        }
-        
-        it { is_expected.to be_a Metasploit::Cache::Auxiliary::Instance }
-      end
-    end
-    
-    context 'metasploit_cache_encoder_contribution' do
-      subject(:metasploit_cache_encoder_contribution) {
-        FactoryGirl.build(:metasploit_cache_encoder_contribution)
-      }
-      
-      it { is_expected.to be_valid }
-      
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_encoder_contribution.contributable
-        }
-        
-        it { is_expected.to be_a Metasploit::Cache::Encoder::Instance }
-      end
-    end   
-    
-    context 'metasploit_cache_exploit_contribution' do
-      subject(:metasploit_cache_exploit_contribution) {
-        FactoryGirl.build(:metasploit_cache_exploit_contribution)
-      }
-      
-      it { is_expected.to be_valid }
-      
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_exploit_contribution.contributable
-        }
-        
-        it { is_expected.to be_a Metasploit::Cache::Exploit::Instance }
-      end
-    end
-    
-    context 'metasploit_cache_nop_contribution' do
-      subject(:metasploit_cache_nop_contribution) {
-        FactoryGirl.build(:metasploit_cache_nop_contribution)
-      }
-      
-      it { is_expected.to be_valid }
-      
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_nop_contribution.contributable
-        }
-        
-        it { is_expected.to be_a Metasploit::Cache::Nop::Instance }
-      end
-    end
-
-    context 'metasploit_cache_payload_single_contribution' do
-      subject(:metasploit_cache_payload_single_contribution) {
-        FactoryGirl.build(:metasploit_cache_payload_single_contribution)
-      }
-
-      it { is_expected.to be_valid }
-
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_payload_single_contribution.contributable
-        }
-
-        it { is_expected.to be_a Metasploit::Cache::Payload::Single::Instance }
-      end
-    end
-
-    context 'metasploit_cache_payload_stage_contribution' do
-      subject(:metasploit_cache_payload_stage_contribution) {
-        FactoryGirl.build(:metasploit_cache_payload_stage_contribution)
-      }
-
-      it { is_expected.to be_valid }
-
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_payload_stage_contribution.contributable
-        }
-
-        it { is_expected.to be_a Metasploit::Cache::Payload::Stage::Instance }
-      end
-    end
-
-    context 'metasploit_cache_payload_stager_contribution' do
-      subject(:metasploit_cache_payload_stager_contribution) {
-        FactoryGirl.build(:metasploit_cache_payload_stager_contribution)
-      }
-
-      it { is_expected.to be_valid }
-
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_payload_stager_contribution.contributable
-        }
-
-        it { is_expected.to be_a Metasploit::Cache::Payload::Stager::Instance }
-      end
-    end
-
-    context 'metasploit_cache_post_contribution' do
-      subject(:metasploit_cache_post_contribution) {
-        FactoryGirl.build(:metasploit_cache_post_contribution)
-      }
-
-      it { is_expected.to be_valid }
-
-      context '#contributable' do
-        subject(:contributable) {
-          metasploit_cache_post_contribution.contributable
-        }
-
-        it { is_expected.to be_a Metasploit::Cache::Post::Instance }
-      end
-    end
   end
 
   context 'validations' do
@@ -172,7 +44,11 @@ RSpec.describe Metasploit::Cache::Contribution do
 
     context 'with existing record' do
       let!(:existing_contribution) {
-        FactoryGirl.create(:metasploit_cache_auxiliary_contribution, :metasploit_cache_contribution_email_address)
+        FactoryGirl.create(
+            :metasploit_cache_contribution,
+            :metasploit_cache_contribution_email_address,
+            contributable: FactoryGirl.build(:metasploit_cache_auxiliary_instance)
+        )
       }
 
       it { is_expected.to validate_uniqueness_of(:author_id).scoped_to([:contributable_type, :contributable_id]) }
@@ -196,7 +72,11 @@ RSpec.describe Metasploit::Cache::Contribution do
       #
 
       let!(:first_contribution) {
-        FactoryGirl.create(:metasploit_cache_auxiliary_contribution, :metasploit_cache_contribution_email_address)
+        FactoryGirl.create(
+            :metasploit_cache_contribution,
+            :metasploit_cache_contribution_email_address,
+            contributable: FactoryGirl.build(:metasploit_cache_auxiliary_instance)
+        )
       }
 
       context 'with same #email_address' do
@@ -208,7 +88,7 @@ RSpec.describe Metasploit::Cache::Contribution do
 
             let(:second_contribution) {
               FactoryGirl.build(
-                  :metasploit_cache_auxiliary_contribution,
+                  :metasploit_cache_contribution,
                   contributable: first_contribution.contributable,
                   email_address: first_contribution.email_address
               )
@@ -232,7 +112,8 @@ RSpec.describe Metasploit::Cache::Contribution do
 
             let(:second_contribution) {
               FactoryGirl.build(
-                  :metasploit_cache_auxiliary_contribution,
+                  :metasploit_cache_contribution,
+                  contributable: FactoryGirl.build(:metasploit_cache_auxiliary_instance),
                   email_address: first_contribution.email_address
               )
             }
@@ -257,8 +138,9 @@ RSpec.describe Metasploit::Cache::Contribution do
 
             let(:second_contribution) {
               FactoryGirl.build(
-                  :metasploit_cache_encoder_contribution,
+                  :metasploit_cache_contribution,
                   contributable_id: first_contribution.contributable_id,
+                  contributable_type: 'Metasploit::Cache::Encoder::Instance',
                   email_address: first_contribution.email_address
               )
             }
@@ -281,7 +163,8 @@ RSpec.describe Metasploit::Cache::Contribution do
 
             let(:second_contribution) {
               FactoryGirl.build(
-                  :metasploit_cache_encoder_contribution,
+                  :metasploit_cache_contribution,
+                  contributable: FactoryGirl.build(:metasploit_cache_encoder_instance),
                   email_address: first_contribution.email_address
               )
             }
@@ -302,7 +185,8 @@ RSpec.describe Metasploit::Cache::Contribution do
       context 'without #email_address' do
         let(:second_contribution) {
           FactoryGirl.build(
-              :metasploit_cache_encoder_contribution,
+              :metasploit_cache_contribution,
+              contributable: FactoryGirl.build(:metasploit_cache_encoder_instance),
               email_address: nil
           )
         }

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metasploit::Cache::Encoder::Instance do
+RSpec.describe Metasploit::Cache::Encoder::Instance, type: :model do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Metasploit::Cache::Encoder::Instance, type: :model do
               }
 
               let(:relative_path) {
-                "encoder/#{reference_name}#{Metasploit::Cache::Module::Ancestor::EXTENSION}"
+                "encoders/#{reference_name}#{Metasploit::Cache::Module::Ancestor::EXTENSION}"
               }
 
               it 'writes encoder Metasploit Module to #real_pathname' do

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -32,8 +32,80 @@ RSpec.describe Metasploit::Cache::Licensable::License do
   end
 
   context "factories" do
-    subject(:metasploit_cache_licensable_license){ FactoryGirl.build :metasploit_cache_auxiliary_license }
-
-    it { is_expected.to be_valid }
+    context 'metasploit_cache_licensable_license' do
+      subject(:metasploit_cache_licensable_license) {
+        FactoryGirl.build(:metasploit_cache_licensable_license)
+      }
+      
+      it { is_expected.not_to be_valid }
+      
+      it 'has nil #licensable' do
+        expect(metasploit_cache_licensable_license.licensable).to be_nil
+      end
+    end
+    
+    context 'metasploit_cache_auxiliary_license' do
+      subject(:metasploit_cache_auxiliary_license) {
+        FactoryGirl.build(:metasploit_cache_auxiliary_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end
+     
+    context 'metasploit_cache_encoder_license' do
+      subject(:metasploit_cache_encoder_license) {
+        FactoryGirl.build(:metasploit_cache_encoder_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end   
+     
+    context 'metasploit_cache_exploit_license' do
+      subject(:metasploit_cache_exploit_license) {
+        FactoryGirl.build(:metasploit_cache_exploit_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end   
+     
+    context 'metasploit_cache_nop_license' do
+      subject(:metasploit_cache_nop_license) {
+        FactoryGirl.build(:metasploit_cache_nop_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end   
+     
+    context 'metasploit_cache_payload_single_license' do
+      subject(:metasploit_cache_payload_single_license) {
+        FactoryGirl.build(:metasploit_cache_payload_single_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end   
+     
+    context 'metasploit_cache_payload_stage_license' do
+      subject(:metasploit_cache_payload_stage_license) {
+        FactoryGirl.build(:metasploit_cache_payload_stage_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end   
+    
+    context 'metasploit_cache_payload_stager_license' do
+      subject(:metasploit_cache_payload_stager_license) {
+        FactoryGirl.build(:metasploit_cache_payload_stager_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end    
+        
+    context 'metasploit_cache_post_license' do
+      subject(:metasploit_cache_post_license) {
+        FactoryGirl.build(:metasploit_cache_post_license)
+      }
+      
+      it { is_expected.to be_valid }
+    end
   end
 end

--- a/spec/app/models/metasploit/cache/licensable/license_spec.rb
+++ b/spec/app/models/metasploit/cache/licensable/license_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe Metasploit::Cache::Licensable::License do
 
     context 'with existing record' do
       let!(:existing_licensable_license) {
-        FactoryGirl.create(:metasploit_cache_auxiliary_license)
+        FactoryGirl.create(
+            :metasploit_cache_licensable_license,
+            licensable: FactoryGirl.build(:metasploit_cache_auxiliary_instance)
+        )
       }
 
       it { is_expected.to validate_uniqueness_of(:license_id).scoped_to(:licensable_type, :licensable_id) }
@@ -42,70 +45,6 @@ RSpec.describe Metasploit::Cache::Licensable::License do
       it 'has nil #licensable' do
         expect(metasploit_cache_licensable_license.licensable).to be_nil
       end
-    end
-    
-    context 'metasploit_cache_auxiliary_license' do
-      subject(:metasploit_cache_auxiliary_license) {
-        FactoryGirl.build(:metasploit_cache_auxiliary_license)
-      }
-      
-      it { is_expected.to be_valid }
-    end
-     
-    context 'metasploit_cache_encoder_license' do
-      subject(:metasploit_cache_encoder_license) {
-        FactoryGirl.build(:metasploit_cache_encoder_license)
-      }
-      
-      it { is_expected.to be_valid }
-    end   
-     
-    context 'metasploit_cache_exploit_license' do
-      subject(:metasploit_cache_exploit_license) {
-        FactoryGirl.build(:metasploit_cache_exploit_license)
-      }
-      
-      it { is_expected.to be_valid }
-    end   
-     
-    context 'metasploit_cache_nop_license' do
-      subject(:metasploit_cache_nop_license) {
-        FactoryGirl.build(:metasploit_cache_nop_license)
-      }
-      
-      it { is_expected.to be_valid }
-    end   
-     
-    context 'metasploit_cache_payload_single_license' do
-      subject(:metasploit_cache_payload_single_license) {
-        FactoryGirl.build(:metasploit_cache_payload_single_license)
-      }
-      
-      it { is_expected.to be_valid }
-    end   
-     
-    context 'metasploit_cache_payload_stage_license' do
-      subject(:metasploit_cache_payload_stage_license) {
-        FactoryGirl.build(:metasploit_cache_payload_stage_license)
-      }
-      
-      it { is_expected.to be_valid }
-    end   
-    
-    context 'metasploit_cache_payload_stager_license' do
-      subject(:metasploit_cache_payload_stager_license) {
-        FactoryGirl.build(:metasploit_cache_payload_stager_license)
-      }
-      
-      it { is_expected.to be_valid }
-    end    
-        
-    context 'metasploit_cache_post_license' do
-      subject(:metasploit_cache_post_license) {
-        FactoryGirl.build(:metasploit_cache_post_license)
-      }
-      
-      it { is_expected.to be_valid }
     end
   end
 end

--- a/spec/app/models/metasploit/cache/platformable/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platformable/platform_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Metasploit::Cache::Platformable::Platform do
   end
 
   context 'factories' do
+    context 'metasploit_cache_platformable_platform' do
+      subject(:metasploit_cache_platformable_platform) {
+        FactoryGirl.build(:metasploit_cache_platformable_platform)
+      }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has nil #platformable' do
+        expect(metasploit_cache_platformable_platform.platformable).to be_nil
+      end
+    end
+
     context 'metasploit_cache_encoder_platform' do
       subject(:metasploit_cache_encoder_platform) {
         FactoryGirl.build(:metasploit_cache_encoder_platform)

--- a/spec/app/models/metasploit/cache/platformable/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platformable/platform_spec.rb
@@ -32,62 +32,6 @@ RSpec.describe Metasploit::Cache::Platformable::Platform do
         expect(metasploit_cache_platformable_platform.platformable).to be_nil
       end
     end
-
-    context 'metasploit_cache_encoder_platform' do
-      subject(:metasploit_cache_encoder_platform) {
-        FactoryGirl.build(:metasploit_cache_encoder_platform)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_exploit_target_platform' do
-      subject(:metasploit_cache_exploit_target_platform) {
-        FactoryGirl.build(:metasploit_cache_exploit_target_platform)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_nop_platform' do
-      subject(:metasploit_cache_nop_platform) {
-        FactoryGirl.build(:metasploit_cache_nop_platform)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_payload_single_platform' do
-      subject(:metasploit_cache_payload_single_platform) {
-        FactoryGirl.build(:metasploit_cache_payload_single_platform)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_payload_stage_platform' do
-      subject(:metasploit_cache_payload_stage_platform) {
-        FactoryGirl.build(:metasploit_cache_payload_stage_platform)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_payload_stager_platform' do
-      subject(:metasploit_cache_payload_stager_platform) {
-        FactoryGirl.build(:metasploit_cache_payload_stager_platform)
-      }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'metasploit_cache_post_platform' do
-      subject(:metasploit_cache_post_platform) {
-        FactoryGirl.build(:metasploit_cache_post_platform)
-      }
-
-      it { is_expected.to be_valid }
-    end
   end
 
   context 'validations' do
@@ -96,7 +40,10 @@ RSpec.describe Metasploit::Cache::Platformable::Platform do
 
     context 'with pre-existing record' do
       let!(:existing_platformable_platform) {
-        FactoryGirl.create(:metasploit_cache_encoder_platform)
+        FactoryGirl.create(
+            :metasploit_cache_platformable_platform,
+            platformable: FactoryGirl.build(:metasploit_cache_encoder_instance)
+        )
       }
 
       it { is_expected.to validate_uniqueness_of(:platform_id).scoped_to(:platformable_type, :platformable_id) }

--- a/spec/factories/metasploit/cache/actionable/actionable_actions.rb
+++ b/spec/factories/metasploit/cache/actionable/actionable_actions.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  trait :metasploit_cache_actionable_actions do
+    transient do
+      action_count 1
+    end
+
+    after(:build) do |actionable, evaluator|
+      actionable.actions = build_list(
+          :metasploit_cache_actionable_action,
+          evaluator.action_count,
+          actionable: actionable
+      )
+    end
+  end
+end

--- a/spec/factories/metasploit/cache/actionable/actions.rb
+++ b/spec/factories/metasploit/cache/actionable/actions.rb
@@ -3,16 +3,20 @@ FactoryGirl.define do
   # Factories
   #
 
-  factory :metasploit_cache_auxiliary_action,
-          class: Metasploit::Cache::Actionable::Action,
-          traits: [:metasploit_cache_actionable_action] do
-    association :actionable, factory: :metasploit_cache_auxiliary_instance
-  end
+  factory :metasploit_cache_actionable_action,
+          class: Metasploit::Cache::Actionable::Action do
+    # @note this factory is invalid unless caller sets actionable
+    actionable nil
 
-  factory :metasploit_cache_post_action,
-          class: Metasploit::Cache::Actionable::Action,
-          traits: [:metasploit_cache_actionable_action] do
-    association :actionable, factory: :metasploit_cache_post_instance
+    name { generate :metasploit_cache_actionable_action_name }
+
+    factory :metasploit_cache_auxiliary_action do
+      association :actionable, factory: :metasploit_cache_auxiliary_instance
+    end
+
+    factory :metasploit_cache_post_action do
+      association :actionable, factory: :metasploit_cache_post_instance
+    end
   end
 
   #
@@ -21,13 +25,5 @@ FactoryGirl.define do
 
   sequence :metasploit_cache_actionable_action_name do |n|
     "Metasploit::Cache::Actionable::Action#name #{n}"
-  end
-
-  #
-  # Traits
-  #
-
-  trait :metasploit_cache_actionable_action do
-    name { generate :metasploit_cache_actionable_action_name }
   end
 end

--- a/spec/factories/metasploit/cache/actionable/actions.rb
+++ b/spec/factories/metasploit/cache/actionable/actions.rb
@@ -9,14 +9,6 @@ FactoryGirl.define do
     actionable nil
 
     name { generate :metasploit_cache_actionable_action_name }
-
-    factory :metasploit_cache_auxiliary_action do
-      association :actionable, factory: :metasploit_cache_auxiliary_instance
-    end
-
-    factory :metasploit_cache_post_action do
-      association :actionable, factory: :metasploit_cache_post_instance
-    end
   end
 
   #

--- a/spec/factories/metasploit/cache/architecturable/architecturable_architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architecturable_architectures.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  trait :metasploit_cache_architecturable_architecturable_architectures do
+    transient do
+      architecturable_architecture_count 1
+    end
+
+    after(:build) do |architecturable, evaluator|
+      architecturable.architecturable_architectures = build_list(
+          :metasploit_cache_architecturable_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: architecturable
+      )
+    end
+  end
+end

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -3,67 +3,39 @@ FactoryGirl.define do
   # Factories
   #
 
-  factory :metasploit_cache_encoder_architecture,
-          class: Metasploit::Cache::Architecturable::Architecture,
-          traits: [
-              :metasploit_cache_architecturable_architecture
-          ] do
-    association :architecturable, factory: :metasploit_cache_encoder_instance
-  end
+  factory :metasploit_cache_architecturable_architecture,
+          class: Metasploit::Cache::Architecturable::Architecture do
+    # @note This factory is invalid unless `architecturable` is set by the caller
+    architecturable { nil }
 
-  factory :metasploit_cache_exploit_target_architecture,
-          class: Metasploit::Cache::Architecturable::Architecture,
-          traits: [
-              :metasploit_cache_architecturable_architecture
-          ] do
-    association :architecturable, factory: :metasploit_cache_exploit_target
-  end
-
-  factory :metasploit_cache_nop_architecture,
-          class: Metasploit::Cache::Architecturable::Architecture,
-          traits: [
-              :metasploit_cache_architecturable_architecture
-          ] do
-    association :architecturable, factory: :metasploit_cache_nop_instance
-  end
-
-  factory :metasploit_cache_payload_single_architecture,
-          class: Metasploit::Cache::Architecturable::Architecture,
-          traits: [
-              :metasploit_cache_architecturable_architecture
-          ] do
-    association :architecturable, factory: :metasploit_cache_payload_single_instance
-  end
-
-  factory :metasploit_cache_payload_stage_architecture,
-          class: Metasploit::Cache::Architecturable::Architecture,
-          traits: [
-              :metasploit_cache_architecturable_architecture
-          ] do
-    association :architecturable, factory: :metasploit_cache_payload_stage_instance
-  end
-
-  factory :metasploit_cache_payload_stager_architecture,
-          class: Metasploit::Cache::Architecturable::Architecture,
-          traits: [
-              :metasploit_cache_architecturable_architecture
-          ] do
-    association :architecturable, factory: :metasploit_cache_payload_stager_instance
-  end
-
-  factory :metasploit_cache_post_architecture,
-          class: Metasploit::Cache::Architecturable::Architecture,
-          traits: [
-              :metasploit_cache_architecturable_architecture
-          ] do
-    association :architecturable, factory: :metasploit_cache_post_instance
-  end
-
-  #
-  # Traits
-  #
-
-  trait :metasploit_cache_architecturable_architecture do
     architecture { generate :metasploit_cache_architecture }
+
+    factory :metasploit_cache_encoder_architecture do
+      association :architecturable, factory: :metasploit_cache_encoder_instance
+    end
+
+    factory  :metasploit_cache_exploit_target_architecture do
+      association :architecturable, factory: :metasploit_cache_exploit_target
+    end
+
+    factory :metasploit_cache_nop_architecture do
+      association :architecturable, factory: :metasploit_cache_nop_instance
+    end
+
+    factory :metasploit_cache_payload_single_architecture do
+      association :architecturable, factory: :metasploit_cache_payload_single_instance
+    end
+
+    factory :metasploit_cache_payload_stage_architecture do
+      association :architecturable, factory: :metasploit_cache_payload_stage_instance
+    end
+
+    factory :metasploit_cache_payload_stager_architecture do
+      association :architecturable, factory: :metasploit_cache_payload_stager_instance
+    end
+
+    factory :metasploit_cache_post_architecture do
+      association :architecturable, factory: :metasploit_cache_post_instance
+    end
   end
 end

--- a/spec/factories/metasploit/cache/architecturable/architectures.rb
+++ b/spec/factories/metasploit/cache/architecturable/architectures.rb
@@ -9,33 +9,5 @@ FactoryGirl.define do
     architecturable { nil }
 
     architecture { generate :metasploit_cache_architecture }
-
-    factory :metasploit_cache_encoder_architecture do
-      association :architecturable, factory: :metasploit_cache_encoder_instance
-    end
-
-    factory  :metasploit_cache_exploit_target_architecture do
-      association :architecturable, factory: :metasploit_cache_exploit_target
-    end
-
-    factory :metasploit_cache_nop_architecture do
-      association :architecturable, factory: :metasploit_cache_nop_instance
-    end
-
-    factory :metasploit_cache_payload_single_architecture do
-      association :architecturable, factory: :metasploit_cache_payload_single_instance
-    end
-
-    factory :metasploit_cache_payload_stage_architecture do
-      association :architecturable, factory: :metasploit_cache_payload_stage_instance
-    end
-
-    factory :metasploit_cache_payload_stager_architecture do
-      association :architecturable, factory: :metasploit_cache_payload_stager_instance
-    end
-
-    factory :metasploit_cache_post_architecture do
-      association :architecturable, factory: :metasploit_cache_post_instance
-    end
   end
 end

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -6,14 +6,12 @@ FactoryGirl.define do
   factory :metasploit_cache_auxiliary_instance,
           class: Metasploit::Cache::Auxiliary::Instance,
           traits: [
+              :metasploit_cache_auxiliary_instance_actions,
+              :metasploit_cache_auxiliary_instance_contributions,
+              :metasploit_cache_auxiliary_instance_licensable_licenses,
+              # Must be after all association traits so associations are built when writing contents
               :metasploit_cache_auxiliary_instance_auxiliary_class_ancestor_contents
           ] do
-    transient do
-      action_count 1
-      contribution_count 1
-      licensable_license_count 1
-    end
-
     description { generate :metasploit_cache_auxiliary_instance_description }
     name { generate :metasploit_cache_auxiliary_instance_name }
     stance { generate :metasploit_cache_module_stance }
@@ -23,34 +21,6 @@ FactoryGirl.define do
     #
 
     association :auxiliary_class, factory: :metasploit_cache_auxiliary_class
-
-    #
-    # Callbacks
-    #
-
-    # Create associated objects w/ the counts established above in the
-    # transient attributes. This enables specs using these factories to
-    # specify a number of associated objects and therefore easily make valid/invalid
-    # instances.
-    after(:build) { |auxiliary_instance, evaluator|
-      auxiliary_instance.actions = build_list(
-          :metasploit_cache_auxiliary_action,
-          evaluator.action_count,
-          actionable: auxiliary_instance
-      )
-      
-      auxiliary_instance.contributions = build_list(
-          :metasploit_cache_auxiliary_contribution,
-          evaluator.contribution_count,
-          contributable: auxiliary_instance
-      )
-      
-      auxiliary_instance.licensable_licenses = build_list(
-          :metasploit_cache_auxiliary_license,
-          evaluator.licensable_license_count,
-          licensable: auxiliary_instance
-      )
-    }
   end
 
   #
@@ -63,6 +33,76 @@ FactoryGirl.define do
 
   sequence :metasploit_cache_auxiliary_instance_name do |n|
     "Metasploit::Cache::Auxiliary::Instance#name #{n}"
+  end
+
+  #
+  # Traits
+  #
+
+  trait :metasploit_cache_auxiliary_instance_actions do
+    transient do
+      action_count 1
+    end
+
+    #
+    # Callbacks
+    #
+
+    # Create associated objects w/ the count established above in the
+    # transient attribute. This enables specs using these factories to
+    # specify a number of associated objects and therefore easily make valid/invalid
+    # instances.
+    after(:build) do |auxiliary_instance, evaluator|
+      auxiliary_instance.actions = build_list(
+          :metasploit_cache_auxiliary_action,
+          evaluator.action_count,
+          actionable: auxiliary_instance
+      )
+    end
+  end
+
+  trait :metasploit_cache_auxiliary_instance_contributions do
+    transient do
+      contribution_count 1
+    end
+
+    #
+    # Callbacks
+    #
+
+    # Create associated objects w/ the count established above in the
+    # transient attribute. This enables specs using these factories to
+    # specify a number of associated objects and therefore easily make valid/invalid
+    # instances.
+    after(:build) do |auxiliary_instance, evaluator|
+      auxiliary_instance.contributions = build_list(
+          :metasploit_cache_auxiliary_contribution,
+          evaluator.contribution_count,
+          contributable: auxiliary_instance
+      )
+    end
+  end
+
+  trait :metasploit_cache_auxiliary_instance_licensable_licenses do
+    transient do
+      licensable_license_count 1
+    end
+
+    #
+    # Callbacks
+    #
+
+    # Create associated objects w/ the count established above in the
+    # transient attribute. This enables specs using these factories to
+    # specify a number of associated objects and therefore easily make valid/invalid
+    # instances.
+    after(:build) do |auxiliary_instance, evaluator|
+      auxiliary_instance.licensable_licenses = build_list(
+          :metasploit_cache_auxiliary_license,
+          evaluator.licensable_license_count,
+          licensable: auxiliary_instance
+      )
+    end
   end
 
   #

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
           class: Metasploit::Cache::Auxiliary::Instance,
           traits: [
               :metasploit_cache_auxiliary_instance_actions,
-              :metasploit_cache_auxiliary_instance_contributions,
+              :metasploit_cache_contributable_contributions,
               :metasploit_cache_auxiliary_instance_licensable_licenses,
               # Must be after all association traits so associations are built when writing contents
               :metasploit_cache_auxiliary_instance_auxiliary_class_ancestor_contents
@@ -57,28 +57,6 @@ FactoryGirl.define do
           :metasploit_cache_auxiliary_action,
           evaluator.action_count,
           actionable: auxiliary_instance
-      )
-    end
-  end
-
-  trait :metasploit_cache_auxiliary_instance_contributions do
-    transient do
-      contribution_count 1
-    end
-
-    #
-    # Callbacks
-    #
-
-    # Create associated objects w/ the count established above in the
-    # transient attribute. This enables specs using these factories to
-    # specify a number of associated objects and therefore easily make valid/invalid
-    # instances.
-    after(:build) do |auxiliary_instance, evaluator|
-      auxiliary_instance.contributions = build_list(
-          :metasploit_cache_auxiliary_contribution,
-          evaluator.contribution_count,
-          contributable: auxiliary_instance
       )
     end
   end

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
           traits: [
               :metasploit_cache_auxiliary_instance_actions,
               :metasploit_cache_contributable_contributions,
-              :metasploit_cache_auxiliary_instance_licensable_licenses,
+              :metasploit_cache_licensable_licensable_licenses,
               # Must be after all association traits so associations are built when writing contents
               :metasploit_cache_auxiliary_instance_auxiliary_class_ancestor_contents
           ] do
@@ -60,32 +60,6 @@ FactoryGirl.define do
       )
     end
   end
-
-  trait :metasploit_cache_auxiliary_instance_licensable_licenses do
-    transient do
-      licensable_license_count 1
-    end
-
-    #
-    # Callbacks
-    #
-
-    # Create associated objects w/ the count established above in the
-    # transient attribute. This enables specs using these factories to
-    # specify a number of associated objects and therefore easily make valid/invalid
-    # instances.
-    after(:build) do |auxiliary_instance, evaluator|
-      auxiliary_instance.licensable_licenses = build_list(
-          :metasploit_cache_auxiliary_license,
-          evaluator.licensable_license_count,
-          licensable: auxiliary_instance
-      )
-    end
-  end
-
-  #
-  # Traits
-  #
 
   trait :metasploit_cache_auxiliary_instance_auxiliary_class_ancestor_contents do
     transient do

--- a/spec/factories/metasploit/cache/auxiliary/instances.rb
+++ b/spec/factories/metasploit/cache/auxiliary/instances.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   factory :metasploit_cache_auxiliary_instance,
           class: Metasploit::Cache::Auxiliary::Instance,
           traits: [
-              :metasploit_cache_auxiliary_instance_actions,
+              :metasploit_cache_actionable_actions,
               :metasploit_cache_contributable_contributions,
               :metasploit_cache_licensable_licensable_licenses,
               # Must be after all association traits so associations are built when writing contents
@@ -38,28 +38,6 @@ FactoryGirl.define do
   #
   # Traits
   #
-
-  trait :metasploit_cache_auxiliary_instance_actions do
-    transient do
-      action_count 1
-    end
-
-    #
-    # Callbacks
-    #
-
-    # Create associated objects w/ the count established above in the
-    # transient attribute. This enables specs using these factories to
-    # specify a number of associated objects and therefore easily make valid/invalid
-    # instances.
-    after(:build) do |auxiliary_instance, evaluator|
-      auxiliary_instance.actions = build_list(
-          :metasploit_cache_auxiliary_action,
-          evaluator.action_count,
-          actionable: auxiliary_instance
-      )
-    end
-  end
 
   trait :metasploit_cache_auxiliary_instance_auxiliary_class_ancestor_contents do
     transient do

--- a/spec/factories/metasploit/cache/contributable/contributions.rb
+++ b/spec/factories/metasploit/cache/contributable/contributions.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  trait :metasploit_cache_contributable_contributions do
+    transient do
+      contribution_count 1
+    end
+
+    after(:build) do |contributable, evaluator|
+      contributable.contributions = build_list(
+          :metasploit_cache_contribution,
+          evaluator.contribution_count,
+          contributable: contributable
+      )
+    end
+  end
+end

--- a/spec/factories/metasploit/cache/contributions.rb
+++ b/spec/factories/metasploit/cache/contributions.rb
@@ -9,38 +9,6 @@ FactoryGirl.define do
     contributable nil
 
     association :author, factory: :metasploit_cache_author
-
-    factory :metasploit_cache_auxiliary_contribution do
-      association :contributable, factory: :metasploit_cache_auxiliary_instance
-    end
-
-    factory :metasploit_cache_encoder_contribution do
-      association :contributable, factory: :metasploit_cache_encoder_instance
-    end
-
-    factory :metasploit_cache_exploit_contribution do
-      association :contributable, factory: :metasploit_cache_exploit_instance
-    end
-
-    factory :metasploit_cache_nop_contribution do
-      association :contributable, factory: :metasploit_cache_nop_instance
-    end
-
-    factory :metasploit_cache_payload_single_contribution do
-      association :contributable, factory: :metasploit_cache_payload_single_instance
-    end
-
-    factory :metasploit_cache_payload_stage_contribution do
-      association :contributable, factory: :metasploit_cache_payload_stage_instance
-    end
-
-    factory :metasploit_cache_payload_stager_contribution do
-      association :contributable, factory: :metasploit_cache_payload_stager_instance
-    end
-
-    factory :metasploit_cache_post_contribution do
-      association :contributable, factory: :metasploit_cache_post_instance
-    end
   end
 
   #

--- a/spec/factories/metasploit/cache/contributions.rb
+++ b/spec/factories/metasploit/cache/contributions.rb
@@ -3,77 +3,49 @@ FactoryGirl.define do
   # Factories
   #
 
-  factory :metasploit_cache_auxiliary_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_auxiliary_instance
-  end
+  factory :metasploit_cache_contribution,
+          class: Metasploit::Cache::Contribution do
+    # @note factory is invalid if caller does not set contributable
+    contributable nil
 
-  factory :metasploit_cache_encoder_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_encoder_instance
-  end
+    association :author, factory: :metasploit_cache_author
 
-  factory :metasploit_cache_exploit_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_exploit_instance
-  end
+    factory :metasploit_cache_auxiliary_contribution do
+      association :contributable, factory: :metasploit_cache_auxiliary_instance
+    end
 
-  factory :metasploit_cache_nop_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_nop_instance
-  end
+    factory :metasploit_cache_encoder_contribution do
+      association :contributable, factory: :metasploit_cache_encoder_instance
+    end
 
-  factory :metasploit_cache_payload_single_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_payload_single_instance
-  end
+    factory :metasploit_cache_exploit_contribution do
+      association :contributable, factory: :metasploit_cache_exploit_instance
+    end
 
-  factory :metasploit_cache_payload_stage_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_payload_stage_instance
-  end
+    factory :metasploit_cache_nop_contribution do
+      association :contributable, factory: :metasploit_cache_nop_instance
+    end
 
-  factory :metasploit_cache_payload_stager_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_payload_stager_instance
-  end
+    factory :metasploit_cache_payload_single_contribution do
+      association :contributable, factory: :metasploit_cache_payload_single_instance
+    end
 
-  factory :metasploit_cache_post_contribution,
-          class: Metasploit::Cache::Contribution,
-          traits: [
-              :metasploit_cache_contribution
-          ] do
-    association :contributable, factory: :metasploit_cache_post_instance
+    factory :metasploit_cache_payload_stage_contribution do
+      association :contributable, factory: :metasploit_cache_payload_stage_instance
+    end
+
+    factory :metasploit_cache_payload_stager_contribution do
+      association :contributable, factory: :metasploit_cache_payload_stager_instance
+    end
+
+    factory :metasploit_cache_post_contribution do
+      association :contributable, factory: :metasploit_cache_post_instance
+    end
   end
 
   #
   # Traits
   #
-
-  trait :metasploit_cache_contribution do
-    association :author, factory: :metasploit_cache_author
-  end
 
   trait :metasploit_cache_contribution_email_address do
     association :email_address, factory: :metasploit_cache_email_address

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
               :metasploit_cache_architecturable_architecturable_architectures,
               :metasploit_cache_contributable_contributions,
               :metasploit_cache_licensable_licensable_licenses,
-              :metasploit_cache_encoder_instance_platformable_platforms,
+              :metasploit_cache_platformable_platformable_platforms,
               # Must be after all association traits so associations are populated before generating content
               :metasploit_cache_encoder_instance_encoder_class_ancestor_contents
           ] do
@@ -38,20 +38,6 @@ FactoryGirl.define do
   #
   # Traits
   #
-
-  trait :metasploit_cache_encoder_instance_platformable_platforms do
-    transient do
-      platformable_platform_count 1
-    end
-
-    after(:build) do |encoder_instance, evaluator|
-      encoder_instance.platformable_platforms = build_list(
-          :metasploit_cache_encoder_platform,
-          evaluator.platformable_platform_count,
-          platformable: encoder_instance
-      )
-    end
-  end
 
   trait :metasploit_cache_encoder_instance_encoder_class_ancestor_contents do
     transient do

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   factory :metasploit_cache_encoder_instance,
           class: Metasploit::Cache::Encoder::Instance,
           traits: [
-              :metasploit_cache_encoder_instance_architecturable_architectures,
+              :metasploit_cache_architecturable_architecturable_architectures,
               :metasploit_cache_encoder_instance_contributions,
               :metasploit_cache_encoder_instance_licensable_licenses,
               :metasploit_cache_encoder_instance_platformable_platforms,
@@ -38,20 +38,6 @@ FactoryGirl.define do
   #
   # Traits
   #
-
-  trait :metasploit_cache_encoder_instance_architecturable_architectures do
-    transient do
-      architecturable_architecture_count 1
-    end
-
-    after(:build) do |encoder_instance, evaluator|
-      encoder_instance.architecturable_architectures = build_list(
-          :metasploit_cache_encoder_architecture,
-          evaluator.architecturable_architecture_count,
-          architecturable: encoder_instance
-      )
-    end
-  end
 
   trait :metasploit_cache_encoder_instance_contributions do
     transient do

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
               :metasploit_cache_contributable_contributions,
-              :metasploit_cache_encoder_instance_licensable_licenses,
+              :metasploit_cache_licensable_licensable_licenses,
               :metasploit_cache_encoder_instance_platformable_platforms,
               # Must be after all association traits so associations are populated before generating content
               :metasploit_cache_encoder_instance_encoder_class_ancestor_contents
@@ -38,20 +38,6 @@ FactoryGirl.define do
   #
   # Traits
   #
-
-  trait :metasploit_cache_encoder_instance_licensable_licenses do
-    transient do
-      licensable_license_count 1
-    end
-
-    after(:build) do |encoder_instance, evaluator|
-      encoder_instance.licensable_licenses = build_list(
-          :metasploit_cache_encoder_license,
-          evaluator.licensable_license_count,
-          licensable: encoder_instance
-      )
-    end
-  end
 
   trait :metasploit_cache_encoder_instance_platformable_platforms do
     transient do

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -6,15 +6,13 @@ FactoryGirl.define do
   factory :metasploit_cache_encoder_instance,
           class: Metasploit::Cache::Encoder::Instance,
           traits: [
+              :metasploit_cache_encoder_instance_architecturable_architectures,
+              :metasploit_cache_encoder_instance_contributions,
+              :metasploit_cache_encoder_instance_licensable_licenses,
+              :metasploit_cache_encoder_instance_platformable_platforms,
+              # Must be after all association traits so associations are populated before generating content
               :metasploit_cache_encoder_instance_encoder_class_ancestor_contents
           ] do
-    transient do
-      architecturable_architecture_count 1
-      contribution_count 1
-      licensable_license_count 1
-      platformable_platform_count 1
-    end
-
     description { generate :metasploit_cache_encoder_instance_description }
     name { generate :metasploit_cache_encoder_instance_name }
 
@@ -23,36 +21,6 @@ FactoryGirl.define do
     #
 
     association :encoder_class, factory: :metasploit_cache_encoder_class
-
-    #
-    # Callbacks
-    #
-
-    after(:build) do |encoder_instance, evaluator|
-      encoder_instance.architecturable_architectures = build_list(
-          :metasploit_cache_encoder_architecture,
-          evaluator.architecturable_architecture_count,
-          architecturable: encoder_instance
-      )
-      
-      encoder_instance.contributions = build_list(
-        :metasploit_cache_encoder_contribution,
-        evaluator.contribution_count,
-        contributable: encoder_instance
-      )
-      
-      encoder_instance.licensable_licenses = build_list(
-        :metasploit_cache_encoder_license,
-        evaluator.licensable_license_count,
-        licensable: encoder_instance
-      )
-      
-      encoder_instance.platformable_platforms = build_list(
-          :metasploit_cache_encoder_platform,
-          evaluator.platformable_platform_count,
-          platformable: encoder_instance
-      )
-    end
   end
 
   #
@@ -70,6 +38,62 @@ FactoryGirl.define do
   #
   # Traits
   #
+
+  trait :metasploit_cache_encoder_instance_architecturable_architectures do
+    transient do
+      architecturable_architecture_count 1
+    end
+
+    after(:build) do |encoder_instance, evaluator|
+      encoder_instance.architecturable_architectures = build_list(
+          :metasploit_cache_encoder_architecture,
+          evaluator.architecturable_architecture_count,
+          architecturable: encoder_instance
+      )
+    end
+  end
+
+  trait :metasploit_cache_encoder_instance_contributions do
+    transient do
+      contribution_count 1
+    end
+
+    after(:build) do |encoder_instance, evaluator|
+      encoder_instance.contributions = build_list(
+          :metasploit_cache_encoder_contribution,
+          evaluator.contribution_count,
+          contributable: encoder_instance
+      )
+    end
+  end
+
+  trait :metasploit_cache_encoder_instance_licensable_licenses do
+    transient do
+      licensable_license_count 1
+    end
+
+    after(:build) do |encoder_instance, evaluator|
+      encoder_instance.licensable_licenses = build_list(
+          :metasploit_cache_encoder_license,
+          evaluator.licensable_license_count,
+          licensable: encoder_instance
+      )
+    end
+  end
+
+  trait :metasploit_cache_encoder_instance_platformable_platforms do
+    transient do
+      platformable_platform_count 1
+    end
+
+    after(:build) do |encoder_instance, evaluator|
+      encoder_instance.platformable_platforms = build_list(
+          :metasploit_cache_encoder_platform,
+          evaluator.platformable_platform_count,
+          platformable: encoder_instance
+      )
+    end
+  end
 
   trait :metasploit_cache_encoder_instance_encoder_class_ancestor_contents do
     transient do

--- a/spec/factories/metasploit/cache/encoder/instances.rb
+++ b/spec/factories/metasploit/cache/encoder/instances.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
           class: Metasploit::Cache::Encoder::Instance,
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
-              :metasploit_cache_encoder_instance_contributions,
+              :metasploit_cache_contributable_contributions,
               :metasploit_cache_encoder_instance_licensable_licenses,
               :metasploit_cache_encoder_instance_platformable_platforms,
               # Must be after all association traits so associations are populated before generating content
@@ -38,20 +38,6 @@ FactoryGirl.define do
   #
   # Traits
   #
-
-  trait :metasploit_cache_encoder_instance_contributions do
-    transient do
-      contribution_count 1
-    end
-
-    after(:build) do |encoder_instance, evaluator|
-      encoder_instance.contributions = build_list(
-          :metasploit_cache_encoder_contribution,
-          evaluator.contribution_count,
-          contributable: encoder_instance
-      )
-    end
-  end
 
   trait :metasploit_cache_encoder_instance_licensable_licenses do
     transient do

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -1,8 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_exploit_instance,
-          class: Metasploit::Cache::Exploit::Instance do
+          class: Metasploit::Cache::Exploit::Instance,
+          traits: [
+              :metasploit_cache_contributable_contributions
+          ] do
     transient do
-      contribution_count 1
       exploit_target_count 1
       licensable_license_count 1
       referencable_reference_count 1
@@ -25,12 +27,6 @@ FactoryGirl.define do
     #
 
     after(:build) { |exploit_instance, evaluator|
-      exploit_instance.contributions = build_list(
-          :metasploit_cache_exploit_contribution,
-          evaluator.contribution_count,
-          contributable: exploit_instance
-      )
-
       exploit_instance.exploit_targets = build_list(
           :metasploit_cache_exploit_target,
           evaluator.exploit_target_count,

--- a/spec/factories/metasploit/cache/exploit/instances.rb
+++ b/spec/factories/metasploit/cache/exploit/instances.rb
@@ -2,11 +2,11 @@ FactoryGirl.define do
   factory :metasploit_cache_exploit_instance,
           class: Metasploit::Cache::Exploit::Instance,
           traits: [
-              :metasploit_cache_contributable_contributions
+              :metasploit_cache_contributable_contributions,
+              :metasploit_cache_licensable_licensable_licenses
           ] do
     transient do
       exploit_target_count 1
-      licensable_license_count 1
       referencable_reference_count 1
     end
 
@@ -31,12 +31,6 @@ FactoryGirl.define do
           :metasploit_cache_exploit_target,
           evaluator.exploit_target_count,
           exploit_instance: exploit_instance
-      )
-
-      exploit_instance.licensable_licenses = build_list(
-        :metasploit_cache_exploit_license,
-        evaluator.licensable_license_count,
-        licensable: exploit_instance
       )
 
       exploit_instance.referencable_references = build_list(

--- a/spec/factories/metasploit/cache/exploit/targets.rb
+++ b/spec/factories/metasploit/cache/exploit/targets.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :metasploit_cache_exploit_target,
-          class: Metasploit::Cache::Exploit::Target do
+          class: Metasploit::Cache::Exploit::Target,
+          traits: [
+              :metasploit_cache_architecturable_architecturable_architectures
+          ] do
     transient do
       architecturable_architecture_count 1
       platformable_platform_count 1
@@ -20,12 +23,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |exploit_target, evaluator|
-      exploit_target.architecturable_architectures = build_list(
-          :metasploit_cache_exploit_target_architecture,
-          evaluator.architecturable_architecture_count,
-          architecturable: exploit_target
-      )
-      
       exploit_target.platformable_platforms = build_list(
           :metasploit_cache_exploit_target_platform,
           evaluator.platformable_platform_count,

--- a/spec/factories/metasploit/cache/exploit/targets.rb
+++ b/spec/factories/metasploit/cache/exploit/targets.rb
@@ -2,13 +2,9 @@ FactoryGirl.define do
   factory :metasploit_cache_exploit_target,
           class: Metasploit::Cache::Exploit::Target,
           traits: [
-              :metasploit_cache_architecturable_architecturable_architectures
+              :metasploit_cache_architecturable_architecturable_architectures,
+              :metasploit_cache_platformable_platformable_platforms
           ] do
-    transient do
-      architecturable_architecture_count 1
-      platformable_platform_count 1
-    end
-
     index { generate :metasploit_cache_exploit_target_index }
     name { generate :metasploit_cache_exploit_target_name }
  
@@ -17,18 +13,6 @@ FactoryGirl.define do
     #
 
     association :exploit_instance, factory: :metasploit_cache_exploit_instance
-
-    #
-    # Callbacks
-    #
-
-    after(:build) do |exploit_target, evaluator|
-      exploit_target.platformable_platforms = build_list(
-          :metasploit_cache_exploit_target_platform,
-          evaluator.platformable_platform_count,
-          platformable: exploit_target
-      )
-    end
   end
 
   sequence :metasploit_cache_exploit_target_index do |n|

--- a/spec/factories/metasploit/cache/licensable/licensable_licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licensable_licenses.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  trait :metasploit_cache_licensable_licensable_licenses do
+    transient do
+      licensable_license_count 1
+    end
+
+    after(:build) do |licensable, evaluator|
+      licensable.licensable_licenses = build_list(
+          :metasploit_cache_licensable_license,
+          evaluator.licensable_license_count,
+          licensable: licensable
+      )
+    end
+  end
+end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -1,61 +1,41 @@
 FactoryGirl.define do
-  #
-  # Factories
-  #
+  factory :metasploit_cache_licensable_license,
+          class: Metasploit::Cache::Licensable::License do
+    # @note Factory is invalid unless caller sets licensable
+    licensable nil
 
-  factory :metasploit_cache_auxiliary_license,
-                 class: Metasploit::Cache::Licensable::License,
-                 traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_auxiliary_instance
-  end
-
-  factory :metasploit_cache_encoder_license,
-          class: Metasploit::Cache::Licensable::License,
-          traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_encoder_instance
-  end
-
-  factory :metasploit_cache_exploit_license,
-          class: Metasploit::Cache::Licensable::License,
-          traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_exploit_instance
-  end
-
-  factory :metasploit_cache_nop_license,
-          class: Metasploit::Cache::Licensable::License,
-          traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_nop_instance
-  end
-
-  factory :metasploit_cache_payload_single_license,
-          class: Metasploit::Cache::Licensable::License,
-          traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_payload_single_instance
-  end
-
-  factory :metasploit_cache_payload_stage_license,
-          class: Metasploit::Cache::Licensable::License,
-          traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_payload_stage_instance
-  end
-
-  factory :metasploit_cache_payload_stager_license,
-          class: Metasploit::Cache::Licensable::License,
-          traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_payload_stager_instance
-  end
-
-  factory :metasploit_cache_post_license,
-          class: Metasploit::Cache::Licensable::License,
-          traits: [:metasploit_cache_licensable_license] do
-    association :licensable, factory: :metasploit_cache_post_instance
-  end
-
-  #
-  # Traits
-  #
-
-  trait :metasploit_cache_licensable_license do
     association :license, factory: :metasploit_cache_license
+
+    factory :metasploit_cache_auxiliary_license do
+      association :licensable, factory: :metasploit_cache_auxiliary_instance
+    end
+
+    factory :metasploit_cache_encoder_license do
+      association :licensable, factory: :metasploit_cache_encoder_instance
+    end
+
+    factory :metasploit_cache_exploit_license do
+      association :licensable, factory: :metasploit_cache_exploit_instance
+    end
+
+    factory :metasploit_cache_nop_license do
+      association :licensable, factory: :metasploit_cache_nop_instance
+    end
+
+    factory :metasploit_cache_payload_single_license do
+      association :licensable, factory: :metasploit_cache_payload_single_instance
+    end
+
+    factory :metasploit_cache_payload_stage_license do
+      association :licensable, factory: :metasploit_cache_payload_stage_instance
+    end
+
+    factory :metasploit_cache_payload_stager_license do
+      association :licensable, factory: :metasploit_cache_payload_stager_instance
+    end
+
+    factory :metasploit_cache_post_license do
+      association :licensable, factory: :metasploit_cache_post_instance
+    end
   end
 end

--- a/spec/factories/metasploit/cache/licensable/licenses.rb
+++ b/spec/factories/metasploit/cache/licensable/licenses.rb
@@ -5,37 +5,5 @@ FactoryGirl.define do
     licensable nil
 
     association :license, factory: :metasploit_cache_license
-
-    factory :metasploit_cache_auxiliary_license do
-      association :licensable, factory: :metasploit_cache_auxiliary_instance
-    end
-
-    factory :metasploit_cache_encoder_license do
-      association :licensable, factory: :metasploit_cache_encoder_instance
-    end
-
-    factory :metasploit_cache_exploit_license do
-      association :licensable, factory: :metasploit_cache_exploit_instance
-    end
-
-    factory :metasploit_cache_nop_license do
-      association :licensable, factory: :metasploit_cache_nop_instance
-    end
-
-    factory :metasploit_cache_payload_single_license do
-      association :licensable, factory: :metasploit_cache_payload_single_instance
-    end
-
-    factory :metasploit_cache_payload_stage_license do
-      association :licensable, factory: :metasploit_cache_payload_stage_instance
-    end
-
-    factory :metasploit_cache_payload_stager_license do
-      association :licensable, factory: :metasploit_cache_payload_stager_instance
-    end
-
-    factory :metasploit_cache_post_license do
-      association :licensable, factory: :metasploit_cache_post_instance
-    end
   end
 end

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :metasploit_cache_nop_instance,
-          class: Metasploit::Cache::Nop::Instance do
+          class: Metasploit::Cache::Nop::Instance,
+          traits: [
+              :metasploit_cache_architecturable_architecturable_architectures
+          ] do
     transient do
       architecturable_architecture_count 1
       contribution_count 1
@@ -27,13 +30,7 @@ FactoryGirl.define do
           evaluator.contribution_count,
           contributable: nop_instance
       )
-      
-      nop_instance.architecturable_architectures = build_list(
-          :metasploit_cache_nop_architecture,
-          evaluator.architecturable_architecture_count,
-          architecturable: nop_instance
-      )
-      
+
       nop_instance.licensable_licenses = build_list(
         :metasploit_cache_nop_license,
         evaluator.licensable_license_count,

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -4,12 +4,9 @@ FactoryGirl.define do
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
               :metasploit_cache_contributable_contributions,
-              :metasploit_cache_licensable_licensable_licenses
+              :metasploit_cache_licensable_licensable_licenses,
+              :metasploit_cache_platformable_platformable_platforms
           ] do
-    transient do
-      platformable_platform_count 1
-    end
-
     description { generate :metasploit_cache_nop_instance_description }
     name { generate :metasploit_cache_nop_instance_name }
 
@@ -18,18 +15,6 @@ FactoryGirl.define do
     #
 
     association :nop_class, factory: :metasploit_cache_nop_class
-
-    #
-    # Callbacks
-    #
-
-    after(:build) do |nop_instance, evaluator|
-      nop_instance.platformable_platforms = build_list(
-          :metasploit_cache_nop_platform,
-          evaluator.platformable_platform_count,
-          platformable: nop_instance
-      )
-    end
   end
 
   #

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -2,11 +2,10 @@ FactoryGirl.define do
   factory :metasploit_cache_nop_instance,
           class: Metasploit::Cache::Nop::Instance,
           traits: [
-              :metasploit_cache_architecturable_architecturable_architectures
+              :metasploit_cache_architecturable_architecturable_architectures,
+              :metasploit_cache_contributable_contributions
           ] do
     transient do
-      architecturable_architecture_count 1
-      contribution_count 1
       licensable_license_count 1
       platformable_platform_count 1
     end
@@ -25,12 +24,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |nop_instance, evaluator|
-      nop_instance.contributions = build_list(
-          :metasploit_cache_nop_contribution,
-          evaluator.contribution_count,
-          contributable: nop_instance
-      )
-
       nop_instance.licensable_licenses = build_list(
         :metasploit_cache_nop_license,
         evaluator.licensable_license_count,

--- a/spec/factories/metasploit/cache/nop/instances.rb
+++ b/spec/factories/metasploit/cache/nop/instances.rb
@@ -3,10 +3,10 @@ FactoryGirl.define do
           class: Metasploit::Cache::Nop::Instance,
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
-              :metasploit_cache_contributable_contributions
+              :metasploit_cache_contributable_contributions,
+              :metasploit_cache_licensable_licensable_licenses
           ] do
     transient do
-      licensable_license_count 1
       platformable_platform_count 1
     end
 
@@ -24,12 +24,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |nop_instance, evaluator|
-      nop_instance.licensable_licenses = build_list(
-        :metasploit_cache_nop_license,
-        evaluator.licensable_license_count,
-        licensable: nop_instance
-      )
-      
       nop_instance.platformable_platforms = build_list(
           :metasploit_cache_nop_platform,
           evaluator.platformable_platform_count,

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
-          class: Metasploit::Cache::Payload::Single::Instance do
+          class: Metasploit::Cache::Payload::Single::Instance,
+          traits: [
+              :metasploit_cache_architecturable_architecturable_architectures
+          ] do
     transient do
       contribution_count 1
       architecturable_architecture_count 1
@@ -24,12 +27,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_single_instance, evaluator|
-      payload_single_instance.architecturable_architectures = build_list(
-          :metasploit_cache_payload_single_architecture,
-          evaluator.architecturable_architecture_count,
-          architecturable: payload_single_instance
-      )
-      
       payload_single_instance.contributions = build_list(
         :metasploit_cache_payload_single_contribution,
         evaluator.contribution_count,

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -2,11 +2,10 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
           class: Metasploit::Cache::Payload::Single::Instance,
           traits: [
-              :metasploit_cache_architecturable_architecturable_architectures
+              :metasploit_cache_architecturable_architecturable_architectures,
+              :metasploit_cache_contributable_contributions
           ] do
     transient do
-      contribution_count 1
-      architecturable_architecture_count 1
       licensable_license_count 1
       platformable_platform_count 1
     end
@@ -27,12 +26,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_single_instance, evaluator|
-      payload_single_instance.contributions = build_list(
-        :metasploit_cache_payload_single_contribution,
-        evaluator.contribution_count,
-        contributable: payload_single_instance
-      )
-      
       payload_single_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_single_license,
         evaluator.licensable_license_count,

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -4,12 +4,9 @@ FactoryGirl.define do
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
               :metasploit_cache_contributable_contributions,
-              :metasploit_cache_licensable_licensable_licenses
+              :metasploit_cache_licensable_licensable_licenses,
+              :metasploit_cache_platformable_platformable_platforms
           ] do
-    transient do
-      platformable_platform_count 1
-    end
-
     description { generate :metasploit_cache_payload_single_instance_description }
     name { generate :metasploit_cache_payload_single_instance_name }
     privileged { generate :metasploit_cache_payload_single_instance_privileged }
@@ -20,18 +17,6 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_single_class, factory: :metasploit_cache_payload_single_class
-    
-    #
-    # Callbacks
-    #
-
-    after(:build) do |payload_single_instance, evaluator|
-      payload_single_instance.platformable_platforms = build_list(
-          :metasploit_cache_payload_single_platform,
-          evaluator.platformable_platform_count,
-          platformable: payload_single_instance
-      )
-    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -3,10 +3,10 @@ FactoryGirl.define do
           class: Metasploit::Cache::Payload::Single::Instance,
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
-              :metasploit_cache_contributable_contributions
+              :metasploit_cache_contributable_contributions,
+              :metasploit_cache_licensable_licensable_licenses
           ] do
     transient do
-      licensable_license_count 1
       platformable_platform_count 1
     end
 
@@ -26,12 +26,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_single_instance, evaluator|
-      payload_single_instance.licensable_licenses = build_list(
-        :metasploit_cache_payload_single_license,
-        evaluator.licensable_license_count,
-        licensable: payload_single_instance
-      )
-      
       payload_single_instance.platformable_platforms = build_list(
           :metasploit_cache_payload_single_platform,
           evaluator.platformable_platform_count,

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -2,10 +2,10 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_stage_instance,
           class: Metasploit::Cache::Payload::Stage::Instance,
           traits: [
-              :metasploit_cache_architecturable_architecturable_architectures
+              :metasploit_cache_architecturable_architecturable_architectures,
+              :metasploit_cache_contributable_contributions
           ] do
     transient do
-      contribution_count 1
       licensable_license_count 1
       platformable_platform_count 1
     end
@@ -25,12 +25,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_stage_instance, evaluator|
-      payload_stage_instance.contributions = build_list(
-          :metasploit_cache_payload_stage_contribution,
-          evaluator.contribution_count,
-          contributable: payload_stage_instance
-      )
-      
       payload_stage_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stage_license,
         evaluator.licensable_license_count,

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -3,10 +3,10 @@ FactoryGirl.define do
           class: Metasploit::Cache::Payload::Stage::Instance,
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
-              :metasploit_cache_contributable_contributions
+              :metasploit_cache_contributable_contributions,
+              :metasploit_cache_licensable_licensable_licenses
           ] do
     transient do
-      licensable_license_count 1
       platformable_platform_count 1
     end
 
@@ -25,12 +25,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_stage_instance, evaluator|
-      payload_stage_instance.licensable_licenses = build_list(
-        :metasploit_cache_payload_stage_license,
-        evaluator.licensable_license_count,
-        licensable: payload_stage_instance
-      )
-      
       payload_stage_instance.platformable_platforms = build_list(
           :metasploit_cache_payload_stage_platform,
           evaluator.platformable_platform_count,

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -1,8 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stage_instance,
-          class: Metasploit::Cache::Payload::Stage::Instance do
+          class: Metasploit::Cache::Payload::Stage::Instance,
+          traits: [
+              :metasploit_cache_architecturable_architecturable_architectures
+          ] do
     transient do
-      architecturable_architecture_count 1
       contribution_count 1
       licensable_license_count 1
       platformable_platform_count 1
@@ -23,12 +25,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_stage_instance, evaluator|
-      payload_stage_instance.architecturable_architectures = build_list(
-          :metasploit_cache_payload_stage_architecture,
-          evaluator.architecturable_architecture_count,
-          architecturable: payload_stage_instance
-      )
-      
       payload_stage_instance.contributions = build_list(
           :metasploit_cache_payload_stage_contribution,
           evaluator.contribution_count,

--- a/spec/factories/metasploit/cache/payload/stage/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stage/instances.rb
@@ -4,12 +4,9 @@ FactoryGirl.define do
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
               :metasploit_cache_contributable_contributions,
-              :metasploit_cache_licensable_licensable_licenses
+              :metasploit_cache_licensable_licensable_licenses,
+              :metasploit_cache_platformable_platformable_platforms
           ] do
-    transient do
-      platformable_platform_count 1
-    end
-
     description { generate :metasploit_cache_payload_stage_instance_description }
     name { generate :metasploit_cache_payload_stage_instance_name }
     privileged { generate :metasploit_cache_payload_stage_instance_privileged }
@@ -19,18 +16,6 @@ FactoryGirl.define do
     #
 
     association :payload_stage_class, factory: :metasploit_cache_payload_stage_class
-
-    #
-    # Callbacks
-    #
-
-    after(:build) do |payload_stage_instance, evaluator|
-      payload_stage_instance.platformable_platforms = build_list(
-          :metasploit_cache_payload_stage_platform,
-          evaluator.platformable_platform_count,
-          platformable: payload_stage_instance
-      )
-    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -4,12 +4,9 @@ FactoryGirl.define do
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
               :metasploit_cache_contributable_contributions,
-              :metasploit_cache_licensable_licensable_licenses
+              :metasploit_cache_licensable_licensable_licenses,
+              :metasploit_cache_platformable_platformable_platforms
           ] do
-    transient do
-      platformable_platform_count 1
-    end
-
     description { generate :metasploit_cache_payload_stager_instance_description }
     handler_type_alias { generate :metasploit_cache_payload_stager_handler_type_alias }
     name { generate :metasploit_cache_payload_stager_instance_name }
@@ -21,18 +18,6 @@ FactoryGirl.define do
 
     association :handler, factory: :metasploit_cache_payload_handler
     association :payload_stager_class, factory: :metasploit_cache_payload_stager_class
-
-    #
-    # Callbacks
-    #
-
-    after(:build) do |payload_stager_instance, evaluator|
-      payload_stager_instance.platformable_platforms = build_list(
-          :metasploit_cache_payload_stage_platform,
-          evaluator.platformable_platform_count,
-          platformable: payload_stager_instance
-      )
-    end
   end
 
   #

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -2,11 +2,10 @@ FactoryGirl.define do
   factory :metasploit_cache_payload_stager_instance,
           class: Metasploit::Cache::Payload::Stager::Instance,
           traits: [
-              :metasploit_cache_architecturable_architecturable_architectures
+              :metasploit_cache_architecturable_architecturable_architectures,
+              :metasploit_cache_contributable_contributions
           ] do
     transient do
-      architecturable_architecture_count 1
-      contribution_count 1
       licensable_license_count 1
       platformable_platform_count 1
     end
@@ -28,12 +27,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_stager_instance, evaluator|
-      payload_stager_instance.contributions = build_list(
-          :metasploit_cache_payload_stager_contribution,
-          evaluator.contribution_count,
-          contributable: payload_stager_instance
-      )
-      
       payload_stager_instance.licensable_licenses = build_list(
         :metasploit_cache_payload_stager_license,
         evaluator.licensable_license_count,

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_stager_instance,
-          class: Metasploit::Cache::Payload::Stager::Instance do
+          class: Metasploit::Cache::Payload::Stager::Instance,
+          traits: [
+              :metasploit_cache_architecturable_architecturable_architectures
+          ] do
     transient do
       architecturable_architecture_count 1
       contribution_count 1
@@ -25,12 +28,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_stager_instance, evaluator|
-      payload_stager_instance.architecturable_architectures = build_list(
-          :metasploit_cache_payload_stager_architecture,
-          evaluator.architecturable_architecture_count,
-          architecturable: payload_stager_instance
-      )
-      
       payload_stager_instance.contributions = build_list(
           :metasploit_cache_payload_stager_contribution,
           evaluator.contribution_count,

--- a/spec/factories/metasploit/cache/payload/stager/instances.rb
+++ b/spec/factories/metasploit/cache/payload/stager/instances.rb
@@ -3,10 +3,10 @@ FactoryGirl.define do
           class: Metasploit::Cache::Payload::Stager::Instance,
           traits: [
               :metasploit_cache_architecturable_architecturable_architectures,
-              :metasploit_cache_contributable_contributions
+              :metasploit_cache_contributable_contributions,
+              :metasploit_cache_licensable_licensable_licenses
           ] do
     transient do
-      licensable_license_count 1
       platformable_platform_count 1
     end
 
@@ -27,12 +27,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |payload_stager_instance, evaluator|
-      payload_stager_instance.licensable_licenses = build_list(
-        :metasploit_cache_payload_stager_license,
-        evaluator.licensable_license_count,
-        licensable: payload_stager_instance
-      )
-      
       payload_stager_instance.platformable_platforms = build_list(
           :metasploit_cache_payload_stage_platform,
           evaluator.platformable_platform_count,

--- a/spec/factories/metasploit/cache/platformable/platformable_platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platformable_platforms.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  trait :metasploit_cache_platformable_platformable_platforms do
+    transient do
+      platformable_platform_count 1
+    end
+
+    after(:build) do |platforamble, evaluator|
+      platforamble.platformable_platforms = build_list(
+          :metasploit_cache_platformable_platform,
+          evaluator.platformable_platform_count,
+          platformable: platforamble
+      )
+    end
+  end
+end

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -5,33 +5,5 @@ FactoryGirl.define do
 
     # @note factory is invalid unless caller set platformable
     platformable nil
-
-    factory :metasploit_cache_encoder_platform do
-      association :platformable, factory: :metasploit_cache_encoder_instance
-    end
-
-    factory :metasploit_cache_exploit_target_platform do
-      association :platformable, factory: :metasploit_cache_exploit_target
-    end
-
-    factory :metasploit_cache_nop_platform do
-      association :platformable, factory: :metasploit_cache_nop_instance
-    end
-
-    factory :metasploit_cache_payload_single_platform do
-      association :platformable, factory: :metasploit_cache_payload_single_instance
-    end
-
-    factory :metasploit_cache_payload_stage_platform do
-      association :platformable, factory: :metasploit_cache_payload_stage_instance
-    end
-
-    factory :metasploit_cache_payload_stager_platform do
-      association :platformable, factory: :metasploit_cache_payload_stager_instance
-    end
-
-    factory :metasploit_cache_post_platform do
-      association :platformable, factory: :metasploit_cache_post_instance
-    end
   end
 end

--- a/spec/factories/metasploit/cache/platformable/platforms.rb
+++ b/spec/factories/metasploit/cache/platformable/platforms.rb
@@ -1,69 +1,37 @@
 FactoryGirl.define do
-  #
-  # Factories
-  #
-
-  factory :metasploit_cache_encoder_platform,
-          class: Metasploit::Cache::Platformable::Platform,
-          traits: [
-              :metasploit_cache_platformable_platform
-          ] do
-    association :platformable, factory: :metasploit_cache_encoder_instance
-  end
-
-  factory :metasploit_cache_exploit_target_platform,
-          class: Metasploit::Cache::Platformable::Platform,
-          traits: [
-              :metasploit_cache_platformable_platform
-          ] do
-    association :platformable, factory: :metasploit_cache_exploit_target
-  end
-
-  factory :metasploit_cache_nop_platform,
-          class: Metasploit::Cache::Platformable::Platform,
-          traits: [
-              :metasploit_cache_platformable_platform
-          ] do
-    association :platformable, factory: :metasploit_cache_nop_instance
-  end
-
-  factory :metasploit_cache_payload_single_platform,
-          class: Metasploit::Cache::Platformable::Platform,
-          traits: [
-              :metasploit_cache_platformable_platform
-          ] do
-    association :platformable, factory: :metasploit_cache_payload_single_instance
-  end
-
-  factory :metasploit_cache_payload_stage_platform,
-          class: Metasploit::Cache::Platformable::Platform,
-          traits: [
-              :metasploit_cache_platformable_platform
-          ] do
-    association :platformable, factory: :metasploit_cache_payload_stage_instance
-  end
-
-  factory :metasploit_cache_payload_stager_platform,
-          class: Metasploit::Cache::Platformable::Platform,
-          traits: [
-              :metasploit_cache_platformable_platform
-          ] do
-    association :platformable, factory: :metasploit_cache_payload_stager_instance
-  end
-
-  factory :metasploit_cache_post_platform,
-          class: Metasploit::Cache::Platformable::Platform,
-          traits: [
-              :metasploit_cache_platformable_platform
-          ] do
-    association :platformable, factory: :metasploit_cache_post_instance
-  end
-
-  #
-  # Traits
-  #
-
-  trait :metasploit_cache_platformable_platform do
+  factory :metasploit_cache_platformable_platform,
+          class: Metasploit::Cache::Platformable::Platform do
     platform { generate :metasploit_cache_platform }
+
+    # @note factory is invalid unless caller set platformable
+    platformable nil
+
+    factory :metasploit_cache_encoder_platform do
+      association :platformable, factory: :metasploit_cache_encoder_instance
+    end
+
+    factory :metasploit_cache_exploit_target_platform do
+      association :platformable, factory: :metasploit_cache_exploit_target
+    end
+
+    factory :metasploit_cache_nop_platform do
+      association :platformable, factory: :metasploit_cache_nop_instance
+    end
+
+    factory :metasploit_cache_payload_single_platform do
+      association :platformable, factory: :metasploit_cache_payload_single_instance
+    end
+
+    factory :metasploit_cache_payload_stage_platform do
+      association :platformable, factory: :metasploit_cache_payload_stage_instance
+    end
+
+    factory :metasploit_cache_payload_stager_platform do
+      association :platformable, factory: :metasploit_cache_payload_stager_instance
+    end
+
+    factory :metasploit_cache_post_platform do
+      association :platformable, factory: :metasploit_cache_post_instance
+    end
   end
 end

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -2,10 +2,10 @@ FactoryGirl.define do
   factory :metasploit_cache_post_instance,
           class: Metasploit::Cache::Post::Instance,
           traits: [
-              :metasploit_cache_contributable_contributions
+              :metasploit_cache_contributable_contributions,
+              :metasploit_cache_licensable_licensable_licenses
           ] do
     transient do
-      licensable_license_count 1
       platformable_platform_count 1
     end
 
@@ -25,12 +25,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |post_instance, evaluator|
-      post_instance.licensable_licenses = build_list(
-        :metasploit_cache_post_license,
-        evaluator.licensable_license_count,
-        licensable: post_instance
-      )
-
       post_instance.platformable_platforms = build_list(
           :metasploit_cache_post_platform,
           evaluator.platformable_platform_count,

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -3,12 +3,9 @@ FactoryGirl.define do
           class: Metasploit::Cache::Post::Instance,
           traits: [
               :metasploit_cache_contributable_contributions,
-              :metasploit_cache_licensable_licensable_licenses
+              :metasploit_cache_licensable_licensable_licenses,
+              :metasploit_cache_platformable_platformable_platforms
           ] do
-    transient do
-      platformable_platform_count 1
-    end
-
     description { generate :metasploit_cache_post_instance_description }
     disclosed_on { generate :metasploit_cache_post_instance_disclosed_on }
     name { generate :metasploit_cache_post_instance_name }
@@ -19,18 +16,6 @@ FactoryGirl.define do
     #
 
     association :post_class, factory: :metasploit_cache_post_class
-
-    #
-    # Callbacks
-    #
-
-    after(:build) do |post_instance, evaluator|
-      post_instance.platformable_platforms = build_list(
-          :metasploit_cache_post_platform,
-          evaluator.platformable_platform_count,
-          platformable: post_instance
-      )
-    end
   end
 
   #

--- a/spec/factories/metasploit/cache/post/instances.rb
+++ b/spec/factories/metasploit/cache/post/instances.rb
@@ -1,8 +1,10 @@
 FactoryGirl.define do
   factory :metasploit_cache_post_instance,
-          class: Metasploit::Cache::Post::Instance do
+          class: Metasploit::Cache::Post::Instance,
+          traits: [
+              :metasploit_cache_contributable_contributions
+          ] do
     transient do
-      contribution_count 1
       licensable_license_count 1
       platformable_platform_count 1
     end
@@ -23,12 +25,6 @@ FactoryGirl.define do
     #
 
     after(:build) do |post_instance, evaluator|
-      post_instance.contributions = build_list(
-        :metasploit_cache_post_contribution,
-        evaluator.contribution_count,
-        contributable: post_instance
-      )
-
       post_instance.licensable_licenses = build_list(
         :metasploit_cache_post_license,
         evaluator.licensable_license_count,

--- a/spec/support/matchers/load_metasploit_model.rb
+++ b/spec/support/matchers/load_metasploit_model.rb
@@ -8,7 +8,7 @@ RSpec::Matchers.define :load_metasploit_module do
   failure_message do |module_ancestor_load|
     lines = []
     lines << "#{module_ancestor_load.class} expected to be valid " \
-             "and load #{module_ancestor_load.module_ancestor.full_name}, " \
+             "and load #{module_ancestor_load.module_ancestor.real_pathname}, " \
              "but had errors:"
     lines.concat module_ancestor_load.errors.full_messages
 


### PR DESCRIPTION
MSP-13028

The cells used to generate module instance files from factories did not handle multiple elements being in an association because there was no logic to add commas between elements of the array.  This was not spotted because there were no tests using association counts over the default of 1 that then tried to load the generated file.

Tests are added to check that a module instance with 2 of every association can be loaded by the respective module type load.  Factories are also DRYed up by using traits and eliminating type-specific association factories in favor of using an invalid factory that must have the parent record filled by the caller.