### PR TITLE
Load Metasploit::Cache::Exploit::Instance from metasploit-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,121 @@ In a Rails application, Metasploit::Cache acts a
 just as if they were defined under app/models.  If your Rails appliation needs to modify the models, this can be done
 using [metasploit-concern](https://github.com/rapid7/metasploit-concern).
 
+## Seeds
+
+### `Metasploit::Cache::Authority`
+
+Authorities for references (`Metasploit::Cache::Reference#authority`) must be known to prevent typos and so that
+reference URLs can be calculated correctly.  When a new authority needs to be supported, such as 
+
+#### Terminology
+
+The metasyntactic variables should be replaced in the example code in this section with their appropriate values.
+
+| Metasyntactic Variable                | Description                                                                                                                                                                    | Example                                          |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| `<abbreviation>`                      | Abbreviation used as first element of metasploit-framework references                                                                                                          | `CVE`                                            |
+| `<titleized-abbreviation>`            | `<abbreviation>` with the first letter capitalized and all others lowercase, so it can be used a ruby Module name                                                              | `Cve`                                            |
+| `<summary>`                           | The expanded form of `<abbreviation>`                                                                                                                                          | `Common Vulnerabilities and Expose`              |
+| `<url>`                               | The URL to the authority's home page or root URL for their reference database.                                                                                                 | `http://cvedetails.com`                          |
+| `<designation-tempalte(designation)>` | Interpolated string that uses `Metasploit::Cache::Reference#designation` to compose a URL to the `Metasploit::Cache::Reference#authority`'s page for the specific designation. | `"http://cvedetails.com/cve/CVE-#{designation}"` |
+| `<format-description>`                | Human-readable description of `<designation-template(designation)>` format for spec testing it.                                                                                | `under cve directory`                            |
+| `<designation-format>`                | Format using N's, dashes, and literals to show where digits or years appear in designations                                                                                    | `YYYY-NNNN`                                      |
+| `<designation-name>`                  | What the authority calls their designations, usually `<foo> ID`                                                                                                                | `CVE ID`                                         |
+
+#### Code
+
+1. Create `lib/metasploit/cache/authority/<authority>.rb`:
+   
+       # <summary> authority-specific code.
+       module Metasploit::Cache::Authority::<captialized-abbreviation>
+         # Returns URL to {Metasploit::cache::Reference#designation <designation-name>'s} page.
+         #
+         # @param designation [String] <designation-format> <designation-name>
+         # @return [String] URL
+         def self.designation_url(designation)
+           "<designation-template(designation)>"
+         end
+       end
+       
+2. In `app/models/metasploit/cache/authority.rb`, `autoload` the new module:
+   
+       autoload <titleized-abbreviation>
+       
+3. In `lib/metasploit/cache/authority/seed.rb`, in the `ATTRIBUTES` constant add a `Hash` to the `Array`, in order of
+   `:abbreviation`:
+   
+       {
+         abbreviation: '<abbreviation>',
+         obsolete: false,
+         summary: '<summary>'
+         url: '<url>'
+       }
+
+#### Specs
+
+1. Add a sequence to `spec/factories/metasploit/cache/references.rb`:
+   
+       sequence(:metasploit_cache_reference_<abbreviation>_designation) { |n|
+         n.to_s
+       end
+   
+   If the new authority has designations more complicated than simple, increasing numbers, such as YEAR-NUMBER, then
+   simulate that with the sequence:
+   
+       sequence :metasploit_cache_reference_<abbreviation>_designation { |n|
+         number = n % 1000
+         year = n / 1000
+         
+         "#{year}-#{number}"
+       }
+       
+2. In `spec/app/models/metasploit/cache/authority_spec.rb`, in the `'seeds'` context, add the following shared example
+   usage, keeping the order by `:abbreviation`:
+   
+       it_should_behave_like 'Metasploit::Cache::Authority seed',
+                             abbreviation: '<abbreviation>',
+                             extension_name: 'Metasploit::Cache::Authority::<titleized-abbreviation>',
+                             obsolete: false,
+                             summary: '<summary>',
+                             url: '<url>'
+
+3. Create a new `spec/lib/metasploit/cache/authority/<abbreviation>_spec.rb`:
+   
+       RSpec.describe Metasploit::Cache::Authority::<captialized-abbreviation> do
+         context 'designation_url' do
+           subject(:designation_url) {
+             described_class.designation_url(designation)
+           }
+           
+           let(:designation) {
+             FactoryGirl.generate :metasploit_cache_reference_<abbreviation>_designation
+           }
+           
+           it 'is <format description>' do
+             expect(designation_url).to eq("<designation-template(designation)>")
+           end
+         end
+       end                            
+
+4. In `spec/app/models/metasploit/cache/reference_spec.rb`, in the `'derivation'` context, in the `'with authority'`
+   context, in the `'with abbreviation'` context, add a new `context` with the `<abbreviation>`:
+   
+       context '<abbreviation>' do
+         let(:abbreviation) {
+           '<abbreviation>'
+         }
+         
+         let(:designation) {
+           FactoryGirl.generate :metasploit_cache_reference_<abbreviation>_designation
+         }
+         
+         it_should_behave_like 'derives',
+                               :url,
+                               validates: false
+       end
+
+
 ## Testing
 
 ### With metasploit-framework

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ automated compatibility between Metasploit Modules.
 
 The metasyntactic variables should be replace d in the example code in this section with their appropriate values.
 
+| Metasyntactic Variable   | Description                                                                                                        | Example      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------|--------------|
+| `<relative-name>`        | The name of the platform relative to its parent.  For root platforms, this is the same as `<fully-qualified-name>` | `10`         |
+| `<parent-relative-name>` | The `<relative-name>` for the parent platform.                                                                     | `Windows`    |
+| `<fully-qualified-name>` | The `<relative-name>` of each level joined together.                                                               | `Windows 10` |
+
 #### Code
 
 1. In `lib/metasploit/cache/platform/seed.rb`, add an entry to `RELATIVE_NAME_TREE`.  Each level is in alphabetical

--- a/README.md
+++ b/README.md
@@ -145,6 +145,104 @@ The metasyntactic variables should be replaced in the example code in this secti
        end
 
 
+### `Metasploit::Cache::Platform`
+
+Platforms for Metasploit Modules and exploit Metasploit Module targets must be known to prevent typos and assist with
+automated compatibility between Metasploit Modules.
+
+#### Terminology
+
+The metasyntactic variables should be replace d in the example code in this section with their appropriate values.
+
+#### Code
+
+1. In `lib/metasploit/cache/platform/seed.rb`, add an entry to `RELATIVE_NAME_TREE`.  Each level is in alphabetical
+   order.  Leaf nodes point to `nil` to end the branch.
+   
+   If adding a platform without any versions, just put it at the first level
+   
+       RELATIVE_NAME_TREE = {
+         # ...
+         '<relative-name>' => nil
+         # ...
+       }
+   
+   If adding a version or variant to a pre-existing platform, nest it under the parent platform
+   
+      RELATIVE_NAME_TREE = {
+        # ...
+        '<parent-relative-name>' => {
+          `<relative-name>' => nil
+        }
+        # ...
+      }
+
+#### Specs
+
+1. In `app/models/metasploit/cache/platform_spec.rb`, in the `'.fully_qualified_names'` context, add an example for the
+   `<fully-qualified-name>` in alphabetical order
+   
+       RSpec.describe Metasploit::Cache::Platform do
+         # ...
+         context '.fully_qualified_names' do
+           # ...
+           it { is_expected.to include '<fully-qualified-name>' }
+           # ...
+         # ...
+       end
+
+##### For Root platforms
+
+NOTE: Do these steps only when adding a root platform.
+
+1. In `app/models/metasploit/cache/platform_spec.rb`, in the `'root_fully_qualified_name_set'` context, add an example
+   for the `<fully-qualified-name>` in alphabetical order.
+   
+       RSpec.describe Metasploit::Cache::Platform do
+         # ...
+         context 'root_fully_qualified_name_set' do
+           # ...
+           it { is_expected.to include '<fully-qualified-name>' }
+           # ...
+         # ...
+       end
+       
+2. In `lib/metasploit/cache/platform/seed_spec.rb`, in `'CONSTANTS'` context, in `'RELATIVE_NAME_TREE'` context, add
+   an example for the `<fully-qualified-name>` in alphabetical order.
+   
+       RSpec.describe Metasploit::Cache::Platform::Seed do
+         context 'CONSTANTS' do
+           context 'RELATIVE_NAME_TREE' do
+             # ...
+             it { is_expected.to include('<fully-qualified-name>') }
+             # ...
+           end
+         end
+         # ...
+       end
+
+##### For Nested Platforms
+
+NOTE: Do these steps only when adding non-root, nested platforms.
+
+1. In `lib/metasploit/cache/platform/seed_spec.rb`, in `'CONSTANTS'` context, in `'RELATIVE_NAME_TREE'` context, add
+   an example for the `<relative-name>` in alphabetical order.
+   
+       RSpec.describe Metasploit::Cache::Platform::Seed do
+         context 'CONSTANTS' do
+           context 'RELATIVE_NAME_TREE' do
+             # ...
+             context "['<parent-relative-name>']" do
+               # ...
+               it { is_expected.to include('<relative-name>') }
+               # ...
+             end
+             # ...
+           end
+         end
+         # ...
+       end
+
 ## Testing
 
 ### With metasploit-framework

--- a/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor/show.erb
@@ -8,6 +8,14 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= auxiliary_class.rank.number %>
 
   #
+  # Class Attributes
+  #
+
+  class << self
+    attr_accessor :framework
+  end
+
+  #
   # Instance Methods
   #
 

--- a/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
@@ -8,6 +8,14 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= encoder_class.rank.number %>
 
   #
+  # Class Attributes
+  #
+
+  class << self
+    attr_accessor :framework
+  end
+
+  #
   # Instance Methods
   #
 

--- a/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor/show.erb
@@ -8,6 +8,14 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= exploit_class.rank.number %>
 
   #
+  # Class Attributes
+  #
+
+  class << self
+    attr_accessor :framework
+  end
+
+  #
   # Instance Methods
   #
 

--- a/app/models/metasploit/cache/authority.rb
+++ b/app/models/metasploit/cache/authority.rb
@@ -8,6 +8,7 @@ class Metasploit::Cache::Authority < ActiveRecord::Base
 
   autoload :Bid
   autoload :Cve
+  autoload :Cwe
   autoload :Msb
   autoload :Osvdb
   autoload :Pmasa

--- a/app/models/metasploit/cache/authority.rb
+++ b/app/models/metasploit/cache/authority.rb
@@ -17,6 +17,7 @@ class Metasploit::Cache::Authority < ActiveRecord::Base
   autoload :Seed
   autoload :UsCertVu
   autoload :Waraxe
+  autoload :Wpvdb
   autoload :Zdi
 
   #

--- a/app/models/metasploit/cache/authority.rb
+++ b/app/models/metasploit/cache/authority.rb
@@ -9,6 +9,7 @@ class Metasploit::Cache::Authority < ActiveRecord::Base
   autoload :Bid
   autoload :Cve
   autoload :Cwe
+  autoload :Edb
   autoload :Msb
   autoload :Osvdb
   autoload :Pmasa

--- a/app/models/metasploit/cache/auxiliary/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/auxiliary/instance/ephemeral.rb
@@ -79,6 +79,7 @@ class Metasploit::Cache::Auxiliary::Instance::Ephemeral < Metasploit::Model::Bas
       synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
         synchronizer.synchronize(
             destination: block_destination,
+            logger: tagged,
             source: metasploit_module_instance
         )
       }

--- a/app/models/metasploit/cache/encoder/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/encoder/instance/ephemeral.rb
@@ -66,21 +66,25 @@ class Metasploit::Cache::Encoder::Instance::Ephemeral < Metasploit::Model::Base
         Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
     ]
 
-    synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
-      synchronizer.synchronize(
-          destination: block_destination,
-          source: metasploit_module_instance
-      )
-    }
+    synchronized = nil
 
-    saved = ActiveRecord::Base.connection_pool.with_connection {
-      synchronized.batched_save
-    }
-
-    unless saved
-      log_error(synchronized) {
-        "Could not be persisted to #{synchronized.class}: #{synchronized.errors.full_messages.to_sentence}"
+    with_encoder_instance_tag(to) do |tagged|
+      synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
+        synchronizer.synchronize(
+            destination: block_destination,
+            source: metasploit_module_instance
+        )
       }
+
+      saved = ActiveRecord::Base.connection_pool.with_connection {
+        synchronized.batched_save
+      }
+
+      unless saved
+        tagged.error {
+          "Could not be persisted to #{synchronized.class}: #{synchronized.errors.full_messages.to_sentence}"
+        }
+      end
     end
 
     synchronized
@@ -88,28 +92,27 @@ class Metasploit::Cache::Encoder::Instance::Ephemeral < Metasploit::Model::Base
 
   private
 
-  # Logs errors to {#logger} with `encoder_instance`'s {Metasploit::Cache::Encoder::Instance#encoder_class}'s
-  # {Metasploit::Cache::Direct::Class#ancestor}'s {Metasploit::Cache::Module::Ancestor#real_pathname}.
-  #
-  # @yield Block called when logger severity is error or worse.
-  # @yieldreturn [String] Message to print to log as error if logger severity level allows for print of ERROR messages.
-  # @return [void]
-  def log_error(encoder_instance, &block)
-    if logger.error?
-      real_path = ActiveRecord::Base.connection_pool.with_connection {
-        encoder_instance.encoder_class.ancestor.real_pathname.to_s
-      }
-
-      logger.tagged(real_path) do |tagged|
-        tagged.error(&block)
-      end
-    end
-  end
-
   # {Metasploit::Cache::Module::Ancestor#real_path_sha1_hex_digest} used to resurrect {#auxiliary_instance}.
   #
   # @return [String]
   def real_path_sha1_hex_digest
     metasploit_module_instance.class.ephemeral_cache_by_source[:ancestor].real_path_sha1_hex_digest
+  end
+  
+  # Tags log with {Metasploit::Cache::Encoder::Instance#encoder_class}
+  # {Metasploit::Cache::Encoder::Class#ancestor} {Metasploit::Cache::Module::Ancestor#real_pathname}.
+  #
+  # @param encoder_instance [Metasploit::Cache::Encoder::Instance]
+  # @yield [tagged_logger]
+  # @yieldparam tagged_logger [ActiveSupport::TaggedLogger] {#logger} with
+  #   {Metasploit::Cache::Module#Ancestor#real_pathname} tag.
+  # @yieldreturn [void]
+  # @return [void]
+  def with_encoder_instance_tag(encoder_instance, &block)
+    real_path = ActiveRecord::Base.connection_pool.with_connection {
+      encoder_instance.encoder_class.ancestor.real_pathname.to_s
+    }
+
+    Metasploit::Cache::Logged.with_tagged_logger(ActiveRecord::Base, logger, real_path, &block)
   end
 end

--- a/app/models/metasploit/cache/encoder/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/encoder/instance/ephemeral.rb
@@ -72,6 +72,7 @@ class Metasploit::Cache::Encoder::Instance::Ephemeral < Metasploit::Model::Base
       synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
         synchronizer.synchronize(
             destination: block_destination,
+            logger: logger,
             source: metasploit_module_instance
         )
       }

--- a/app/models/metasploit/cache/exploit/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/exploit/instance/ephemeral.rb
@@ -81,6 +81,7 @@ class Metasploit::Cache::Exploit::Instance::Ephemeral < Metasploit::Model::Base
       synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
         synchronizer.synchronize(
             destination: block_destination,
+            logger: tagged,
             source: metasploit_module_instance
         )
       }

--- a/app/models/metasploit/cache/exploit/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/exploit/instance/ephemeral.rb
@@ -6,6 +6,7 @@ class Metasploit::Cache::Exploit::Instance::Ephemeral < Metasploit::Model::Base
 
   autoload :ExploitTargets
   autoload :ReferencableReferences
+  autoload :Stance
 
   #
   # Attributes
@@ -60,7 +61,7 @@ class Metasploit::Cache::Exploit::Instance::Ephemeral < Metasploit::Model::Base
   #   Giving `to` saves a database lookup if {#exploit_instance} is not loaded.
   # @return [Metasploit::Cache:Exploit::Instance] `#persisted?` will be `false` if saving fails.
   def persist(to: exploit_instance)
-    [:description, :name, :privileged, :stance].each do |attribute|
+    [:description, :name, :privileged].each do |attribute|
       to.send("#{attribute}=", metasploit_module_instance.send(attribute))
     end
 
@@ -70,7 +71,8 @@ class Metasploit::Cache::Exploit::Instance::Ephemeral < Metasploit::Model::Base
         Metasploit::Cache::Contributable::Ephemeral::Contributions,
         self.class::ExploitTargets,
         Metasploit::Cache::Licensable::Ephemeral::LicensableLicenses,
-        Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences
+        Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences,
+        self.class::Stance
     ]
 
     synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|

--- a/app/models/metasploit/cache/exploit/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/exploit/instance/ephemeral.rb
@@ -75,21 +75,25 @@ class Metasploit::Cache::Exploit::Instance::Ephemeral < Metasploit::Model::Base
         self.class::Stance
     ]
 
-    synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
-      synchronizer.synchronize(
-          destination: block_destination,
-          source: metasploit_module_instance
-      )
-    }
+    synchronized = nil
 
-    saved = ActiveRecord::Base.connection_pool.with_connection {
-      synchronized.batched_save
-    }
-
-    unless saved
-      log_error(synchronized) {
-        "Could not be persisted to #{synchronized.class}: #{synchronized.errors.full_messages.to_sentence}"
+    with_exploit_instance_tag(to) do |tagged|
+      synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
+        synchronizer.synchronize(
+            destination: block_destination,
+            source: metasploit_module_instance
+        )
       }
+
+      saved = ActiveRecord::Base.connection_pool.with_connection {
+        synchronized.batched_save
+      }
+
+      unless saved
+        tagged.error {
+          "Could not be persisted to #{synchronized.class}: #{synchronized.errors.full_messages.to_sentence}"
+        }
+      end
     end
 
     synchronized
@@ -97,28 +101,27 @@ class Metasploit::Cache::Exploit::Instance::Ephemeral < Metasploit::Model::Base
 
   private
 
-  # Logs errors to {#logger} with `exploit_instance`'s {Metasploit::Cache::Exploit::Instance#exploit_class}'s
-  # {Metasploit::Cache::Direct::Class#ancestor}'s {Metasploit::Cache::Module::Ancestor#real_pathname}.
-  #
-  # @yield Block called when logger severity is error or worse.
-  # @yieldreturn [String] Message to print to log as error if logger severity level allows for print of ERROR messages.
-  # @return [void]
-  def log_error(exploit_instance, &block)
-    if logger.error?
-      real_path = ActiveRecord::Base.connection_pool.with_connection {
-        exploit_instance.exploit_class.ancestor.real_pathname.to_s
-      }
-
-      logger.tagged(real_path) do |tagged|
-        tagged.error(&block)
-      end
-    end
-  end
-
   # {Metasploit::Cache::Module::Ancestor#real_path_sha1_hex_digest} used to resurrect {#auxiliary_instance}.
   #
   # @return [String]
   def real_path_sha1_hex_digest
     metasploit_module_instance.class.ephemeral_cache_by_source[:ancestor].real_path_sha1_hex_digest
+  end
+
+  # Tags log with {Metasploit::Cache::Exploit::Instance#exploit_class} {Metasploit::Cache::Exploit::Class#ancestor}
+  # {Metasploit::Cache::Module::Ancestor#real_pathname}.
+  #
+  # @param exploit_instance [Metasploit::Cache::Exploit::Instance]
+  # @yield [tagged_logger]
+  # @yieldparam tagged_logger [ActiveSupport::TaggedLogger] {#logger} with
+  #   {Metasploit::Cache::Module#Ancestor#real_pathname} tag.
+  # @yieldreturn [void]
+  # @return [void]
+  def with_exploit_instance_tag(exploit_instance, &block)
+    real_path = ActiveRecord::Base.connection_pool.with_connection {
+      exploit_instance.exploit_class.ancestor.real_pathname.to_s
+    }
+
+    Metasploit::Cache::Logged.with_tagged_logger(ActiveRecord::Base, logger, real_path, &block)
   end
 end

--- a/app/models/metasploit/cache/referencable/reference.rb
+++ b/app/models/metasploit/cache/referencable/reference.rb
@@ -32,7 +32,8 @@ class Metasploit::Cache::Referencable::Reference < ActiveRecord::Base
   # The reference associated with the referencable
   belongs_to :reference,
              class_name: 'Metasploit::Cache::Reference',
-             inverse_of: :referencable_references
+             inverse_of: :referencable_references,
+             validate: true
 
   #
   # Validations

--- a/lib/metasploit/cache.rb
+++ b/lib/metasploit/cache.rb
@@ -50,6 +50,7 @@ module Metasploit
     autoload :Invalid
     autoload :Licensable
     autoload :License
+    autoload :Logged
     autoload :Login
     autoload :Module
     autoload :NilifyBlanks

--- a/lib/metasploit/cache/actionable/ephemeral/actions.rb
+++ b/lib/metasploit/cache/actionable/ephemeral/actions.rb
@@ -83,9 +83,11 @@ module Metasploit::Cache::Actionable::Ephemeral::Actions
   # Synchronizes actions from Metasploit Module instance `source` to persisted `#actions` on `destination`.
   #
   # @param destination [ActiveRecord::Base, #actions]
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
   # @param source [#actions] Metasploit Module instance
   # @return [#actions] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       cached_destination_attribute_set = destination_attribute_set(destination)
       cached_source_attribute_set = source_attribute_set(source)

--- a/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
+++ b/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
@@ -113,12 +113,19 @@ module Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectur
   # The set of architecture abbreviations from `#arch` from the `source` Metasploit Module instance.
   #
   # @param source [#arch] Metasploit Module instance
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with the
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
   # @return [Set<String>] Set of architecture abbreviations
-  def self.source_attribute_set(source)
+  def self.source_attribute_set(source, logger:)
     source.arch.each_with_object(Set.new) { |abbreviation, set|
       canonical_abbreviations = CANONICAL_ABBREVIATIONS_BY_SOURCE_ABBREVIATION[abbreviation]
 
       if canonical_abbreviations
+        logger.warn {
+          "Deprecated, non-canonical architecture abbreviation (#{abbreviation.inspect}) converted to canonical " \
+          "abbreviations (#{canonical_abbreviations.inspect})"
+        }
+
         set.merge(canonical_abbreviations)
       else
         set.add abbreviation
@@ -139,7 +146,10 @@ module Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectur
       reduce(
           destination: destination,
           destination_attribute_set: destination_attribute_set(destination),
-          source_attribute_set: source_attribute_set(source)
+          source_attribute_set: source_attribute_set(
+              source,
+              logger: logger
+          )
       )
     }
   end

--- a/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
+++ b/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
@@ -9,6 +9,9 @@ module Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectur
       'mips' => [
           'mipsbe',
           'mipsle'
+      ],
+      'x64' => [
+          'x86_64'
       ]
   }
 

--- a/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
+++ b/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures.rb
@@ -127,9 +127,11 @@ module Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectur
   # {#destination}.
   #
   # @param destination [#architecturable_architectures] a {Metasploit::Cache::Architecturable::Architecture#architecturable}.
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
   # @param source [#arch] a Metasploit Module instance
   # @return [#architecturable_architectures] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       reduce(
           destination: destination,

--- a/lib/metasploit/cache/authority/cwe.rb
+++ b/lib/metasploit/cache/authority/cwe.rb
@@ -1,0 +1,10 @@
+# Common Weakness Enumeration authority-specific code.
+module Metasploit::Cache::Authority::Cwe
+  # Returns URL to {Metasploit::Cache::Reference#designation Weakness ID's} page.
+  #
+  # @param designation [String] N+ Weakness ID
+  # @return [String] URL
+  def self.designation_url(designation)
+    "https://cwe.mitre.org/data/definitions/#{designation}.html"
+  end
+end

--- a/lib/metasploit/cache/authority/edb.rb
+++ b/lib/metasploit/cache/authority/edb.rb
@@ -1,0 +1,10 @@
+# Exploit Database authority-specific code.
+module Metasploit::Cache::Authority::Edb
+  # Returns URL to {Metasploit::Cache::Reference#designation Exploit Database ID's} page.
+  #
+  # @param designation [String] N+ Exploit Database ID.
+  # @return [String] URL
+  def self.designation_url(designation)
+    "https://www.exploit-db.com/exploits/#{designation}"
+  end
+end

--- a/lib/metasploit/cache/authority/seed.rb
+++ b/lib/metasploit/cache/authority/seed.rb
@@ -72,6 +72,12 @@ module Metasploit::Cache::Authority::Seed
           :url => 'http://www.waraxe.us/content-cat-1.html'
       },
       {
+          abbreviation: 'WPVDB',
+          obsolete: false,
+          summary: 'WPScan Vulnerability Database',
+          url: 'https://wpvulndb.com'
+      },
+      {
           abbreviation: 'ZDI',
           obsolete: false,
           summary: 'Zero Day Initiative',

--- a/lib/metasploit/cache/authority/seed.rb
+++ b/lib/metasploit/cache/authority/seed.rb
@@ -18,6 +18,12 @@ module Metasploit::Cache::Authority::Seed
           :url => 'http://cvedetails.com'
       },
       {
+          abbreviation: 'CWE',
+          obsolete: false,
+          summary: 'Common Weakness Enumeration',
+          url: 'https://cwe.mitre.org/data/index.html'
+      },
+      {
           :abbreviation => 'MIL',
           :obsolete => true,
           :summary => 'milw0rm',

--- a/lib/metasploit/cache/authority/seed.rb
+++ b/lib/metasploit/cache/authority/seed.rb
@@ -24,6 +24,12 @@ module Metasploit::Cache::Authority::Seed
           url: 'https://cwe.mitre.org/data/index.html'
       },
       {
+          abbreviation: 'EDB',
+          obsolete: false,
+          summary: 'Offensive Security Exploit Database Archive',
+          url: 'https://www.exploit-db.com'
+      },
+      {
           :abbreviation => 'MIL',
           :obsolete => true,
           :summary => 'milw0rm',

--- a/lib/metasploit/cache/authority/wpvdb.rb
+++ b/lib/metasploit/cache/authority/wpvdb.rb
@@ -1,0 +1,10 @@
+# WPScan Vulnerability Database authority-specific code.
+module Metasploit::Cache::Authority::Wpvdb
+  # Returns URL to {Metasploit::Cache::Reference#designation Vulnerability ID's} page.
+  #
+  # @param designation [String] N+ Vulnerability ID
+  # @return [String] URL
+  def self.designation_url(designation)
+    "https://wpvulndb.com/vulnerabilities/#{designation}"
+  end
+end

--- a/lib/metasploit/cache/contributable/ephemeral/contributions.rb
+++ b/lib/metasploit/cache/contributable/ephemeral/contributions.rb
@@ -161,9 +161,11 @@ module Metasploit::Cache::Contributable::Ephemeral::Contributions
   # Synchronizes authors from Metasploit Module instance `source` to persisted `#contributions` on {#destination}.
   #
   # @param destination [#contributions] a {Metasploit::Cache::Contribution#contributable}.
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathnam}.
   # @param source [#authors] a Metasploit Module instance
   # @return [#contributions] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       cached_contribution_by_attributes = contribution_by_attributes(destination)
       cached_destination_attributes_set = destination_attributes_set(cached_contribution_by_attributes)

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -10,10 +10,12 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
   # @param destination_attributes_by_name [Hash{String => Object}] Hash with {Metasploit::Cache::Exploit::Target#name}
   #   of `destination` keys.
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}
   # @param source_attributes_by_name [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
   #   Maps `target.name` to exploit Metasploit Module instance target attributes.
   # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets]
-  def self.build_added(destination:, destination_attributes_by_name:, source_attributes_by_name:)
+  def self.build_added(destination:, destination_attributes_by_name:, logger:, source_attributes_by_name:)
     destination_name_set = name_set(destination_attributes_by_name)
     source_name_set = name_set(source_attributes_by_name)
     added_name_set = Metasploit::Cache::Ephemeral::AttributeSet.added(
@@ -37,6 +39,7 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
         Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.build_added(
             destination: target,
             destination_attribute_set: Set.new,
+            logger: logger,
             source_attribute_set: attributes.fetch(:platform_fully_qualified_name_set)
         )
       end
@@ -188,14 +191,22 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
           logger: logger
       )
 
-      reduced = [:mark_removed_for_destruction, :update_changed, :build_added].reduce(destination) { |block_destination, method|
+      marked = mark_removed_for_destruction(
+                   destination: destination,
+                   destination_attributes_by_name: cached_destination_attributes_by_name,
+                   source_attributes_by_name: cached_source_attributes_by_name
+      )
+
+      reduced = [:update_changed, :build_added].reduce(marked) { |block_destination, method|
         public_send(
             method,
             destination: block_destination,
             destination_attributes_by_name: cached_destination_attributes_by_name,
+            logger: logger,
             source_attributes_by_name: cached_source_attributes_by_name
         )
       }
+
       update_default_exploit_target(
           destination: reduced,
           source: source
@@ -210,9 +221,11 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #exploit_targets]
   # @param destination_attributes_by_name [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
   # @param source_attributes_by_name [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
   # @return [Metasploit::Cache::Exploit::Instance, #exploit_targets] `destination`
-  def self.update_changed(destination:, destination_attributes_by_name:, source_attributes_by_name:)
+  def self.update_changed(destination:, destination_attributes_by_name:, logger:, source_attributes_by_name:)
     unless destination.new_record?
       destination_name_set = name_set(destination_attributes_by_name)
       source_name_set = name_set(source_attributes_by_name)
@@ -249,6 +262,7 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
           Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.reduce(
               destination: exploit_target,
               destination_attribute_set: destination_platform_fully_qualified_name_set,
+              logger: logger,
               source_attribute_set: source_platform_fully_qualified_name_set
           )
         }

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -168,9 +168,11 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # {Metasploit::Cache::Exploit::Instance#default_exploit_target} on `destination`.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #default_exploit_target, #exploit_targets]
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathnam}.
   # @param source [#default_target, #targets] an exploit Metasploit Module instance
   # @return [Metasploit::Cache::Exploit::Instance, #default_exploit_target, #exploit_targets] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       cached_destination_attributes_by_name = destination_attributes_by_name(destination)
       cached_source_attributes_by_name = source_attributes_by_name(source)

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -132,19 +132,27 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   # platforms.
   #
   # @param source [#targets] exploit Metasploit Module instance
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}
   # @return [Hash{String => Hash{architecture_abbreviation_set: Set<String>, index: Integer, platform_fully_qualified_name_set: Set<String>}}]
   #   Maps target name to other attributes.
-  def self.source_attributes_by_name(source)
+  def self.source_attributes_by_name(source, logger:)
     source_architecture_abbreviation_set = nil
     source_platform_fully_qualified_name_set = nil
 
     source.targets.each_with_index.each_with_object({}) do |(target, index), attributes_by_name|
       # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L141-L144
       if target.arch.nil?
-        source_architecture_abbreviation_set ||= Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(source)
+        source_architecture_abbreviation_set ||= Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(
+            source,
+            logger: logger
+        )
         architecture_abbreviation_set = source_architecture_abbreviation_set
       else
-        architecture_abbreviation_set = Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(target)
+        architecture_abbreviation_set = Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(
+            target,
+            logger: logger
+        )
       end
 
       # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L136
@@ -175,7 +183,10 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
   def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       cached_destination_attributes_by_name = destination_attributes_by_name(destination)
-      cached_source_attributes_by_name = source_attributes_by_name(source)
+      cached_source_attributes_by_name = source_attributes_by_name(
+          source,
+          logger: logger
+      )
 
       reduced = [:mark_removed_for_destruction, :update_changed, :build_added].reduce(destination) { |block_destination, method|
         public_send(

--- a/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets.rb
@@ -143,7 +143,7 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets
     source.targets.each_with_index.each_with_object({}) do |(target, index), attributes_by_name|
       # @see https://github.com/rapid7/metasploit-framework/blob/7113c801b1bb332db0f63078ae8bad5dc9da9157/lib/msf/core/module/target.rb#L141-L144
       if target.arch.nil?
-        source_architecture_abbreviation_set ||= Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(
+        source_architecture_abbreviation_set ||= Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.present_source_attribute_set(
             source,
             logger: logger
         )

--- a/lib/metasploit/cache/exploit/instance/ephemeral/stance.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/stance.rb
@@ -1,0 +1,41 @@
+# Normalizes exploit Metasploit Module instance `#stance`, which can be aggressive, passive, or both.  Aggressive and
+# both are counted as aggressive, since any aggressiveness means the module can be used to start an attack on a target.
+module Metasploit::Cache::Exploit::Instance::Ephemeral::Stance
+  # Method to check for stance in `source_stance`.
+  #
+  # @param source_stance [Array<String>, String]
+  # @return [#call(String)]
+  def self.is_stance_method(source_stance)
+    name = case source_stance
+           when Array
+             :include?
+           else
+             :==
+           end
+
+    source_stance.method(name)
+  end
+
+  # Synchronizes the `#stance` from exploit Metasploit MOdule instance `source` to persisted
+  # {Metasploit::Cache::Exploit::Instance#stance} on `destination`.
+  #
+  # @param destination [Metasploit::Cache::Exploit::Instance, #stance]
+  # @param source [#stance]
+  # @return [Metasploit::Cache::Exploit::Instance, #stance] `destination`
+  def self.synchronize(destination:, source:)
+    is_source_stance = is_stance_method(source.stance)
+
+    # reset to nil in case stance has changed to an unrecognized value
+    destination.stance = nil
+
+    Metasploit::Cache::Module::Stance::PRECEDENCE.each do |stance|
+      if is_source_stance.(stance)
+        destination.stance = stance
+
+        break
+      end
+    end
+
+    destination
+  end
+end

--- a/lib/metasploit/cache/exploit/instance/ephemeral/stance.rb
+++ b/lib/metasploit/cache/exploit/instance/ephemeral/stance.rb
@@ -20,9 +20,11 @@ module Metasploit::Cache::Exploit::Instance::Ephemeral::Stance
   # {Metasploit::Cache::Exploit::Instance#stance} on `destination`.
   #
   # @param destination [Metasploit::Cache::Exploit::Instance, #stance]
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathnam}.
   # @param source [#stance]
   # @return [Metasploit::Cache::Exploit::Instance, #stance] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     is_source_stance = is_stance_method(source.stance)
 
     # reset to nil in case stance has changed to an unrecognized value

--- a/lib/metasploit/cache/licensable/ephemeral/licensable_licenses.rb
+++ b/lib/metasploit/cache/licensable/ephemeral/licensable_licenses.rb
@@ -79,9 +79,11 @@ module Metasploit::Cache::Licensable::Ephemeral::LicensableLicenses
   # Synchronizes license from Metasploit Module instance `source` to persisted `#licenses` on `destination`.
   #
   # @param destination [#licenses] a {Metasploit::Cache::Licensable::License#licensable}.
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathnam}.
   # @param source [#license] a Metasploit Module instance
   # @return [#licenses] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       cached_destination_attribute_set = destination_attribute_set(destination)
       cached_source_attribute_set = source_attribute_set(source)

--- a/lib/metasploit/cache/logged.rb
+++ b/lib/metasploit/cache/logged.rb
@@ -1,0 +1,36 @@
+# Modifies logger of logged for duration of the blocks.
+module Metasploit::Cache::Logged
+  # Changes `#logger` on `logged` for the duration of the block to `logger`.
+  #
+  # @param logged [#logger, #logger=]
+  # @param logger [Logger]
+  # @yield [logger]
+  # @yieldparam logger [Logger] `logger`
+  # @yieldreturn [void]
+  # @return [void]
+  def self.with_logger(logged, logger)
+    original_logger = logged.logger
+
+    begin
+      logged.logger = logger
+
+      yield logger
+    ensure
+      logged.logger = original_logger
+    end
+  end
+
+  # Tags {#logger} with the given tag and then runs block {with_logger}.
+  #
+  # @param logged [#logger, #logger=]
+  # @param logger [ActiveSupport::TaggedLogger, #tagged]
+  # @yield [logger]
+  # @yieldparam logger [ActiveSupport::TaggedLogger] `logger` with `tag` applied
+  # @yieldreturn [void]
+  # @return [void]
+  def self.with_tagged_logger(logged, logger, tag, &block)
+    logger.tagged(tag) do
+      with_logger(logged, logger, &block)
+    end
+  end
+end

--- a/lib/metasploit/cache/module/instance/load.rb
+++ b/lib/metasploit/cache/module/instance/load.rb
@@ -133,6 +133,10 @@ class Metasploit::Cache::Module::Instance::Load < Metasploit::Model::Base
   #
   # @return [void]
   def metasploit_module_class_new_valid
+    # ensure metasploit_module_instance loading is attempted prior to check if there was an exception.  This ensures
+    # there is no dependency on validation order.
+    metasploit_module_instance
+
     if metasploit_module_class_new_exception
       errors.add(
                 :metasploit_module_class_new,

--- a/lib/metasploit/cache/module/instance/load.rb
+++ b/lib/metasploit/cache/module/instance/load.rb
@@ -9,6 +9,11 @@ class Metasploit::Cache::Module::Instance::Load < Metasploit::Model::Base
   # @return [#new(metasploit_module_instance: Object, logger: ActiveSupport::TaggedLogging)]
   attr_accessor :ephemeral_class
 
+  # Framework that {#metasploit_module_class} `#initialize` can access Metasploit Framework world state.
+  #
+  # @return metasploit_framework [#events]
+  attr_accessor :metasploit_framework
+
   # The module instance being loaded.
   #
   # @return [ActiveRecord::Base]
@@ -21,7 +26,7 @@ class Metasploit::Cache::Module::Instance::Load < Metasploit::Model::Base
 
   # `Metasploit<n>` ruby `Class` declared in {Metasploit::Cache::Module::Ancestor#contents}.
   #
-  # @return [Class]
+  # @return [Class, #framework=]
   attr_accessor :metasploit_module_class
 
   # Exception raised when `new` is called on {#metasploit_module_class}.
@@ -50,13 +55,15 @@ class Metasploit::Cache::Module::Instance::Load < Metasploit::Model::Base
 
   validates :ephemeral_class,
             presence: true
-  validates :module_instance,
+  validates :metasploit_framework,
             presence: true
   validates :metasploit_module_instance,
             presence: {
                 unless: :loading_context?
             }
   validates :metasploit_module_class,
+            presence: true
+  validates :module_instance,
             presence: true
   validates :logger,
             presence: true
@@ -109,6 +116,8 @@ class Metasploit::Cache::Module::Instance::Load < Metasploit::Model::Base
   #   Exception is saved to `metasploit_module_class_new_exception`.
   def metasploit_module_class_new
     begin
+      metasploit_module_class.framework = metasploit_framework
+
       metasploit_module_class.new
     rescue Interrupt
       # handle Interrupt as pass-through unlike other Exceptions so users can bail with Ctrl+C

--- a/lib/metasploit/cache/module/stance.rb
+++ b/lib/metasploit/cache/module/stance.rb
@@ -13,4 +13,10 @@ module Metasploit::Cache::Module::Stance
       AGGRESSIVE,
       PASSIVE
   ]
+
+  # If a module has an array of stances, then {AGGRESSIVE} is favored or {PASSIVE}.
+  PRECEDENCE = [
+      AGGRESSIVE,
+      PASSIVE
+  ]
 end

--- a/lib/metasploit/cache/platform/seed.rb
+++ b/lib/metasploit/cache/platform/seed.rb
@@ -15,7 +15,7 @@ module Metasploit::Cache::Platform::Seed
       'Firefox' => nil,
       'FreeBSD' => nil,
       'HPUX' => nil,
-      'IRIX' => nil,
+      'Irix' => nil,
       'Java' => nil,
       'Javascript' => nil,
       'Linux' => nil,

--- a/lib/metasploit/cache/platform/seed.rb
+++ b/lib/metasploit/cache/platform/seed.rb
@@ -17,7 +17,7 @@ module Metasploit::Cache::Platform::Seed
       'HPUX' => nil,
       'Irix' => nil,
       'Java' => nil,
-      'Javascript' => nil,
+      'JavaScript' => nil,
       'Linux' => nil,
       'NetBSD' => nil,
       'Netware' => nil,

--- a/lib/metasploit/cache/platformable/ephemeral/platformable_platforms.rb
+++ b/lib/metasploit/cache/platformable/ephemeral/platformable_platforms.rb
@@ -136,9 +136,11 @@ module Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
   # `#platformable_platforms` on {#destination}.
   #
   # @param destination [#platformable_platforms] a {Metasploit::Cache::Platformable::Platform#platformable}.
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
   # @param source [#platform] a Metasploit Module instance
   # @return [#platformable_platforms] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       reduce(
           destination: destination,

--- a/lib/metasploit/cache/referencable/ephemeral/referencable_references.rb
+++ b/lib/metasploit/cache/referencable/ephemeral/referencable_references.rb
@@ -42,11 +42,12 @@ module Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences
   #   Set of Hashes of either
   #   `{authority: {abbreviation: Metasploit::Cache::Authority#abbreviation}, designation: Metasploit::Cache::Reference#designation}`
   #   or `{url: Metasploit::Cache::Reference#url}` on `destination`.
+  # @param logger (see Metasploit::Cache::Reference::Ephemeral.new_by_attributes_proc)
   # @param source_attributes_set [Set<Hash{authority: Hash{abbreviation: String}, destination: String}, Hash{url: String}>]
   #   Set of Hashes of either `{authority: {abbreviation: ctx_id}, designation: ctx_val}` or `{url: ctx_val}` of
   #   `references` of `source`.
   # @return [#referencable_references] `destination`
-  def self.build_added(destination:, destination_attributes_set:, source_attributes_set:)
+  def self.build_added(destination:, destination_attributes_set:, logger:, source_attributes_set:)
     cached_added_attributes_set = Metasploit::Cache::Ephemeral::AttributeSet.added(
         destination: destination_attributes_set,
         source: source_attributes_set
@@ -55,7 +56,8 @@ module Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences
     cached_authority_by_abbreviation = authority_by_abbreviation(cached_added_attributes_set)
     cached_reference_by_attributes = Metasploit::Cache::Reference::Ephemeral.by_attributes(
         attributes_set: cached_added_attributes_set,
-        authority_by_abbreviation: cached_authority_by_abbreviation
+        authority_by_abbreviation: cached_authority_by_abbreviation,
+        logger: logger
     )
 
     cached_added_attributes_set.each do |attributes|
@@ -183,7 +185,8 @@ module Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences
       build_added(
           destination: marked,
           destination_attributes_set: cached_destination_attributes_set,
-          source_attributes_set: cached_source_attributes_set
+          source_attributes_set: cached_source_attributes_set,
+          logger: logger
       )
     }
   end

--- a/lib/metasploit/cache/referencable/ephemeral/referencable_references.rb
+++ b/lib/metasploit/cache/referencable/ephemeral/referencable_references.rb
@@ -164,9 +164,11 @@ module Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences
   # {#destination}.
   #
   # @param destination [#referencable_references] a {Metasploit::Cache::Referencable::Reference#referencable}.
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathnam}.
   # @param source [#references] a Metasploit Module instance
   # @return [#referencable_references] `destination`
-  def self.synchronize(destination:, source:)
+  def self.synchronize(destination:, logger:, source:)
     Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
       cached_referencable_reference_by_attributes = referencable_reference_by_attributes(destination)
       cached_destination_attributes_set = destination_attributes_set(cached_referencable_reference_by_attributes)

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -11,9 +11,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 68
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 6
+      PATCH = 7
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-      PRERELEASE = 'unify-instance-loads'
+      PRERELEASE = 'load-exploit-instance-from-metasploit-framework'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/authority_spec.rb
+++ b/spec/app/models/metasploit/cache/authority_spec.rb
@@ -180,6 +180,13 @@ RSpec.describe Metasploit::Cache::Authority do
                           :url => 'http://www.waraxe.us/content-cat-1.html'
 
     it_should_behave_like 'Metasploit::Cache::Authority seed',
+                          :abbreviation => 'WPVDB',
+                          :extension_name => 'Metasploit::Cache::Authority::Wpvdb',
+                          :obsolete => false,
+                          :summary => 'WPScan Vulnerability Database',
+                          :url => 'https://wpvulndb.com'
+
+    it_should_behave_like 'Metasploit::Cache::Authority seed',
                           abbreviation: 'ZDI',
                           extension_name: 'Metasploit::Cache::Authority::Zdi',
                           obsolete: false,

--- a/spec/app/models/metasploit/cache/authority_spec.rb
+++ b/spec/app/models/metasploit/cache/authority_spec.rb
@@ -117,6 +117,13 @@ RSpec.describe Metasploit::Cache::Authority do
                           :url => 'http://cvedetails.com'
 
     it_should_behave_like 'Metasploit::Cache::Authority seed',
+                          abbreviation: 'CWE',
+                          extension_name: 'Metasploit::Cache::Authority::Cwe',
+                          obsolete: false,
+                          summary: 'Common Weakness Enumeration',
+                          url: 'https://cwe.mitre.org/data/index.html'
+
+    it_should_behave_like 'Metasploit::Cache::Authority seed',
                           :abbreviation => 'MIL',
                           :extension_name => nil,
                           :obsolete => true,

--- a/spec/app/models/metasploit/cache/authority_spec.rb
+++ b/spec/app/models/metasploit/cache/authority_spec.rb
@@ -124,6 +124,13 @@ RSpec.describe Metasploit::Cache::Authority do
                           url: 'https://cwe.mitre.org/data/index.html'
 
     it_should_behave_like 'Metasploit::Cache::Authority seed',
+                          abbreviation: 'EDB',
+                          extension_name: 'Metasploit::Cache::Authority::Edb',
+                          obsolete: false,
+                          summary: 'Offensive Security Exploit Database Archive',
+                          url: 'https://www.exploit-db.com'
+
+    it_should_behave_like 'Metasploit::Cache::Authority seed',
                           :abbreviation => 'MIL',
                           :extension_name => nil,
                           :obsolete => true,

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -162,7 +162,19 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
 
                   module_instance_load.valid?
 
-                  expect(metasploit_cache_auxiliary_instance).to be_valid
+                  unless metasploit_cache_auxiliary_instance.valid?
+                    # Only covered on failure
+                    # :nocov:
+                    fail "Expected #{metasploit_cache_auxiliary_instance.class} to be valid, but got errors:\n" \
+                         "#{metasploit_cache_auxiliary_instance.errors.full_messages.join("\n")}\n" \
+                         "\n" \
+                         "Log:\n" \
+                         "#{log_string_io.string}\n" \
+                         "Expected #{module_instance_load.class} to be valid, but got errors:\n" \
+                         "#{module_instance_load.errors.full_messages.join("\n")}"
+                    # :nocov:
+                  end
+
                   expect(module_instance_load).to be_valid
                   expect(metasploit_cache_auxiliary_instance).to be_persisted
 

--- a/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/auxiliary/instance_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
                   StringIO.new
                 }
 
+                let(:metasploit_framework) {
+                  double('Metasploit::Framework')
+                }
+
                 let(:module_ancestor_load) {
                   Metasploit::Cache::Module::Ancestor::Load.new(
                       # This should match the major version number of metasploit-framework
@@ -131,9 +135,10 @@ RSpec.describe Metasploit::Cache::Auxiliary::Instance, type: :model do
                 let(:module_instance_load) {
                   Metasploit::Cache::Module::Instance::Load.new(
                       ephemeral_class: Metasploit::Cache::Auxiliary::Instance::Ephemeral,
+                      logger: logger,
+                      metasploit_framework: metasploit_framework,
                       metasploit_module_class: direct_class_load.metasploit_class,
                       module_instance: metasploit_cache_auxiliary_instance,
-                      logger: logger
                   )
                 }
 

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -160,11 +160,23 @@ RSpec.describe Metasploit::Cache::Encoder::Instance, type: :model do
                   expect(direct_class_load).to be_valid
                   expect(encoder_class).to be_persisted
 
-                  expect(module_ancestor_load).to be_valid(:loading)
+                  expect(module_instance_load).to be_valid(:loading)
 
                   module_instance_load.valid?
+                  
+                  unless metasploit_cache_encoder_instance.valid?
+                    # Only covered on failure
+                    # :nocov:
+                    fail "Expected #{metasploit_cache_encoder_instance.class} to be valid, but got errors:\n" \
+                         "#{metasploit_cache_encoder_instance.errors.full_messages.join("\n")}\n" \
+                         "\n" \
+                         "Log:\n" \
+                         "#{log_string_io.string}\n" \
+                         "Expected #{module_instance_load.class} to be valid, but got errors:\n" \
+                         "#{module_instance_load.errors.full_messages.join("\n")}"
+                    # :nocov:
+                  end
 
-                  expect(metasploit_cache_encoder_instance).to be_valid
                   expect(module_instance_load).to be_valid
                   expect(metasploit_cache_encoder_instance).to be_persisted
 

--- a/spec/app/models/metasploit/cache/encoder/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/encoder/instance_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe Metasploit::Cache::Encoder::Instance, type: :model do
                   StringIO.new
                 }
 
+                let(:metasploit_framework) {
+                  double('Metasploit::Framework')
+                }
+
                 let(:module_ancestor_load) {
                   Metasploit::Cache::Module::Ancestor::Load.new(
                       # This should match the major version number of metasploit-framework
@@ -128,9 +132,10 @@ RSpec.describe Metasploit::Cache::Encoder::Instance, type: :model do
                 let(:module_instance_load) {
                   Metasploit::Cache::Module::Instance::Load.new(
                       ephemeral_class: Metasploit::Cache::Encoder::Instance::Ephemeral,
+                      logger: logger,
+                      metasploit_framework: metasploit_framework,
                       metasploit_module_class: direct_class_load.metasploit_class,
                       module_instance: metasploit_cache_encoder_instance,
-                      logger: logger
                   )
                 }
 

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -196,14 +196,25 @@ RSpec.describe Metasploit::Cache::Exploit::Instance, type: :model do
                   expect(direct_class_load).to be_valid
                   expect(exploit_class).to be_persisted
 
-                  expect(module_ancestor_load).to be_valid(:loading)
+                  expect(module_instance_load).to be_valid(:loading)
 
                   module_instance_load.valid?
 
-                  expect(full_metasploit_cache_exploit_instance).to be_valid
+                  unless full_metasploit_cache_exploit_instance.valid?
+                    # Only covered on failure
+                    # :nocov:
+                    fail "Expected #{full_metasploit_cache_exploit_instance.class} to be valid, but got errors:\n" \
+                         "#{full_metasploit_cache_exploit_instance.errors.full_messages.join("\n")}\n" \
+                         "\n" \
+                         "Log:\n" \
+                         "#{log_string_io.string}\n" \
+                         "Expected #{module_instance_load.class} to be valid, but got errors:\n" \
+                         "#{module_instance_load.errors.full_messages.join("\n")}"
+                    # :nocov:
+                  end
+
                   expect(module_instance_load).to be_valid
                   expect(full_metasploit_cache_exploit_instance).to be_persisted
-
 
                   expect(full_metasploit_cache_exploit_instance.contributions.count).to eq(contribution_count)
                   expect(full_metasploit_cache_exploit_instance.licensable_licenses.count).to eq(licensable_license_count)

--- a/spec/app/models/metasploit/cache/exploit/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/exploit/instance_spec.rb
@@ -144,6 +144,10 @@ RSpec.describe Metasploit::Cache::Exploit::Instance, type: :model do
                   StringIO.new
                 }
 
+                let(:metasploit_framework) {
+                  double('Metasploit::Framework')
+                }
+
                 let(:module_ancestor_load) {
                   Metasploit::Cache::Module::Ancestor::Load.new(
                       # This should match the major version number of metasploit-framework
@@ -156,9 +160,10 @@ RSpec.describe Metasploit::Cache::Exploit::Instance, type: :model do
                 let(:module_instance_load) {
                   Metasploit::Cache::Module::Instance::Load.new(
                       ephemeral_class: Metasploit::Cache::Exploit::Instance::Ephemeral,
+                      logger: logger,
+                      metasploit_framework: metasploit_framework,
                       metasploit_module_class: direct_class_load.metasploit_class,
-                      module_instance: full_metasploit_cache_exploit_instance,
-                      logger: logger
+                      module_instance: full_metasploit_cache_exploit_instance
                   )
                 }
 

--- a/spec/app/models/metasploit/cache/platform_spec.rb
+++ b/spec/app/models/metasploit/cache/platform_spec.rb
@@ -129,9 +129,9 @@ RSpec.describe Metasploit::Cache::Platform do
     it { should include 'Firefox' }
     it { should include 'FreeBSD' }
     it { should include 'HPUX' }
-    it { should include 'IRIX' }
+    it { should include 'Irix' }
     it { should include 'Java' }
-    it { should include 'Javascript' }
+    it { should include 'JavaScript' }
     it { should include 'NetBSD' }
     it { should include 'Netware' }
     it { should include 'NodeJS' }
@@ -249,9 +249,9 @@ RSpec.describe Metasploit::Cache::Platform do
     it { should include 'Firefox' }
     it { should include 'FreeBSD' }
     it { should include 'HPUX' }
-    it { should include 'IRIX' }
+    it { should include 'Irix' }
     it { should include 'Java' }
-    it { should include 'Javascript' }
+    it { should include 'JavaScript' }
     it { should include 'NetBSD' }
     it { should include 'Netware' }
     it { should include 'NodeJS' }

--- a/spec/app/models/metasploit/cache/referencable/reference_spec.rb
+++ b/spec/app/models/metasploit/cache/referencable/reference_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metasploit::Cache::Referencable::Reference do
 
   context "associations" do
     it { is_expected.to belong_to(:referencable) }
-    it { is_expected.to belong_to(:reference).class_name('Metasploit::Cache::Reference').inverse_of(:referencable_references) }
+    it { is_expected.to belong_to(:reference).class_name('Metasploit::Cache::Reference').inverse_of(:referencable_references).validate(true) }
   end
 
   context "validations" do

--- a/spec/app/models/metasploit/cache/reference_spec.rb
+++ b/spec/app/models/metasploit/cache/reference_spec.rb
@@ -154,6 +154,20 @@ RSpec.describe Metasploit::Cache::Reference do
           it_should_behave_like 'derives', :url, :validates => false
         end
 
+        context 'WPVDB' do
+          let(:abbreviation) do
+            'WPVDB'
+          end
+
+          let(:designation) do
+            FactoryGirl.generate :metasploit_cache_reference_wpvdb_designation
+          end
+
+          it_should_behave_like 'derives',
+                                :url,
+                                validates: false
+        end
+
         context 'ZDI' do
           let(:abbreviation) do
             'ZDI'

--- a/spec/app/models/metasploit/cache/reference_spec.rb
+++ b/spec/app/models/metasploit/cache/reference_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe Metasploit::Cache::Reference do
                                 validates: false
         end
 
+        context 'EDB' do
+          let(:abbreviation) {
+            'EDB'
+          }
+
+          let(:designation) {
+            FactoryGirl.generate :metasploit_cache_reference_edb_designation
+          }
+
+          it_should_behave_like 'derives',
+                                :url,
+                                validates: false
+        end
+
         context 'MSB' do
           let(:abbreviation) do
             'MSB'

--- a/spec/app/models/metasploit/cache/reference_spec.rb
+++ b/spec/app/models/metasploit/cache/reference_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe Metasploit::Cache::Reference do
           it_should_behave_like 'derives', :url, :validates => false
         end
 
+        context 'CWE' do
+          let(:abbreviation) {
+            'CWE'
+          }
+
+          let(:designation) {
+            FactoryGirl.generate :metasploit_cache_reference_cwe_designation
+          }
+
+          it_should_behave_like 'derives',
+                                :url,
+                                validates: false
+        end
+
         context 'MSB' do
           let(:abbreviation) do
             'MSB'

--- a/spec/factories/metasploit/cache/references.rb
+++ b/spec/factories/metasploit/cache/references.rb
@@ -123,6 +123,10 @@ FactoryGirl.define do
     "%d-SA#%d" % [year, number]
   end
 
+  sequence(:metasploit_cache_reference_wpvdb_designation) { |n|
+    n.to_s
+  }
+
   sequence :metasploit_cache_reference_zdi_designation do |n|
     year, number = n.divmod(1000)
 

--- a/spec/factories/metasploit/cache/references.rb
+++ b/spec/factories/metasploit/cache/references.rb
@@ -85,6 +85,10 @@ FactoryGirl.define do
     n.to_s
   }
 
+  sequence(:metasploit_cache_reference_edb_designation) { |n|
+    n.to_s
+  }
+
   sequence :metasploit_cache_reference_msb_designation do |n|
     number = n % 1000
     year = n / 1000

--- a/spec/factories/metasploit/cache/references.rb
+++ b/spec/factories/metasploit/cache/references.rb
@@ -81,6 +81,10 @@ FactoryGirl.define do
     "%04d-%04d" % [year, number]
   end
 
+  sequence(:metasploit_cache_reference_cwe_designation) { |n|
+    n.to_s
+  }
+
   sequence :metasploit_cache_reference_msb_designation do |n|
     number = n % 1000
     year = n / 1000

--- a/spec/lib/metasploit/cache/actionable/ephemeral/actions_spec.rb
+++ b/spec/lib/metasploit/cache/actionable/ephemeral/actions_spec.rb
@@ -447,6 +447,7 @@ RSpec.describe Metasploit::Cache::Actionable::Ephemeral::Actions do
     subject(:synchronize) {
       described_class.synchronize(
           destination: destination,
+          logger: logger,
           source: source
       )
     }
@@ -454,6 +455,16 @@ RSpec.describe Metasploit::Cache::Actionable::Ephemeral::Actions do
     #
     # lets
     #
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(log_string_io)
+      )
+    }
+
+    let(:log_string_io) {
+      StringIO.new
+    }
 
     let(:source) {
       double(

--- a/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
+++ b/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
@@ -345,12 +345,27 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
     subject(:synchronize) {
       described_class.synchronize(
                          destination: destination,
+                         logger: logger,
                          source: source
       )
     }
 
+    #
+    # lets
+    #
+
     let(:destination) {
       Metasploit::Cache::Encoder::Instance.new
+    }
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(log_string_io)
+      )
+    }
+
+    let(:log_string_io) {
+      StringIO.new
     }
 
     let(:source) {

--- a/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
+++ b/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
@@ -1,4 +1,30 @@
 RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures do
+  let(:logger) {
+    ActiveSupport::TaggedLogging.new(
+        Logger.new(log_string_io)
+    )
+  }
+
+  let(:log_string_io) {
+    StringIO.new
+  }
+
+  context 'CONSTANTS' do
+    context 'CANONICAL_ABBREVATIONS_BY_SOURCE_ABBREVATION' do
+      subject(:canonical_abbreviations_by_source_abbreviation) {
+        described_class::CANONICAL_ABBREVIATIONS_BY_SOURCE_ABBREVIATION
+      }
+
+      it "maps 'mips' to ['mipsbe', 'mipsle'] because mips archiectures are endian-specific" do
+        expect(canonical_abbreviations_by_source_abbreviation['mips']).to match_array ['mipsbe', 'mipsle']
+      end
+
+      it "maps 'x64' to 'x86_64' because multiple architectures have 64-bit variants" do
+        expect(canonical_abbreviations_by_source_abbreviation['x64']).to match_array ['x86_64']
+      end
+    end
+  end
+
   context 'build_added' do
     subject(:build_added) {
       described_class.build_added(
@@ -323,7 +349,19 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
         end
       end
 
-      context "without 'mips'" do
+      context "with 'x64'" do
+        let(:arch) {
+          [
+              'x64'
+          ]
+        }
+
+        it "includes 'x86_64'" do
+          expect(source_attribute_set).to eq Set.new ['x86_64']
+        end
+      end
+
+      context 'otherwise' do
         let(:arch) {
           [
               architecture_abbreviation

--- a/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
+++ b/spec/lib/metasploit/cache/architecturable/ephemeral/architecturable_architectures_spec.rb
@@ -319,7 +319,10 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
 
   context 'source_attribute_set' do
     subject(:source_attribute_set) {
-      described_class.source_attribute_set(source)
+      described_class.source_attribute_set(
+          source,
+          logger: logger
+      )
     }
 
     let(:source) {
@@ -344,6 +347,15 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
           ]
         }
 
+        it 'logs warning that abbreviation is deprecated' do
+          source_attribute_set
+
+          expect(log_string_io.string).to include(
+                                              'Deprecated, non-canonical architecture abbreviation ("mips") ' \
+                                              'converted to canonical abbreviations (["mipsbe", "mipsle"])'
+                                          )
+        end
+
         it "includes 'mipsbe' and 'mipsle'" do
           expect(source_attribute_set).to eq Set.new(['mipsbe', 'mipsle'])
         end
@@ -355,6 +367,15 @@ RSpec.describe Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArc
               'x64'
           ]
         }
+
+        it 'logs warning that abbreviation is deprecated' do
+          source_attribute_set
+
+          expect(log_string_io.string).to include(
+                                              'Deprecated, non-canonical architecture abbreviation ("x64") converted ' \
+                                              'to canonical abbreviations (["x86_64"])'
+                                          )
+        end
 
         it "includes 'x86_64'" do
           expect(source_attribute_set).to eq Set.new ['x86_64']

--- a/spec/lib/metasploit/cache/authority/cwe_spec.rb
+++ b/spec/lib/metasploit/cache/authority/cwe_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Metasploit::Cache::Authority::Cwe do
+  context 'designation_url' do
+    subject(:designation_url) {
+      described_class.designation_url(designation)
+    }
+
+    let(:designation) {
+      FactoryGirl.generate :metasploit_cache_reference_cwe_designation
+    }
+
+    it 'is under definitions directory' do
+      expect(designation_url).to eq("https://cwe.mitre.org/data/definitions/#{designation}.html")
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/authority/edb_spec.rb
+++ b/spec/lib/metasploit/cache/authority/edb_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Metasploit::Cache::Authority::Edb do
+  context 'designation_url' do
+    subject(:designation_url) {
+      described_class.designation_url(designation)
+    }
+
+    let(:designation) {
+      FactoryGirl.generate :metasploit_cache_reference_edb_designation
+    }
+
+    it 'is under exploits directory' do
+      expect(designation_url).to eq("https://www.exploit-db.com/exploits/#{designation}")
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/authority/wpvdb_spec.rb
+++ b/spec/lib/metasploit/cache/authority/wpvdb_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Metasploit::Cache::Authority::Wpvdb do
+  context 'designation_url' do
+    subject(:designation_url) {
+      described_class.designation_url(designation)
+    }
+
+    let(:designation) {
+      FactoryGirl.generate :metasploit_cache_reference_edb_designation
+    }
+
+    it 'is under vulnerabilities directory' do
+      expect(designation_url).to eq("https://wpvulndb.com/vulnerabilities/#{designation}")
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/batch/root_spec.rb
+++ b/spec/lib/metasploit/cache/batch/root_spec.rb
@@ -9,7 +9,15 @@ RSpec.describe Metasploit::Cache::Batch::Root do
     Class.new do
       include described_class
 
+      def logger
+        @logger ||= Logger.new(StringIO.new)
+      end
+
       def save
+
+      end
+
+      def valid?
 
       end
     end

--- a/spec/lib/metasploit/cache/contributable/ephemeral/contributions_spec.rb
+++ b/spec/lib/metasploit/cache/contributable/ephemeral/contributions_spec.rb
@@ -656,12 +656,17 @@ RSpec.describe Metasploit::Cache::Contributable::Ephemeral::Contributions do
     subject(:synchronize) {
       described_class.synchronize(
                          destination: destination,
+                         logger: logger,
                          source: source
       )
     }
 
     let(:destination) {
       Metasploit::Cache::Auxiliary::Instance.new
+    }
+
+    let(:logger) {
+      double('ActiveSuppoort::TaggedLogger')
     }
 
     let(:source) {

--- a/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
@@ -541,14 +541,29 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
     subject(:synchronize) {
       described_class.synchronize(
           destination: destination,
+          logger: logger,
           source: source
       )
     }
-    
+
+    #
+    # lets
+    #
+
     let(:destination) {
       Metasploit::Cache::Exploit::Instance.new
     }
-    
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(log_string_io)
+      )
+    }
+
+    let(:log_string_io) {
+      StringIO.new
+    }
+
     let(:source) {
       double(
           'exploit Metasploit Module instance',

--- a/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
     subject(:build_added) {
       described_class.build_added(
           destination: destination,
+          logger: logger,
           destination_attributes_by_name: destination_attributes_by_name,
           source_attributes_by_name: source_attributes_by_name
       )
@@ -616,6 +617,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
       described_class.update_changed(
           destination: destination,
           destination_attributes_by_name: destination_attributes_by_name,
+          logger: logger,
           source_attributes_by_name: source_attributes_by_name
       )
     }

--- a/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/ephemeral/exploit_targets_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets do
+  let(:logger) {
+    ActiveSupport::TaggedLogging.new(
+        Logger.new(log_string_io)
+    )
+  }
+
+  let(:log_string_io) {
+    StringIO.new
+  }
+
   context 'build_added' do
     subject(:build_added) {
       described_class.build_added(
@@ -327,7 +337,10 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
 
   context 'source_attributes_by_name' do
     subject(:source_attributes_by_name) {
-      described_class.source_attributes_by_name(source)
+      described_class.source_attributes_by_name(
+          source,
+          logger: logger
+      )
     }
 
     let(:source) {
@@ -552,16 +565,6 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets d
 
     let(:destination) {
       Metasploit::Cache::Exploit::Instance.new
-    }
-
-    let(:logger) {
-      ActiveSupport::TaggedLogging.new(
-          Logger.new(log_string_io)
-      )
-    }
-
-    let(:log_string_io) {
-      StringIO.new
     }
 
     let(:source) {

--- a/spec/lib/metasploit/cache/exploit/instance/ephemeral/stance_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/ephemeral/stance_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::Stance do
     subject(:synchronize) {
       described_class.synchronize(
           destination: destination,
+          logger: logger,
           source: source
       )
     }
@@ -95,6 +96,16 @@ RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::Stance do
       Metasploit::Cache::Exploit::Instance.new(
           stance: 'Old Stance'
       )
+    }
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(log_string_io)
+      )
+    }
+
+    let(:log_string_io) {
+      StringIO.new
     }
 
     let(:source) {

--- a/spec/lib/metasploit/cache/exploit/instance/ephemeral/stance_spec.rb
+++ b/spec/lib/metasploit/cache/exploit/instance/ephemeral/stance_spec.rb
@@ -1,0 +1,178 @@
+RSpec.describe Metasploit::Cache::Exploit::Instance::Ephemeral::Stance do
+  context 'is_stance_method' do
+    subject(:is_stance_method) {
+      described_class.is_stance_method(source_stance)
+    }
+
+    context 'with nil' do
+      let(:source_stance) {
+        nil
+      }
+
+      it { is_expected.to respond_to(:call) }
+
+      context 'call(stance)' do
+        subject(:comparison) {
+          is_stance_method.call(potential_stance)
+        }
+
+        context 'with Metasploit::Cache::Module::Instance::AGGRESSIVE' do
+          let(:potential_stance) {
+            Metasploit::Cache::Module::Stance::AGGRESSIVE
+          }
+
+          it { is_expected.to eq(false) }
+        end
+
+        context 'with Metasploit::Cache::Module::Instance::AGGRESSIVE' do
+          let(:potential_stance) {
+            Metasploit::Cache::Module::Stance::PASSIVE
+          }
+
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+
+    context 'with Array' do
+      let(:source_stance) {
+        []
+      }
+
+      it { is_expected.to respond_to(:call) }
+
+      context 'call(stance)' do
+        subject(:comparison) {
+          is_stance_method.call(potential_stance)
+        }
+
+        let(:potential_stance) {
+          FactoryGirl.generate :metasploit_cache_module_stance
+        }
+
+        it 'calls #include?' do
+          expect(source_stance).to receive(:include?)
+
+          comparison
+        end
+      end
+    end
+
+    context 'with String' do
+      let(:source_stance) {
+        "not a stance"
+      }
+
+      it { is_expected.to respond_to(:call) }
+
+      context 'call(stance)' do
+        subject(:comparison) {
+          is_stance_method.call(potential_stance)
+        }
+
+        let(:potential_stance) {
+          FactoryGirl.generate :metasploit_cache_module_stance
+        }
+
+        it 'calls #==' do
+          expect(source_stance).to receive(:==)
+
+          comparison
+        end
+      end
+    end
+  end
+
+  context 'synchronize' do
+    subject(:synchronize) {
+      described_class.synchronize(
+          destination: destination,
+          source: source
+      )
+    }
+
+    let(:destination) {
+      Metasploit::Cache::Exploit::Instance.new(
+          stance: 'Old Stance'
+      )
+    }
+
+    let(:source) {
+      double(
+          'exploit Metasploit Module instance',
+          stance: source_stance
+      )
+    }
+    
+    context 'with Array' do
+      context 'containing Metasploit::Cache::Module::Stance::AGGRESSIVE and Metasploit::Cache::Module::Stance::PASSIVE' do
+        let(:source_stance) {
+          [
+              Metasploit::Cache::Module::Stance::PASSIVE,
+              Metasploit::Cache::Module::Stance::AGGRESSIVE
+          ]
+        }
+
+        it 'sets destination.stance to Metasploit::Cache::Module::Stance::AGGRESSIVE' do
+          expect {
+            synchronize
+          }.to change(destination, :stance).to(Metasploit::Cache::Module::Stance::AGGRESSIVE)
+        end
+
+        it 'returns destination' do
+          expect(synchronize).to eq(destination)
+        end
+      end
+    end
+
+    context 'with String' do
+      context 'with Metasploit::Cache::Module::Stance::AGGRESSIVE' do
+        let(:source_stance) {
+          Metasploit::Cache::Module::Stance::AGGRESSIVE
+        }
+        
+        it 'sets destination.stance to Metasploit::Cache::Module::Stance::AGGRESSIVE' do
+          expect {
+            synchronize
+          }.to change(destination, :stance).to(Metasploit::Cache::Module::Stance::AGGRESSIVE)
+        end
+
+        it 'returns destination' do
+          expect(synchronize).to eq(destination)
+        end
+      end
+      
+      context 'with Metasploit::Cache::Module::Stance::PASSIVE' do
+        let(:source_stance) {
+          Metasploit::Cache::Module::Stance::PASSIVE
+        }
+        
+        it 'sets destination.stance to Metasploit::Cache::Module::Stance::PASSIVE' do
+          expect {
+            synchronize
+          }.to change(destination, :stance).to(Metasploit::Cache::Module::Stance::PASSIVE)
+        end
+
+        it 'returns destination' do
+          expect(synchronize).to eq(destination)
+        end
+      end
+
+      context 'with other' do
+        let(:source_stance) {
+          'Unrecognized Stance'
+        }
+
+        it 'sets destination.stance to nil' do
+          expect {
+            synchronize
+          }.to change(destination, :stance).to(nil)
+        end
+
+        it 'returns destination' do
+          expect(synchronize).to eq(destination)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/licensable/ephemeral/licensable_licenses_spec.rb
+++ b/spec/lib/metasploit/cache/licensable/ephemeral/licensable_licenses_spec.rb
@@ -284,12 +284,23 @@ RSpec.describe Metasploit::Cache::Licensable::Ephemeral::LicensableLicenses do
     subject(:synchronize) {
       described_class.synchronize(
           destination: destination,
+          logger: logger,
           source: source
       )
     }
 
     let(:destination) {
       Metasploit::Cache::Auxiliary::Instance.new
+    }
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(log_string_io)
+      )
+    }
+
+    let(:log_string_io) {
+      StringIO.new
     }
 
     let(:source) {

--- a/spec/lib/metasploit/cache/logged_spec.rb
+++ b/spec/lib/metasploit/cache/logged_spec.rb
@@ -1,0 +1,115 @@
+RSpec.describe Metasploit::Cache::Logged do
+  let(:original_logger) {
+    double('Original Logger')
+  }
+
+  let(:logged) {
+    OpenStruct.new(logger: original_logger)
+  }
+
+  let(:logger) {
+    ActiveSupport::TaggedLogging.new(Logger.new(log_string_io))
+  }
+
+  let(:log_string_io) {
+    StringIO.new
+  }
+
+  context 'with_logger' do
+    def with_logger(&block)
+      described_class.with_logger(logged, logger, &block)
+    end
+
+    context 'in block' do
+      it 'changes logged.logger to passed logger' do
+        expect(logged.logger).to eq(original_logger)
+
+        with_logger do
+          expect(logged.logger).to eq(logger)
+        end
+      end
+
+      it 'yields logger' do
+        with_logger do |block_logger|
+          expect(block_logger).to eq(logger)
+        end
+      end
+    end
+
+    context 'after block' do
+      context 'with exception' do
+        it 'restores original logged.logger' do
+          expect {
+            with_logger do
+              raise Exception
+            end
+          }.to raise_error
+
+          expect(logged.logger).to eq(original_logger)
+        end
+      end
+
+      context 'without exception' do
+        it 'restores original logged.logger' do
+          expect {
+            with_logger do
+            end
+          }.not_to raise_error
+
+          expect(logged.logger).to eq(original_logger)
+        end
+      end
+    end
+  end
+
+  context 'with_tagged_logger' do
+    def with_tagged_logger(&block)
+      described_class.with_tagged_logger(logged, logger, tag, &block)
+    end
+
+    let(:tag) {
+      'some/path.rb'
+    }
+
+    context 'in block' do
+      it 'tags log' do
+        with_tagged_logger do
+          logged.logger.error('Tagged Error')
+        end
+
+        expect(log_string_io.string).to eq("[#{tag}] Tagged Error\n")
+      end
+
+      it 'yields logger' do
+        with_tagged_logger do |block_logger|
+          expect(block_logger).to eq(logger)
+        end
+      end
+    end
+
+    context 'after block' do
+      context 'with exception' do
+        it 'restores original logged.logger' do
+          expect {
+            with_tagged_logger do
+              raise Exception
+            end
+          }.to raise_error
+
+          expect(logged.logger).to eq(original_logger)
+        end
+      end
+
+      context 'without exception' do
+        it 'restores original logged.logger' do
+          expect {
+            with_tagged_logger do
+            end
+          }.not_to raise_error
+
+          expect(logged.logger).to eq(original_logger)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/module/instance/load_spec.rb
+++ b/spec/lib/metasploit/cache/module/instance/load_spec.rb
@@ -108,6 +108,10 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
         Metasploit::Cache::Auxiliary::Instance::Ephemeral
       }
 
+      let(:metasploit_framework) {
+        double('Metasploit::Framework')
+      }
+
       let(:module_instance) {
         FactoryGirl.build(:metasploit_cache_auxiliary_instance)
       }
@@ -115,14 +119,23 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
       let(:module_instance_load) {
         described_class.new(
             ephemeral_class: ephemeral_class,
-            module_instance: module_instance,
+            logger: logger,
+            metasploit_framework: metasploit_framework,
             metasploit_module_class: metasploit_module_class,
-            logger: logger
+            module_instance: module_instance
         )
       }
 
       let(:metasploit_module_class) {
-        Class.new.tap { |klass|
+        Class.new do
+          #
+          # Class Attributes
+          #
+
+          class << self
+            attr_accessor :framework
+          end
+        end.tap { |klass|
           actions = module_instance.actions.map { |action|
             double("Metasploit Module Action", name: action.name)
           }
@@ -255,7 +268,11 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
     }
 
     let(:metasploit_module_class) {
-      double('Metasploit Module class')
+      Class.new do
+        class << self
+          attr_accessor :framework
+        end
+      end
     }
 
     context 'with Exception' do
@@ -329,12 +346,17 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
         Metasploit::Cache::Auxiliary::Instance::Ephemeral
       }
 
+      let(:metasploit_framework) {
+        double('Metasploit::Framework')
+      }
+
       let(:module_instance_load) {
         described_class.new(
             ephemeral_class: ephemeral_class,
-            module_instance: module_instance,
+            logger: logger,
+            metasploit_framework: metasploit_framework,
             metasploit_module_class: metasploit_module_class,
-            logger: logger
+            module_instance: module_instance
         ).tap { |block_module_instance_load|
           expect(block_module_instance_load).to be_valid(:loading)
         }
@@ -381,9 +403,10 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
 
             described_class.new(
                 ephemeral_class: ephemeral_class,
-                module_instance: module_instance,
                 logger: logger,
-                metasploit_module_class: direct_class_load.metasploit_class
+                metasploit_framework: metasploit_framework,
+                metasploit_module_class: direct_class_load.metasploit_class,
+                module_instance: module_instance
             )
           }
 
@@ -433,6 +456,14 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
 
           let(:metasploit_module_class) {
             Class.new do
+              #
+              # Class Attributes
+              #
+
+              class << self
+                attr_accessor :framework
+              end
+
               #
               # Attributes
               #
@@ -484,11 +515,23 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
         }
 
         let(:metasploit_module_class) {
-          Class.new.tap { |klass|
-            klass.send(:define_method, :initialize) {
+          Class.new do
+            #
+            # Class Attributes
+            #
+
+            class << self
+              attr_accessor :framework
+            end
+
+            #
+            # initialize
+            #
+
+            def initialize
               raise Exception
-            }
-          }
+            end
+          end
         }
 
         it { is_expected.to be_nil }
@@ -588,9 +631,10 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
             let(:module_instance_load) {
               described_class.new(
                   ephemeral_class: Metasploit::Cache::Auxiliary::Instance::Ephemeral,
-                  module_instance: module_instance,
+                  logger: logger,
+                  metasploit_framework: metasploit_framework,
                   metasploit_module_class: direct_class_load.metasploit_class,
-                  logger: logger
+                  module_instance: module_instance
               )
             }
           end
@@ -613,9 +657,10 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
             let(:module_instance_load) {
               described_class.new(
                   ephemeral_class: Metasploit::Cache::Encoder::Instance::Ephemeral,
-                  module_instance: module_instance,
+                  logger: logger,
+                  metasploit_framework: metasploit_framework,
                   metasploit_module_class: direct_class_load.metasploit_class,
-                  logger: logger
+                  module_instance: module_instance
               )
             }
           end

--- a/spec/lib/metasploit/cache/module/instance/load_spec.rb
+++ b/spec/lib/metasploit/cache/module/instance/load_spec.rb
@@ -419,12 +419,6 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
             )
           }
 
-          it 'logs no errors' do
-            metasploit_module_instance
-
-            expect(log_string_io.string).to be_blank
-          end
-
           it 'makes valid #module_instance' do
             # Doesn't use change so that be_valid's printing is better
             expect(module_instance).not_to be_valid
@@ -498,12 +492,6 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
           let!(:direct_class) {
             FactoryGirl.create(:metasploit_cache_auxiliary_class)
           }
-
-          it 'logs errors' do
-            metasploit_module_instance
-
-            expect(log_string_io.string).not_to be_blank
-          end
 
           it { is_expected.to be_nil }
         end

--- a/spec/lib/metasploit/cache/module/instance/load_spec.rb
+++ b/spec/lib/metasploit/cache/module/instance/load_spec.rb
@@ -652,6 +652,58 @@ RSpec.describe Metasploit::Cache::Module::Instance::Load, type: :model do
               )
             }
           end
+
+          it_should_behave_like 'Metasploit::Cache::*::Instance::Load from relative_path_prefix',
+                                module_path_real_pathname,
+                                'exploits',
+                                pending_reason_by_display_path: {
+                                    'firefox/local/exec_shellcode.rb' => 'Missing references',
+                                    'linux/http/pandora_fms_exec.rb' => 'Missing references',
+                                    'linux/local/desktop_privilege_escalation.rb' => 'Missing references',
+                                    'linux/local/zpanel_zsudo.rb' => 'Missing references',
+                                    'multi/fileformat/js_unpacker_eval_injection.rb' => 'Missing references',
+                                    'multi/handler.rb' => 'Missing DisclosureDate and missing references',
+                                    'multi/misc/java_rmi_server.rb' => 'MSF authority abbreviation is not recognized',
+                                    'osx/browser/safari_user_assisted_download_launch.rb' => 'Missing references',
+                                    'osx/local/persistence.rb' => 'Missing references',
+                                    'unix/local/setuid_nmap.rb' => 'Missing references',
+                                    'unix/webapp/generic_exec.rb' => 'Missing references',
+                                    'unix/webapp/openemr_upload_exec.rb' => 'EBD authority abbreviation is a typo for EDB',
+                                    'unix/webapp/php_eval.rb' => 'Missing references',
+                                    'unix/webapp/php_include.rb' => 'Missing references',
+                                    'unix/webapp/wp_admin_shell_upload.rb' => 'Missing references',
+                                    'windows/browser/malwarebytes_update_exec.rb' => "Authority abbreviation (' OSVDB') has space in it",
+                                    'windows/http/xampp_webdav_upload_php.rb' => 'Missing references',
+                                    'windows/local/bypassuac_injection.rb' => 'References are formatted incorrectly with an extra Array layer',
+                                    'windows/local/ntapphelpcachecontrol.rb' => 'OSVEB authority abbreviation is a typo for OSVDB',
+                                    'windows/local/payload_inject.rb' => 'Missing references',
+                                    'windows/local/persistence.rb' => 'Missing references',
+                                    'windows/local/powershell_cmd_upgrade.rb' => 'Missing references',
+                                    'windows/local/pxeexploit.rb' => 'Missing references',
+                                    'windows/local/service_permissions.rb' => 'Missing references'
+                                } do
+            let(:direct_class) {
+              module_ancestor.build_exploit_class
+            }
+
+            let(:module_ancestors) {
+              module_path.exploit_ancestors
+            }
+
+            let(:module_instance) {
+              direct_class.build_exploit_instance
+            }
+
+            let(:module_instance_load) {
+              described_class.new(
+                  ephemeral_class: Metasploit::Cache::Exploit::Instance::Ephemeral,
+                  logger: logger,
+                  metasploit_framework: metasploit_framework,
+                  metasploit_module_class: direct_class_load.metasploit_class,
+                  module_instance: module_instance,
+              )
+            }
+          end
         end
       end
     end

--- a/spec/lib/metasploit/cache/module/stance_spec.rb
+++ b/spec/lib/metasploit/cache/module/stance_spec.rb
@@ -24,5 +24,18 @@ RSpec.describe Metasploit::Cache::Module::Stance do
 
       it { should == 'passive' }
     end
+
+    context 'PRECEDENCE' do
+      subject(:precedence) {
+        described_class::PRECEDENCE
+      }
+
+      it 'should list AGGRESSIVE before PASSIVE' do
+        expect(precedence).to eq [
+                                     described_class::AGGRESSIVE,
+                                     described_class::PASSIVE
+                                 ]
+      end
+    end
   end
 end

--- a/spec/lib/metasploit/cache/platform/seed_spec.rb
+++ b/spec/lib/metasploit/cache/platform/seed_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Metasploit::Cache::Platform::Seed do
   context 'CONSTANTS' do
-    context 'RELATIVE_NAME_TRIE' do
+    context 'RELATIVE_NAME_TREE' do
       subject(:relative_name_tree) do
         described_class::RELATIVE_NAME_TREE
       end

--- a/spec/lib/metasploit/cache/platform/seed_spec.rb
+++ b/spec/lib/metasploit/cache/platform/seed_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Metasploit::Cache::Platform::Seed do
       it { should include('Firefox') }
       it { should include('FreeBSD') }
       it { should include('HPUX') }
-      it { should include('IRIX') }
+      it { should include('Irix') }
       it { should include('Java') }
       it { should include('Javascript') }
       it { should include('Linux') }

--- a/spec/lib/metasploit/cache/platform/seed_spec.rb
+++ b/spec/lib/metasploit/cache/platform/seed_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metasploit::Cache::Platform::Seed do
       it { should include('HPUX') }
       it { should include('Irix') }
       it { should include('Java') }
-      it { should include('Javascript') }
+      it { should include('JavaScript') }
       it { should include('Linux') }
       it { should include('NetBSD') }
       it { should include('Netware') }

--- a/spec/lib/metasploit/cache/platformable/ephemeral/platformable_platforms_spec.rb
+++ b/spec/lib/metasploit/cache/platformable/ephemeral/platformable_platforms_spec.rb
@@ -366,12 +366,27 @@ RSpec.describe Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
     subject(:synchronize) {
       described_class.synchronize(
                          destination: destination,
+                         logger: logger,
                          source: source
       )
     }
 
+    #
+    # lets
+    #
+
     let(:destination) {
       Metasploit::Cache::Encoder::Instance.new
+    }
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(log_string_io)
+      )
+    }
+
+    let(:log_string_io) {
+      StringIO.new
     }
 
     let(:source) {

--- a/spec/lib/metasploit/cache/referencable/ephemeral/referencable_references_spec.rb
+++ b/spec/lib/metasploit/cache/referencable/ephemeral/referencable_references_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences do
+  let(:logger) {
+    ActiveSupport::TaggedLogging.new(
+        Logger.new(log_string_io)
+    )
+  }
+
+  let(:log_string_io) {
+    StringIO.new
+  }
+
   context 'authority_abbreviation_set' do
     subject(:authority_abbreviation_set) {
       described_class.authority_abbreviation_set(attributes_set)
@@ -673,6 +683,7 @@ RSpec.describe Metasploit::Cache::Referencable::Ephemeral::ReferencableReference
     subject(:synchronize) {
       described_class.synchronize(
                          destination: destination,
+                         logger: logger,
                          source: source
       )
     }

--- a/spec/lib/metasploit/cache/referencable/ephemeral/referencable_references_spec.rb
+++ b/spec/lib/metasploit/cache/referencable/ephemeral/referencable_references_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe Metasploit::Cache::Referencable::Ephemeral::ReferencableReference
       described_class.build_added(
           destination: destination,
           destination_attributes_set: destination_attributes_set,
+          logger: logger,
           source_attributes_set: source_attributes_set
       )
     }

--- a/spec/lib/metasploit/cache/reference/ephemeral_spec.rb
+++ b/spec/lib/metasploit/cache/reference/ephemeral_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe Metasploit::Cache::Reference::Ephemeral do
+  let(:logger) {
+    ActiveSupport::TaggedLogging.new(
+        Logger.new(log_string_io)
+    )
+  }
+
+  let(:log_string_io) {
+    StringIO.new
+  }
+
   context 'attributes' do
     subject(:attributes) {
       described_class.attributes(reference)
@@ -57,7 +67,8 @@ RSpec.describe Metasploit::Cache::Reference::Ephemeral do
     subject(:by_attributes) {
       described_class.by_attributes(
           attributes_set: attributes_set,
-          authority_by_abbreviation: authority_by_abbreviation
+          authority_by_abbreviation: authority_by_abbreviation,
+          logger: logger
       )
     }
 
@@ -443,7 +454,8 @@ RSpec.describe Metasploit::Cache::Reference::Ephemeral do
   context 'new_by_attributes_proc' do
     subject(:new_by_attributes_proc) {
       described_class.new_by_attributes_proc(
-          authority_by_abbreviation: authority_by_abbreviation
+          authority_by_abbreviation: authority_by_abbreviation,
+          logger: logger
       )
     }
 

--- a/spec/support/shared/examples/metasploit/cache/batch/root.rb
+++ b/spec/support/shared/examples/metasploit/cache/batch/root.rb
@@ -31,10 +31,16 @@ RSpec.shared_examples_for 'Metasploit::Cache::Batch::Root' do
                                      )
           end
 
-          it 'should call recoverable_save outside batch mode' do
-            expect(base_instance).to receive(:recoverable_save) {
+          it 'should call valid? outside batch mode' do
+            expect(base_instance).to receive(:valid?) {
                                        expect(Metasploit::Cache::Batch).not_to be_batched
                                      }
+
+            batched_save
+          end
+
+          it 'logs exception as error' do
+            expect(base_instance.logger).to receive(:error).with(an_instance_of(ActiveRecord::RecordNotUnique))
 
             batched_save
           end
@@ -58,10 +64,16 @@ RSpec.shared_examples_for 'Metasploit::Cache::Batch::Root' do
                                            }
                 end
 
-                it 'should call recoverable_save outside batch mode' do
-                  expect(base_instance).to receive(:recoverable_save) {
+                it 'should call valid? outside batch mode' do
+                  expect(base_instance).to receive(:valid?) {
                                              expect(Metasploit::Cache::Batch).not_to be_batched
                                            }
+
+                  batched_save
+                end
+
+                it 'logs exception as error' do
+                  expect(base_instance.logger).to receive(:error).with(an_instance_of(ActiveRecord::StatementInvalid))
 
                   batched_save
                 end
@@ -128,10 +140,16 @@ RSpec.shared_examples_for 'Metasploit::Cache::Batch::Root' do
                                            }
                 end
 
-                it 'should call recoverable_save outside batch mode' do
-                  expect(base_instance).to receive(:recoverable_save) {
+                it 'should call valid? outside batch mode' do
+                  expect(base_instance).to receive(:valid?) {
                                              expect(Metasploit::Cache::Batch).not_to be_batched
                                            }
+
+                  batched_save
+                end
+
+                it 'logs exception as error' do
+                  expect(base_instance.logger).to receive(:error).with(an_instance_of(ActiveRecord::StatementInvalid))
 
                   batched_save
                 end

--- a/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
+++ b/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
@@ -56,7 +56,19 @@ shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_pre
 
           module_instance_load.valid?
 
-          expect(module_instance).to be_valid
+          unless module_instance.valid?
+            # Only covered on failure
+            # :nocov:
+            fail "Expected #{module_instance.class} to be valid, but got errors:\n" \
+                 "#{module_instance.errors.full_messages.join("\n")}\n" \
+                 "\n" \
+                 "Log:\n" \
+                 "#{log_string_io.string}\n" \
+                 "Expected #{module_instance_load.class} to be valid, but got errors:\n" \
+                 "#{module_instance_load.errors.full_messages.join("\n")}"
+            # :nocov:
+          end
+
           expect(module_instance_load).to be_valid
           expect(module_instance).to be_persisted
         end

--- a/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
+++ b/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_prefix' do |module_path_real_pathname, relative_path_prefix|
+shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_prefix' do |module_path_real_pathname, relative_path_prefix, pending_reason_by_display_path: {}|
   context relative_path_prefix do
     real_prefix_pathname = module_path_real_pathname.join(relative_path_prefix)
 
@@ -10,10 +10,10 @@ shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_pre
 
     rule.find do |real_path|
       real_pathname = Pathname.new(real_path)
-      display_pathname = real_pathname.relative_path_from(real_prefix_pathname)
+      display_path = real_pathname.relative_path_from(real_prefix_pathname).to_s
       relative_pathname = real_pathname.relative_path_from(module_path_real_pathname)
 
-      context display_pathname.to_s do
+      context display_path do
         let(:direct_class_load) {
           Metasploit::Cache::Direct::Class::Load.new(
               direct_class: direct_class,
@@ -50,7 +50,15 @@ shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_pre
           )
         }
 
-        it 'loads Metasploit Module instance' do
+        options = {}
+
+        pending_reason = pending_reason_by_display_path[display_path]
+
+        if pending_reason
+          options[:pending] = pending_reason
+        end
+
+        it 'loads Metasploit Module instance', options do
           expect(module_ancestor_load).to load_metasploit_module
 
           expect(direct_class_load).to be_valid

--- a/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
+++ b/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
@@ -27,7 +27,11 @@ shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_pre
               'Metasploit Framework',
               datastore: double('Metasploit Framework datastore').tap { |datastore|
                 allow(datastore).to receive(:[]).with(anything).and_return(nil)
-              }
+              },
+              events: double(
+                  'Metasploit Framework events',
+                  add_exploit_subscriber: nil
+              )
           )
         }
 

--- a/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
+++ b/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
@@ -22,6 +22,15 @@ shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_pre
           )
         }
 
+        let(:metasploit_framework) {
+          double(
+              'Metasploit Framework',
+              datastore: double('Metasploit Framework datastore').tap { |datastore|
+                allow(datastore).to receive(:[]).with(anything).and_return(nil)
+              }
+          )
+        }
+
         let(:module_ancestor) {
           module_ancestors.build(
               relative_path: relative_pathname.to_path

--- a/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
+++ b/spec/support/shared/examples/metasploit/cache/module/instance/load/from_relative_path_prefix.rb
@@ -39,10 +39,10 @@ shared_examples_for 'Metasploit::Cache::*::Instance::Load from relative_path_pre
 
         let(:module_ancestor_load) {
           Metasploit::Cache::Module::Ancestor::Load.new(
+              logger: logger,
               # This should match the major version number of metasploit-framework
               maximum_version: 4,
-              module_ancestor: module_ancestor,
-              logger: logger
+              module_ancestor: module_ancestor
           )
         }
 


### PR DESCRIPTION
MSP-12444

# Changelog
* Enhancements
  * `Metasploit::Cache::Module::Stance::PRECEDENCE` lists the stances in order of precedence so code can share knowledge that `Metasploit::Cache::Module::Stance::AGGRESSIVE` is favored over `Metasploit::Cache::Module::Stance::PASSIVE` if a Metasploit Module instance has more than one `#stance`.
  * Log exception and call `#valid?` instead of `#recoverable_save` again when an exception is raised in `Metasploit::Cache::Batch::Root#batched_save` because transactions didn't always replay the same errors on the second save as was expected.
  * Documentation for how to add `Metasploit::Cache::Authority` and `Metasploit::Cache::Platform` seeds in the README.
  * Add new authorities:
    * CWE 
    * EDB
    * WPVDB
  * `Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set` logs when `'mips'` is translated to `['mipsbe', 'mipsle']` and `x64' is translated to `'x86_64'`.
  * `Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms.build_added` logs when a `Metasploit::Cache::Platform#fully_qualified_name` is unseeded and directs reader to view README for instructions on adding seed.
  * `Metasploit::Cache::Reference::Ephemeral.new_by_attributes_proc` logs when a `Metasploit::Cache::Authority#abbreviation` is unseeded and directs reader to view README for instructions on adding seed.
* Bugs Fixes
  * Metasploit Module ancestor cells generated for `:metasploit_module_*_instance` factories now support class attribute `framework` for compatibility with metasploit-framework.
  * Ensure errors from `Metasploit::Cache::Module::Instance::Load#metasploit_module_class` `new` are generated from `#metasploit_module_instance` before validating.
  * Platforms renamed to match capitalization in metasploit-framework
    * `'IRIX'` changed to `'Irix'`
    * `'Javascript'` changed to `'JavaScript'`
  * `'x64'` from source is translated to `'x86_64'`
  * Empty arch from source is translated to `'x86'`
* Incompatible Changes
  * `ActiveRecord::Base.logger` **MUST** be set when calling `Metasploit::Cache::Batch::Root#batched_save` to allow exceptions to be logged as errors.
  * Platforms renamed
    * `'IRIX'` changed to `'Irix'`
    * `'Javascript'` changed to `'JavaScript'`
  * `synchronize(destination:, source:)` changed to `synchronize(destination:, logger:, source:)` to allow logging when `source` uses deprecated or unseeded values.
    * `Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures.source_attribute_set(source)`  changed to `(source, logger:)`.
    * `Metasploit::Cache::Exploit::Instance::Ephemeral::ExploitTargets`
      * `source_attributes_by_name(source)` changed to `source_attributes_by_name(source, logger:)`.
      * `build_added(destination:, destination_attributes_by_name:, source_attributes_by_name:)` changed to `build_added(destination:, destination_attributes_by_name:, logger:, source_attributes_by_name:)`.
      *  `update_changed(destination:, destination_attributes_by_name:, source_attributes_by_name:)` changed to `update_changed(destination:, destination_attributes_by_name:, logger:, source_attributes_by_name:)`.
    * `Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms`
      *`build_added(destination:, destination_attribute_set:, source_attribute_set:)` changed to `build_added(destination:, destination_attribute_set:, logger:, source_attribute_set:)`.
      * `reduce(destination:, destination_attribute_set:, source_attribute_set:)` changed to `reduce(destination:, destination_attribute_set:, logger:, source_attribute_set:)`.
    * `Metasploit::Cache::Referencable::Ephemeral::ReferencableReferences.build_added(destination:, destination_attributes_set:, source_attributes_set:)` changed to `(destination:, destination_attributes_set:, logger:, source_attributes_set:)`.
    * `Metasploit::Cache::Reference::Ephemeral`
      * `by_attributes(attributes_set:, authority_by_abbreviation:)` changed to `by_attributes(attributes_set:, authority_by_abbreviation:, logger:)`.
      * `new_by_attributes_proc(authority_by_abbreviation:)` changed to `new_by_attributes_proc(authority_by_abbreviation:, logger:)`.


# Verification Steps

## Postgresql
- [x] `rm Gemfile.lock`
- [x] `bundle install --without sqlite3`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 100% coverage

### Documentation Coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
- [x] VERIFY no undocumented objects

## Sqlite3
- [x] `rm Gemfile.lock`
- [x] `bundle install --without postgresql`
- [x] `rake db:drop db:create db:migrate`

### Test coverage
- [x] `rake cucumber spec coverage`
- [x] VERIFY no failures
- [x] VERIFY 100% coverage

### Documentation coverage
- [x] `rake yard:stats`
- [x] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [x] Edit `lib/metasploit/cache/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [ ] `git push origin master`