### PR TITLE
Metasploit::Cache::Payload::Single::Instance::Ephemeral

### DIFF
--- a/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/auxiliary/instance/auxiliary_class/ancestor/show.erb
@@ -8,14 +8,6 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= auxiliary_class.rank.number %>
 
   #
-  # Class Attributes
-  #
-
-  class << self
-    attr_accessor :framework
-  end
-
-  #
   # Instance Methods
   #
 

--- a/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/encoder/instance/encoder_class/ancestor/show.erb
@@ -8,14 +8,6 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= encoder_class.rank.number %>
 
   #
-  # Class Attributes
-  #
-
-  class << self
-    attr_accessor :framework
-  end
-
-  #
   # Instance Methods
   #
 

--- a/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/exploit/instance/exploit_class/ancestor/show.erb
@@ -8,14 +8,6 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= exploit_class.rank.number %>
 
   #
-  # Class Attributes
-  #
-
-  class << self
-    attr_accessor :framework
-  end
-
-  #
   # Instance Methods
   #
 

--- a/app/cells/metasploit/cache/nop/instance/nop_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/nop/instance/nop_class/ancestor/show.erb
@@ -8,14 +8,6 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= nop_class.rank.number %>
 
   #
-  # Class Attributes
-  #
-
-  class << self
-    attr_accessor :framework
-  end
-
-  #
   # Instance Methods
   #
 

--- a/app/cells/metasploit/cache/payload/single/instance/payload_single_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/payload/single/instance/payload_single_class/ancestor/show.erb
@@ -1,0 +1,75 @@
+# Module Type: <%= payload_single_class.ancestor.module_type %>
+# Reference Name: <%= payload_single_class.ancestor.reference_name %>
+module <%= metasploit_module_relative_name %>
+  #
+  # CONSTANTS
+  #
+
+  Rank = <%= payload_single_class.rank.number %>
+
+  #
+  # Instance Methods
+  #
+
+  def arch
+    [
+<%- separate(architecturable_architectures, ',') do |architecturable_architecture, separator| -%>
+      '<%= architecturable_architecture.architecture.abbreviation %>'<%= separator %>
+<%- end -%>
+    ]
+  end
+
+  def author
+    [
+<%- separate(contributions, ',') do |contribution, separator| -%>
+  <%- email_address = contribution.email_address
+
+      if email_address
+        email = "'#{email_address.full}'"
+      else
+        email = "nil"
+      end
+  -%>
+      OpenStruct.new(name: '<%= contribution.author.name %>', email: <%= email %>)<%= separator %>
+<%- end -%>
+    ]
+  end
+
+  def description
+    '<%= description %>'
+  end
+
+  def handler_klass
+    # Not a class since this only emulates the interface used by metasploit-cache
+    OpenStruct.new(
+      general_handler_type: '<%= handler.general_handler_type %>',
+      handler_type: '<%= handler.handler_type %>'
+    )
+  end
+
+  def license
+    [
+<%- separate(licensable_licenses, ',') do |licensable_license, separator| -%>
+      '<%= licensable_license.license.abbreviation %>'<%= separator %>
+<%- end -%>
+    ]
+  end
+
+  def name
+    '<%= name %>'
+  end
+
+  def platform
+    OpenStruct.new(
+      platforms: [
+<%- separate(platformable_platforms, ',') do |platformable_platform, separator| -%>
+        OpenStruct.new(realname: '<%= platformable_platform.platform.fully_qualified_name %>')<%= separator %>
+<%- end -%>
+      ]
+    )
+  end
+
+  def privileged
+    <%= !!privileged %>
+  end
+end

--- a/app/cells/metasploit/cache/payload/single/instance/payload_single_class/ancestor_cell.rb
+++ b/app/cells/metasploit/cache/payload/single/instance/payload_single_class/ancestor_cell.rb
@@ -1,0 +1,41 @@
+# Cell for rendering {Metasploit::Cache::Payload::Single::Instance#payload_single_class}
+# {Metasploit::Cache::Direct::Class#ancestor} {Metasploit::Cache::Module::Ancestor#contents}.
+#
+# In addition to content from {Metasploit::Cache::Module::AncestorCell} and
+# {Metasploit::Cache::Direct::Class::AncestorCell}, it also includes `#arch` for
+# {Metasploit::Cache::Payload::Single::Instance#architecturable_architectures},, `#authors` for
+# {Metasploit::Cache::Payload::Single::Instance#contributions}, `#description` for
+# {Metasploit::Cache::Payload::Single::Instance#description}, `#handler_klass` for
+# {Metasploit::Cache::Payload::Single::Instance#handler}, `#license` for
+# {Metasploit::Cache::Payload::Single::Instance#licensable_licenses} {Metasploit::Cache::Licensable::Licenses#license}s,
+# `#name` for {Metasploit::Cache::Payload::Single::Instance#name}, `#platform` for
+# {Metasploit::Cache::Payload::Single::Instance#platformable_platforms}
+# {Metasploit::Cache::Platformable::Platform#platform}s, and `#privileged` for
+# {Metasploit::Cache::Payload::Single::Instance#privileged}.
+class Metasploit::Cache::Payload::Single::Instance::PayloadSingleClass::AncestorCell < Cell::ViewModel
+  include Metasploit::Cache::AncestorCell
+
+  #
+  # Properties
+  #
+
+  property :architecturable_architectures
+  property :payload_single_class
+  property :contributions
+  property :description
+  property :handler
+  property :licensable_licenses
+  property :name
+  property :platformable_platforms
+  property :privileged
+
+  #
+  # Instance Methods
+  #
+
+  def show(metasploit_module_relative_name:)
+    render locals: {
+               metasploit_module_relative_name: metasploit_module_relative_name
+           }
+  end
+end

--- a/app/cells/metasploit/cache/post/instance/post_class/ancestor/show.erb
+++ b/app/cells/metasploit/cache/post/instance/post_class/ancestor/show.erb
@@ -8,14 +8,6 @@ class <%= metasploit_class_relative_name %> < <%= superclass %>
   Rank = <%= post_class.rank.number %>
 
   #
-  # Class Attributes
-  #
-
-  class << self
-    attr_accessor :framework
-  end
-
-  #
   # Instance Methods
   #
 

--- a/app/models/metasploit/cache/direct/class.rb
+++ b/app/models/metasploit/cache/direct/class.rb
@@ -7,6 +7,7 @@ class Metasploit::Cache::Direct::Class < ActiveRecord::Base
 
   autoload :AncestorCell
   autoload :Ephemeral
+  autoload :Framework
   autoload :Load
   autoload :Ranking
   autoload :Spec

--- a/app/models/metasploit/cache/payload/handler.rb
+++ b/app/models/metasploit/cache/payload/handler.rb
@@ -3,6 +3,7 @@
 class Metasploit::Cache::Payload::Handler < ActiveRecord::Base
   extend ActiveSupport::Autoload
 
+  autoload :Ephemeral
   autoload :GeneralType
 
   #

--- a/app/models/metasploit/cache/payload/single/class.rb
+++ b/app/models/metasploit/cache/payload/single/class.rb
@@ -13,6 +13,7 @@ class Metasploit::Cache::Payload::Single::Class < Metasploit::Cache::Payload::Di
   has_one :payload_single_instance,
           class_name: 'Metasploit::Cache::Payload::Single::Instance',
           dependent: :destroy,
+          foreign_key: :payload_single_class_id,
           inverse_of: :payload_single_class
 
   # Reliability of Metasploit Module.

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -34,7 +34,8 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
            as: :licensable,
            autosave: true,
            class_name: 'Metasploit::Cache::Licensable::License',
-           dependent: :destroy
+           dependent: :destroy,
+           inverse_of: :licensable
 
   # The class-level metadata for this single payload Metasploit Module.
   belongs_to :payload_single_class,

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -33,7 +33,8 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   has_many :licensable_licenses,
            as: :licensable,
            autosave: true,
-           class_name: 'Metasploit::Cache::Licensable::License'
+           class_name: 'Metasploit::Cache::Licensable::License',
+           dependent: :destroy
 
   # The class-level metadata for this single payload Metasploit Module.
   belongs_to :payload_single_class,

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -39,6 +39,7 @@ class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
   # The class-level metadata for this single payload Metasploit Module.
   belongs_to :payload_single_class,
              class_name: 'Metasploit::Cache::Payload::Single::Class',
+             foreign_key: :payload_single_class_id,
              inverse_of: :payload_single_instance
 
   # Joins {#platforms} to this single payload Metasploit Module.

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -1,6 +1,11 @@
 # Instance-level metadata for single payload Metasploit Modules
 class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
+  extend ActiveSupport::Autoload
+
   include Metasploit::Cache::Batch::Root
+
+  autoload :Ephemeral
+  autoload :PayloadSingleClass
 
   #
   #

--- a/app/models/metasploit/cache/payload/single/instance.rb
+++ b/app/models/metasploit/cache/payload/single/instance.rb
@@ -1,5 +1,7 @@
 # Instance-level metadata for single payload Metasploit Modules
 class Metasploit::Cache::Payload::Single::Instance < ActiveRecord::Base
+  include Metasploit::Cache::Batch::Root
+
   #
   #
   # Associations

--- a/app/models/metasploit/cache/payload/single/instance/ephemeral.rb
+++ b/app/models/metasploit/cache/payload/single/instance/ephemeral.rb
@@ -1,0 +1,120 @@
+# Ephemeral cache for connecting an in-memory payload_single Metasploit Module's ruby instance to its persisted {Metasploit::Cache::}
+class Metasploit::Cache::Payload::Single::Instance::Ephemeral < Metasploit::Model::Base
+  extend Metasploit::Cache::ResurrectingAttribute
+
+  #
+  # Attributes
+  #
+
+  # The in-memory payload_single Metasploit Module instance being cached.
+  #
+  # @return [Object]
+  attr_accessor :metasploit_module_instance
+
+  # Tagged logger to which to log {#persist} errors.
+  #
+  # @return [ActiveSupport::TaggerLogger]
+  attr_accessor :logger
+
+  #
+  # Resurrecting Attributes
+  #
+
+  # Cached metadata for this {#metasploit_module_instance}.
+  #
+  # @return [Metasploit::Cache::Payload::Single::Instance]
+  resurrecting_attr_accessor(:payload_single_instance) {
+    ActiveRecord::Base.connection_pool.with_connection {
+      Metasploit::Cache::Payload::Single::Instance.joins(
+          payload_single_class: :ancestor
+      ).where(
+           Metasploit::Cache::Module::Ancestor.arel_table[:real_path_sha1_hex_digest].eq(real_path_sha1_hex_digest)
+      ).readonly(false).first
+    }
+  }
+
+  #
+  # Validations
+  #
+
+  validates :metasploit_module_instance,
+            presence: true
+  validates :logger,
+            presence: true
+
+  #
+  # Instance Methods
+  #
+
+  # @note This ephemeral cache should be validated with `#valid?` prior to calling {#persist} to ensure that {#logger}
+  #   is present in case of error.
+  # @note Validation errors for `payload_single_instance` will be logged as errors tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
+  #
+  # @param to [Metasploit::Cache::Payload::Single::Instance] Sve cacheable data to {Metasploit::Cache::Payload::Single::Instance}.
+  #   Giving `to` saves a database lookup if {#payload_single_instance} is not loaded.
+  # @return [Metasploit::Cache:Payload::Single::Instance] `#persisted?` will be `false` if saving fails.
+  def persist(to: payload_single_instance)
+    [:description, :name, :privileged].each do |attribute|
+      to.send("#{attribute}=", metasploit_module_instance.send(attribute))
+    end
+
+    synchronizers = [
+        Metasploit::Cache::Architecturable::Ephemeral::ArchitecturableArchitectures,
+        Metasploit::Cache::Contributable::Ephemeral::Contributions,
+        Metasploit::Cache::Licensable::Ephemeral::LicensableLicenses,
+        Metasploit::Cache::Payload::Handable::Ephemeral::Handler,
+        Metasploit::Cache::Platformable::Ephemeral::PlatformablePlatforms
+    ]
+
+    synchronized = nil
+
+    with_payload_single_instance_tag(to) do |tagged|
+      synchronized = synchronizers.reduce(to) { |block_destination, synchronizer|
+        synchronizer.synchronize(
+            destination: block_destination,
+            logger: logger,
+            source: metasploit_module_instance
+        )
+      }
+
+      saved = ActiveRecord::Base.connection_pool.with_connection {
+        synchronized.batched_save
+      }
+
+      unless saved
+        tagged.error {
+          "Could not be persisted to #{synchronized.class}: #{synchronized.errors.full_messages.to_sentence}"
+        }
+      end
+    end
+
+    synchronized
+  end
+
+  private
+
+  # {Metasploit::Cache::Module::Ancestor#real_path_sha1_hex_digest} used to resurrect {#auxiliary_instance}.
+  #
+  # @return [String]
+  def real_path_sha1_hex_digest
+    metasploit_module_instance.class.ephemeral_cache_by_source[:ancestor].real_path_sha1_hex_digest
+  end
+  
+  # Tags log with {Metasploit::Cache::Payload::Single::Instance#payload_single_class}
+  # {Metasploit::Cache::Payload::Single::Class#ancestor} {Metasploit::Cache::Module::Ancestor#real_pathname}.
+  #
+  # @param payload_single_instance [Metasploit::Cache::Payload::Single::Instance]
+  # @yield [tagged_logger]
+  # @yieldparam tagged_logger [ActiveSupport::TaggedLogger] {#logger} with
+  #   {Metasploit::Cache::Module#Ancestor#real_pathname} tag.
+  # @yieldreturn [void]
+  # @return [void]
+  def with_payload_single_instance_tag(payload_single_instance, &block)
+    real_path = ActiveRecord::Base.connection_pool.with_connection {
+      payload_single_instance.payload_single_class.ancestor.real_pathname.to_s
+    }
+
+    Metasploit::Cache::Logged.with_tagged_logger(ActiveRecord::Base, logger, real_path, &block)
+  end
+end

--- a/lib/metasploit/cache/direct/class/framework.rb
+++ b/lib/metasploit/cache/direct/class/framework.rb
@@ -1,0 +1,18 @@
+# Acts as a stand-in for metasploit-framework's `Msf::Module.framework` attribute.
+#
+# @example A dummy Metasploit Class
+#   class Metasploit4
+#     extend Metasploit::Cache::Direct::Class::Framework
+#   end
+#
+#  Metasploit4.framework = metasploit_framework
+module Metasploit::Cache::Direct::Class::Framework
+  #
+  # Attributes
+  #
+
+  # Framework that `#initialize` can access Metasploit Framework world state.
+  #
+  # @return metasploit_framework [#events]
+  attr_accessor :framework
+end

--- a/lib/metasploit/cache/direct/class/superclass.rb
+++ b/lib/metasploit/cache/direct/class/superclass.rb
@@ -4,6 +4,7 @@
 #   class Metasploit4 < Metasploit::Cache::Direct::Class::Superclass
 #   end
 class Metasploit::Cache::Direct::Class::Superclass
+  extend Metasploit::Cache::Direct::Class::Framework
   extend Metasploit::Cache::Direct::Class::Ranking
   extend Metasploit::Cache::Direct::Class::Usability
 end

--- a/lib/metasploit/cache/payload.rb
+++ b/lib/metasploit/cache/payload.rb
@@ -6,6 +6,7 @@ module Metasploit::Cache::Payload
   autoload :Ancestor
   autoload :AncestorCell
   autoload :Direct
+  autoload :Handable
   autoload :Handler
   autoload :Single
   autoload :Stage

--- a/lib/metasploit/cache/payload/handable.rb
+++ b/lib/metasploit/cache/payload/handable.rb
@@ -1,0 +1,7 @@
+# Namespace for payloads ({Metasploit::Cache::Payload::Single::Instance} and
+# {Metasploit::Cache::Payload::Stager::Instance}) that have a `#handler`.
+module Metasploit::Cache::Payload::Handable
+  extend ActiveSupport::Autoload
+
+  autoload :Ephemeral
+end

--- a/lib/metasploit/cache/payload/handable/ephemeral.rb
+++ b/lib/metasploit/cache/payload/handable/ephemeral.rb
@@ -1,0 +1,6 @@
+# Namespace for loading {Metasploit::Cache::Payload::Handable} associations in the the cache.
+module Metasploit::Cache::Payload::Handable::Ephemeral
+  extend ActiveSupport::Autoload
+
+  autoload :Handler
+end

--- a/lib/metasploit/cache/payload/handable/ephemeral/handler.rb
+++ b/lib/metasploit/cache/payload/handable/ephemeral/handler.rb
@@ -1,0 +1,51 @@
+# Builds a new {Metasploit::Cache::Payload::Handler} if one does not exist with the given
+# {Metasploit::Cache::Payload::Handler#general_handler_type} and {Metasploit::Cache::Payload::Handler#handler_type} or
+# uses the pre-existing {Metasploit::Cache::Payload::Handler} with those attributes as the `#handler` for the
+# destination.
+module Metasploit::Cache::Payload::Handable::Ephemeral::Handler
+  # Attributes of `destination.handler`.
+  #
+  # @param destination (see synchronize)
+  # @return [{}] if `destination` is a new record
+  # @return [{general_handler_type: String, handler_type: String}] if `destination` is persisted
+  def self.destination_attributes(destination)
+    if destination.new_record?
+      {}
+    else
+      Metasploit::Cache::Payload::Handler::Ephemeral.attributes(destination.handler)
+    end
+  end
+
+  # Attributes for `source.handler_klass`
+  #
+  # @param source (see synchronize)
+  # @return [{general_handler_type: String, handler_type: String}]
+  def self.source_attributes(source)
+    Metasploit::Cache::Payload::Handler::Ephemeral.attributes(source.handler_klass)
+  end
+
+  # Synchronizes the `#handler_klass` from single or stager payload Metasploit Module instance `source` to persisted
+  # {Metasploit::Cache::Payload::Single::Instance#handler} or {Metasploit::Cache::Payload::Stager::Instance#handler} on
+  # `destination`.
+  #
+  # @param destination [Metasploit::Cache::Payload::Single::Instance, Metasploit::Cache::Payload::Stager::Instance, #handler]
+  # @param logger [ActiveSupport::TaggedLogger] logger already tagged with
+  #   {Metasploit::Cache::Module::Ancestor#real_pathname}.
+  # @param source [#handler_klass]
+  # @return [Metasploit::Cache::Payload::Single::Instance, Metasploit::Cache::Payload::Stager::Instance, #handler]
+  #   `destination`
+  def self.synchronize(destination:, logger:, source:)
+    Metasploit::Cache::Ephemeral.with_connection_transaction(destination_class: destination.class) {
+      cached_destination_attributes = destination_attributes(destination)
+      cached_source_attributes = source_attributes(source)
+
+      if cached_destination_attributes != cached_source_attributes
+        payload_handler = Metasploit::Cache::Payload::Handler.where(cached_source_attributes).first_or_initialize
+
+        destination.handler = payload_handler
+      end
+    }
+
+    destination
+  end
+end

--- a/lib/metasploit/cache/payload/handler/ephemeral.rb
+++ b/lib/metasploit/cache/payload/handler/ephemeral.rb
@@ -1,0 +1,26 @@
+# Helps with synchronizing Metasploit Handler Class with {Metasploit::Cache::Payload::Handler}
+module Metasploit::Cache::Payload::Handler::Ephemeral
+  #
+  # CONSTANTS
+  #
+
+  # Names of attributes on a Metasploit Handler Class and {Metasploit::Cache::Payload::Handler} that are synchronized.
+  ATTRIBUTE_NAMES = [
+      :general_handler_type,
+      :handler_type
+  ].freeze
+
+  #
+  # Module Methods
+  #
+
+  # Converts attributes of `source` to Hash
+  #
+  # @param source [#general_handler_type, #handler_type]
+  # @return [{general_handler_type: String, handler_type: String}]
+  def self.attributes(source)
+    ATTRIBUTE_NAMES.each_with_object({}) { |attribute_name, hash|
+      hash[attribute_name] = source.public_send(attribute_name)
+    }
+  end
+end

--- a/lib/metasploit/cache/payload/single/instance/payload_single_class.rb
+++ b/lib/metasploit/cache/payload/single/instance/payload_single_class.rb
@@ -1,0 +1,6 @@
+# Namespace for cells for {Metasploit::Cache::Payload::Single::Instance#payload_single_class} and its associations.
+module Metasploit::Cache::Payload::Single::Instance::PayloadSingleClass
+  extend ActiveSupport::Autoload
+
+  autoload :AncestorCell
+end

--- a/lib/metasploit/cache/version.rb
+++ b/lib/metasploit/cache/version.rb
@@ -9,11 +9,11 @@ module Metasploit
       # The major version number.
       MAJOR = 0
       # The minor version number, scoped to the {MAJOR} version number.
-      MINOR = 71
+      MINOR = 72
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 2
+      PATCH = 0
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-      PRERELEASE = 'missing-batch-descendant'
+      PRERELEASE = 'payload-single-instance-ephemeral-and-load'
 
       #
       # Module Methods

--- a/spec/app/models/metasploit/cache/payload/single/class_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/class_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Metasploit::Cache::Payload::Single::Class, type: :model do
 
   context 'associations' do
     it { is_expected.to belong_to(:ancestor).class_name('Metasploit::Cache::Payload::Single::Ancestor') }
-    it { is_expected.to have_one(:payload_single_instance).class_name('Metasploit::Cache::Payload::Single::Instance').dependent(:destroy).inverse_of(:payload_single_class) }
+    it { is_expected.to have_one(:payload_single_instance).class_name('Metasploit::Cache::Payload::Single::Instance').dependent(:destroy).inverse_of(:payload_single_class).with_foreign_key(:payload_single_class_id) }
     it { is_expected.to belong_to(:rank).class_name('Metasploit::Cache::Module::Rank') }
   end
 

--- a/spec/app/models/metasploit/cache/payload/single/instance/ephemeral_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance/ephemeral_spec.rb
@@ -1,0 +1,232 @@
+RSpec.describe Metasploit::Cache::Payload::Single::Instance::Ephemeral do
+  context 'resurrecting attributes' do
+    context '#payload_single_instance' do
+      subject(:payload_single_instance) {
+        payload_single_instance_ephemeral.payload_single_instance
+      }
+
+      #
+      # lets
+      #
+
+      let(:payload_single_instance_ephemeral) {
+        described_class.new(
+            metasploit_module_instance: metasploit_module_instance
+        )
+      }
+
+      let(:metasploit_class) {
+        double(
+            'payload single Metasploit Module class',
+            ephemeral_cache_by_source: {},
+            real_path_sha1_hex_digest: existing_payload_single_instance.payload_single_class.ancestor.real_path_sha1_hex_digest
+        )
+      }
+
+      let(:metasploit_module_instance) {
+        double('payload single Metasploit Module instance').tap { |instance|
+          allow(instance).to receive(:class).and_return(metasploit_class)
+        }
+      }
+
+      #
+      # let!s
+      #
+
+      let!(:existing_payload_single_instance) {
+        FactoryGirl.create(:full_metasploit_cache_payload_single_instance)
+      }
+
+      #
+      # Callbacks
+      #
+
+      before(:each) do
+        metasploit_class.ephemeral_cache_by_source[:ancestor] = metasploit_class
+      end
+
+      it { is_expected.to be_a Metasploit::Cache::Payload::Single::Instance }
+
+      it 'has #payload_single_class matching pre-existing Metasploit::Cache::Payload::Single::Class' do
+        expect(payload_single_instance.payload_single_class).to eq(existing_payload_single_instance.payload_single_class)
+      end
+    end
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of(:logger) }
+    it { is_expected.to validate_presence_of(:metasploit_module_instance) }
+  end
+
+  context '#persist' do
+    subject(:persist) {
+      payload_single_instance_ephemeral.persist(*args)
+    }
+
+    let(:payload_single_instance_ephemeral) {
+      described_class.new(
+          logger: logger,
+          metasploit_module_instance: metasploit_module_instance
+      )
+    }
+
+    let(:metasploit_module_instance) {
+      double(
+          'payload single Metasploit Module instance',
+          arch: [
+              FactoryGirl.generate(:metasploit_cache_architecture_abbreviation)
+          ],
+          author: [
+              double(
+                  'Metasploit Module instance author',
+                  email: "#{FactoryGirl.generate(:metasploit_cache_email_address_local)}@#{FactoryGirl.generate(:metasploit_cache_email_address_domain)}",
+                  name: FactoryGirl.generate(:metasploit_cache_author_name)
+              )
+          ],
+          class: metasploit_class,
+          description: FactoryGirl.generate(:metasploit_cache_payload_single_instance_description),
+          disclosure_date: Date.today,
+          handler_klass: double(
+              'payload Metasploit Module handler',
+              general_handler_type: FactoryGirl.generate(:metasploit_cache_payload_handler_general_handler_type),
+              handler_type: FactoryGirl.generate(:metasploit_cache_payload_handler_handler_type)
+          ),
+          name: FactoryGirl.generate(:metasploit_cache_payload_single_instance_name),
+          license: FactoryGirl.generate(:metasploit_cache_license_abbreviation),
+          platform: double(
+              'Platform List',
+              platforms: [
+                  double('Platform', realname: 'Windows XP')
+              ]
+          ),
+          privileged: true
+      )
+    }
+
+    let(:logger) {
+      ActiveSupport::TaggedLogging.new(
+          Logger.new(string_io)
+      )
+    }
+
+    let(:string_io) {
+      StringIO.new
+    }
+
+    context 'with :to' do
+      let(:args) {
+        [
+            {
+                to: payload_single_instance
+            }
+        ]
+      }
+
+      let(:payload_single_class) {
+        FactoryGirl.create(:metasploit_cache_payload_single_class)
+      }
+
+      let(:payload_single_instance) {
+        payload_single_class.build_payload_single_instance
+      }
+
+      let(:metasploit_class) {
+        double(
+            'payload single Metasploit Module class',
+            ephemeral_cache_by_source: {}
+        )
+      }
+
+      it 'does not access default #payload_single_instance' do
+        expect(payload_single_instance_ephemeral).not_to receive(:payload_single_instance)
+
+        persist
+      end
+
+      it 'uses :to' do
+        expect(payload_single_instance).to receive(:batched_save).and_call_original
+
+        persist
+      end
+
+      context 'batched save' do
+        context 'failure' do
+          before(:each) do
+            payload_single_instance.valid?
+
+            expect(payload_single_instance).to receive(:batched_save).and_return(false)
+          end
+
+          it 'tags log with Metasploit::Cache::Module::Ancestor#real_path' do
+            persist
+
+            expect(string_io.string).to include("[#{payload_single_instance.payload_single_class.ancestor.real_pathname.to_s}]")
+          end
+
+          it 'logs validation errors' do
+            persist
+
+            full_error_messages = payload_single_instance.errors.full_messages.to_sentence
+
+            expect(full_error_messages).not_to be_blank
+            expect(string_io.string).to include("Could not be persisted to #{payload_single_instance.class}: #{full_error_messages}")
+          end
+        end
+
+        context 'success' do
+          specify {
+            expect {
+              persist
+            }.to change(Metasploit::Cache::Payload::Single::Instance, :count).by(1)
+          }
+        end
+      end
+    end
+
+    context 'without :to' do
+      #
+      # lets
+      #
+
+      let(:args) {
+        []
+      }
+
+      let(:metasploit_class) {
+        double(
+            'payload single Metasploit Module class',
+            ephemeral_cache_by_source: {},
+            real_path_sha1_hex_digest: existing_payload_single_instance.payload_single_class.ancestor.real_path_sha1_hex_digest
+        )
+      }
+
+      #
+      # let!s
+      #
+
+      let!(:existing_payload_single_instance) {
+        FactoryGirl.create(:full_metasploit_cache_payload_single_instance)
+      }
+
+      #
+      # Callbacks
+      #
+
+      before(:each) do
+        metasploit_class.ephemeral_cache_by_source[:ancestor] = metasploit_class
+      end
+
+      it 'defaults to #payload_single_instance' do
+        expect(payload_single_instance_ephemeral).to receive(:payload_single_instance).and_call_original
+
+        persist
+      end
+
+      it 'uses #batched_save' do
+        expect(payload_single_instance_ephemeral.payload_single_instance).to receive(:batched_save).and_call_original
+
+        persist
+      end
+    end
+  end
+end

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
     it { is_expected.to have_many(:architecturable_architectures).autosave(true).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
     it { is_expected.to have_many(:contributions).autosave(true).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
-    it { is_expected.to have_many(:licensable_licenses).autosave(true).class_name('Metasploit::Cache::Licensable::License').dependent(:destroy) }
+    it { is_expected.to have_many(:licensable_licenses).autosave(true).class_name('Metasploit::Cache::Licensable::License').dependent(:destroy).inverse_of(:licensable) }
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
     it { is_expected.to belong_to(:payload_single_class).class_name('Metasploit::Cache::Payload::Single::Class').inverse_of(:payload_single_instance).with_foreign_key(:payload_single_class_id) }
     it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
     it { is_expected.to have_many(:licensable_licenses).autosave(true).class_name('Metasploit::Cache::Licensable::License').dependent(:destroy) }
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
-    it { is_expected.to belong_to(:payload_single_class).class_name('Metasploit::Cache::Payload::Single::Class').inverse_of(:payload_single_instance) }
+    it { is_expected.to belong_to(:payload_single_class).class_name('Metasploit::Cache::Payload::Single::Class').inverse_of(:payload_single_instance).with_foreign_key(:payload_single_class_id) }
     it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }
     it { is_expected.to have_many(:platformable_platforms).autosave(true).class_name('Metasploit::Cache::Platformable::Platform').inverse_of(:platformable) }
   end

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
     it { is_expected.to have_many(:architecturable_architectures).autosave(true).class_name('Metasploit::Cache::Architecturable::Architecture').dependent(:destroy).inverse_of(:architecturable) }
     it { is_expected.to have_many(:contributions).autosave(true).class_name('Metasploit::Cache::Contribution').dependent(:destroy).inverse_of(:contributable) }
     it { is_expected.to belong_to(:handler).class_name('Metasploit::Cache::Payload::Handler').inverse_of(:payload_single_instances) }
-    it { is_expected.to have_many(:licensable_licenses).autosave(true).class_name('Metasploit::Cache::Licensable::License')}
+    it { is_expected.to have_many(:licensable_licenses).autosave(true).class_name('Metasploit::Cache::Licensable::License').dependent(:destroy) }
     it { is_expected.to have_many(:licenses).class_name('Metasploit::Cache::License')}
     it { is_expected.to belong_to(:payload_single_class).class_name('Metasploit::Cache::Payload::Single::Class').inverse_of(:payload_single_instance) }
     it { is_expected.to have_many(:platforms).class_name('Metasploit::Cache::Platform') }

--- a/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
+++ b/spec/app/models/metasploit/cache/payload/single/instance_spec.rb
@@ -29,12 +29,242 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
   end
 
   context 'factories' do
+    context 'full_metasploit_cache_payload_single_instance' do
+      subject(:full_metasploit_cache_payload_single_instance) {
+        FactoryGirl.build(:full_metasploit_cache_payload_single_instance)
+      }
+
+      it { is_expected.to be_valid }
+
+      context 'metasploit_cache_payload_single_instance_payload_single_class_ancestor_contents trait' do
+        subject(:full_metasploit_cache_payload_single_instance) {
+          FactoryGirl.build(
+              :full_metasploit_cache_payload_single_instance,
+              payload_single_class: payload_single_class
+          )
+        }
+
+        context 'with #payload_single_class' do
+          let(:payload_single_class) {
+            FactoryGirl.build(
+                :metasploit_cache_payload_single_class,
+                ancestor: payload_single_ancestor,
+                ancestor_contents?: false
+            )
+          }
+
+          context 'with Metasploit::Cache::Direct::Class#ancestor' do
+            let(:payload_single_ancestor) {
+              FactoryGirl.build(
+                  :metasploit_cache_payload_single_ancestor,
+                  content?: false,
+                  relative_path: relative_path
+              )
+            }
+
+            context 'with Metasploit::Cache::Module::Ancestor#real_pathname' do
+              let(:payload_name) {
+                FactoryGirl.generate :metasploit_cache_payload_ancestor_payload_name
+              }
+
+              let(:relative_path) {
+                "payloads/singles/#{payload_name}#{Metasploit::Cache::Module::Ancestor::EXTENSION}"
+              }
+
+              it 'writes payload_single Metasploit Module to #real_pathname' do
+                full_metasploit_cache_payload_single_instance
+
+                expect(payload_single_ancestor.real_pathname).to exist
+              end
+
+              context 'with multiple elements in each association' do
+                include_context 'Metasploit::Cache::Spec::Unload.unload'
+
+                subject(:full_metasploit_cache_payload_single_instance) {
+                  FactoryGirl.build(
+                      :metasploit_cache_payload_single_instance,
+                      :metasploit_cache_architecturable_architecturable_architectures,
+                      :metasploit_cache_contributable_contributions,
+                      :metasploit_cache_licensable_licensable_licenses,
+                      :metasploit_cache_platformable_platformable_platforms,
+                      :metasploit_cache_payload_handable_handler,
+                      :metasploit_cache_payload_single_instance_payload_single_class_ancestor_contents,
+                      architecturable_architecture_count: architecturable_architecture_count,
+                      contribution_count: contribution_count,
+                      licensable_license_count: licensable_license_count,
+                      payload_single_class: payload_single_class,
+                      platformable_platform_count: platformable_platform_count
+                  )
+                }
+
+                #
+                # lets
+                #
+
+                let(:architecturable_architecture_count) {
+                  2
+                }
+
+                let(:contribution_count) {
+                  2
+                }
+
+                let(:licensable_license_count) {
+                  2
+                }
+
+                let(:logger) {
+                  ActiveSupport::TaggedLogging.new(
+                      Logger.new(log_string_io)
+                  )
+                }
+
+                let(:log_string_io) {
+                  StringIO.new
+                }
+
+                let(:metasploit_framework) {
+                  double('Metasploit::Framework')
+                }
+
+                let(:module_ancestor_load) {
+                  Metasploit::Cache::Module::Ancestor::Load.new(
+                      # This should match the major version number of metasploit-framework
+                      maximum_version: 4,
+                      module_ancestor: payload_single_ancestor,
+                      logger: logger
+                  )
+                }
+
+                let(:module_instance_load) {
+                  Metasploit::Cache::Module::Instance::Load.new(
+                      ephemeral_class: Metasploit::Cache::Payload::Single::Instance::Ephemeral,
+                      logger: logger,
+                      metasploit_framework: metasploit_framework,
+                      metasploit_module_class: payload_direct_class_load.metasploit_class,
+                      module_instance: full_metasploit_cache_payload_single_instance
+                  )
+                }
+
+                let(:payload_direct_class_load) {
+                  Metasploit::Cache::Payload::Direct::Class::Load.new(
+                      logger: logger,
+                      metasploit_module: module_ancestor_load.metasploit_module,
+                      payload_direct_class: payload_single_class,
+                      payload_superclass: Metasploit::Cache::Direct::Class::Superclass
+                  )
+                }
+
+                let(:platformable_platform_count) {
+                  2
+                }
+
+                #
+                # Callbacks
+                #
+
+                before(:each) do
+                  # ensure file is written for encoder load
+                  full_metasploit_cache_payload_single_instance
+
+                  # remove factory records so that load is forced to populate
+                  full_metasploit_cache_payload_single_instance.architecturable_architectures = []
+                  full_metasploit_cache_payload_single_instance.contributions = []
+                  full_metasploit_cache_payload_single_instance.licensable_licenses = []
+                  full_metasploit_cache_payload_single_instance.platformable_platforms = []
+                end
+
+                it 'is loadable' do
+                  expect(module_ancestor_load).to load_metasploit_module
+
+                  expect(payload_direct_class_load).to be_valid
+                  expect(payload_single_class).to be_persisted
+
+                  expect(module_instance_load).to be_valid(:loading)
+
+                  module_instance_load.valid?
+
+                  unless full_metasploit_cache_payload_single_instance.valid?
+                    # Only covered on failure
+                    # :nocov:
+                    fail "Expected #{full_metasploit_cache_payload_single_instance.class} to be valid, but got errors:\n" \
+                         "#{full_metasploit_cache_payload_single_instance.errors.full_messages.join("\n")}\n" \
+                         "\n" \
+                         "Log:\n" \
+                         "#{log_string_io.string}\n" \
+                         "Expected #{module_instance_load.class} to be valid, but got errors:\n" \
+                         "#{module_instance_load.errors.full_messages.join("\n")}"
+                    # :nocov:
+                  end
+
+                  expect(module_instance_load).to be_valid
+                  expect(full_metasploit_cache_payload_single_instance).to be_persisted
+
+                  expect(full_metasploit_cache_payload_single_instance.architecturable_architectures.count).to eq(architecturable_architecture_count)
+                  expect(full_metasploit_cache_payload_single_instance.contributions.count).to eq(contribution_count)
+                  expect(full_metasploit_cache_payload_single_instance.licensable_licenses.count).to eq(licensable_license_count)
+                  expect(full_metasploit_cache_payload_single_instance.platformable_platforms.count).to eq(platformable_platform_count)
+                end
+              end
+            end
+
+            context 'without Metasploit::Cache::Module::Ancestor#real_pathname' do
+              let(:relative_path) {
+                nil
+              }
+
+              it 'raises ArgumentError' do
+                expect {
+                  full_metasploit_cache_payload_single_instance
+                }.to raise_error(
+                         ArgumentError,
+                         'Metasploit::Cache::Payload::Single::Ancestor#real_pathname is `nil` and content cannot be ' \
+                         'written.'
+                     )
+              end
+            end
+          end
+
+          context 'without Metasploit::Cache::Direct::Class#ancestor' do
+            let(:payload_single_ancestor) {
+              nil
+            }
+
+            it 'raises ArgumentError' do
+              expect {
+                full_metasploit_cache_payload_single_instance
+              }.to raise_error(
+                       ArgumentError,
+                       'Metasploit::Cache::Payload::Single::Class#ancestor is `nil` and content cannot be written.'
+                   )
+            end
+          end
+        end
+
+        context 'without #payload_single_class' do
+          let(:payload_single_class) {
+            nil
+          }
+
+          it 'raises ArgumentError' do
+            expect {
+              full_metasploit_cache_payload_single_instance
+            }.to raise_error(
+                     ArgumentError,
+                     "Metasploit::Cache::Payload::Single::Instance#payload_single_class is `nil` and it can't be " \
+                     'used to look up Metasploit::Cache::Direct::Class#ancestor to write content.'
+                 )
+          end
+        end
+      end
+    end
+
     context 'metasploit_cache_payload_single_instance' do
       subject(:metasploit_cache_payload_single_instance) {
         FactoryGirl.build(:metasploit_cache_payload_single_instance)
       }
 
-      it { is_expected.to be_valid }
+      it { is_expected.not_to be_valid }
     end
   end
 
@@ -47,26 +277,30 @@ RSpec.describe Metasploit::Cache::Payload::Single::Instance do
 
     it_should_behave_like 'validates at least one in association',
                           :architecturable_architectures,
-                          factory: :metasploit_cache_payload_single_instance
+                          factory: :metasploit_cache_payload_single_instance,
+                          traits: [:metasploit_cache_architecturable_architecturable_architectures]
 
     it_should_behave_like 'validates at least one in association',
                           :contributions,
-                          factory: :metasploit_cache_payload_single_instance
+                          factory: :metasploit_cache_payload_single_instance,
+                          traits: [:metasploit_cache_contributable_contributions]
 
     it_should_behave_like 'validates at least one in association',
                           :licensable_licenses,
-                          factory: :metasploit_cache_payload_single_instance
+                          factory: :metasploit_cache_payload_single_instance,
+                          traits: [:metasploit_cache_licensable_licensable_licenses]
 
     it_should_behave_like 'validates at least one in association',
                           :platformable_platforms,
-                          factory: :metasploit_cache_payload_single_instance
+                          factory: :metasploit_cache_payload_single_instance,
+                          traits: [:metasploit_cache_platformable_platformable_platforms]
 
     # validate_uniqueness_of needs a pre-existing record of the same class to work correctly when the `null: false`
     # constraints exist for other fields.
     context 'with existing record' do
       let!(:existing_payload_single_instance) {
         FactoryGirl.create(
-            :metasploit_cache_payload_single_instance
+            :full_metasploit_cache_payload_single_instance
         )
       }
 

--- a/spec/factories/metasploit/cache/payload/handable/handlers.rb
+++ b/spec/factories/metasploit/cache/payload/handable/handlers.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  trait :metasploit_cache_payload_handable_handler do
+    association :handler, factory: :metasploit_cache_payload_handler
+  end
+end

--- a/spec/factories/metasploit/cache/payload/single/instances.rb
+++ b/spec/factories/metasploit/cache/payload/single/instances.rb
@@ -1,12 +1,6 @@
 FactoryGirl.define do
   factory :metasploit_cache_payload_single_instance,
-          class: Metasploit::Cache::Payload::Single::Instance,
-          traits: [
-              :metasploit_cache_architecturable_architecturable_architectures,
-              :metasploit_cache_contributable_contributions,
-              :metasploit_cache_licensable_licensable_licenses,
-              :metasploit_cache_platformable_platformable_platforms
-          ] do
+          class: Metasploit::Cache::Payload::Single::Instance do
     description { generate :metasploit_cache_payload_single_instance_description }
     name { generate :metasploit_cache_payload_single_instance_name }
     privileged { generate :metasploit_cache_payload_single_instance_privileged }
@@ -15,8 +9,18 @@ FactoryGirl.define do
     # Associations
     #
 
-    association :handler, factory: :metasploit_cache_payload_handler
     association :payload_single_class, factory: :metasploit_cache_payload_single_class
+
+    factory :full_metasploit_cache_payload_single_instance,
+            traits: [
+                :metasploit_cache_architecturable_architecturable_architectures,
+                :metasploit_cache_contributable_contributions,
+                :metasploit_cache_licensable_licensable_licenses,
+                :metasploit_cache_payload_handable_handler,
+                :metasploit_cache_platformable_platformable_platforms,
+                # Must be after all association building traits so assocations are populated for writing contents
+                :metasploit_cache_payload_single_instance_payload_single_class_ancestor_contents
+            ]
   end
 
   #
@@ -32,4 +36,50 @@ FactoryGirl.define do
   }
 
   sequence :metasploit_cache_payload_single_instance_privileged, Metasploit::Cache::Spec.sample_stream([false, true])
+
+  #
+  # Traits
+  #
+
+  trait :metasploit_cache_payload_single_instance_payload_single_class_ancestor_contents do
+    transient do
+      payload_single_class_ancestor_metasploit_module_relative_name { generate :metasploit_cache_module_ancestor_metasploit_module_relative_name }
+    end
+
+    after(:build) do |payload_single_instance, evaluator|
+      payload_single_class = payload_single_instance.payload_single_class
+
+      if payload_single_class.nil?
+        raise ArgumentError,
+              "#{payload_single_instance.class}#payload_single_class is `nil` and it can't be used to look up " \
+                "Metasploit::Cache::Direct::Class#ancestor to write content."
+      end
+
+      payload_single_ancestor = payload_single_class.ancestor
+
+      if payload_single_ancestor.nil?
+        raise ArgumentError, "#{payload_single_class.class}#ancestor is `nil` and content cannot be written."
+      end
+
+      real_pathname = payload_single_ancestor.real_pathname
+
+      unless real_pathname
+        raise ArgumentError, "#{payload_single_ancestor.class}#real_pathname is `nil` and content cannot be written."
+      end
+
+      cell = Metasploit::Cache::Payload::Single::Instance::PayloadSingleClass::AncestorCell.(payload_single_instance)
+
+      # make directory
+      real_pathname.parent.mkpath
+
+      real_pathname.open('wb') do |f|
+        f.write(
+            cell.(
+                :show,
+                metasploit_module_relative_name: evaluator.payload_single_class_ancestor_metasploit_module_relative_name
+            )
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/metasploit/cache/payload/handable/ephemeral/handler_spec.rb
+++ b/spec/lib/metasploit/cache/payload/handable/ephemeral/handler_spec.rb
@@ -1,0 +1,164 @@
+RSpec.describe Metasploit::Cache::Payload::Handable::Ephemeral::Handler do
+  context 'destination_attributes' do
+    subject(:destination_attributes) {
+      described_class.destination_attributes(destination)
+    }
+
+    context 'with new reccord' do
+      let(:destination) {
+        Metasploit::Cache::Payload::Single::Instance.new
+      }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'with persisted record' do
+      let(:destination) {
+        FactoryGirl.create(:metasploit_cache_payload_single_instance)
+      }
+
+      it 'maps Metasploit::Cache::Payload::Handler#general_handler_type to :general_handler_type' do
+        expect(destination_attributes[:general_handler_type]).to eq(destination.handler.general_handler_type)
+      end
+
+      it 'maps Metasploit::Cache::Payload::Handler#handler_type to :handler_type' do
+        expect(destination_attributes[:handler_type]).to eq(destination.handler.handler_type)
+      end
+    end
+  end
+
+  context 'source_attributes' do
+    subject(:source_attributes) {
+      described_class.source_attributes(source)
+    }
+
+    let(:source) {
+      double(
+          'handled payload Metasploit Module instance',
+          handler_klass: double(
+              'payload Metasploit Module Handle Class',
+              general_handler_type: FactoryGirl.generate(:metasploit_cache_payload_handler_general_handler_type),
+              handler_type: FactoryGirl.generate(:metasploit_cache_payload_handler_handler_type)
+          )
+      )
+    }
+
+    it 'maps #handler_klass #general_handler_type to :general_handler_type' do
+      expect(source_attributes[:general_handler_type]).to eq(source.handler_klass.general_handler_type)
+    end
+
+    it 'maps #handler_klass #handler_type to :handler_type' do
+      expect(source_attributes[:handler_type]).to eq(source.handler_klass.handler_type)
+    end
+  end
+
+  context 'synchronize' do
+    subject(:synchronize) {
+      described_class.synchronize(
+          destination: destination,
+          logger: logger,
+          source: source
+      )
+    }
+
+    let(:logger) {
+      double('Logger')
+    }
+
+    context 'with same attributes' do
+      let(:destination) {
+        FactoryGirl.create(:metasploit_cache_payload_single_instance)
+      }
+
+      let(:source) {
+        double(
+            'single payload Metasploit Module instance',
+            handler_klass: double(
+                'Metasploit Handler Class',
+                general_handler_type: destination.handler.general_handler_type,
+                handler_type: destination.handler.handler_type
+            )
+        )
+      }
+
+      it 'does not change destination.handler' do
+        expect {
+          synchronize
+        }.not_to change(destination, :handler)
+      end
+    end
+
+    context 'without same attributes' do
+      let(:destination) {
+        Metasploit::Cache::Payload::Single::Instance.new
+      }
+
+      let(:general_handler_type) {
+        FactoryGirl.generate :metasploit_cache_payload_handler_general_handler_type
+      }
+
+      let(:handler_type) {
+        FactoryGirl.generate :metasploit_cache_payload_handler_handler_type
+      }
+
+      let(:source) {
+        double(
+            'single payload Metasploit Module instance',
+            handler_klass: double(
+                'Metasploit Handler Class',
+                general_handler_type: general_handler_type,
+                handler_type: handler_type
+            )
+        )
+      }
+
+      context 'with existing Metasploit::Cache::Payload::Handler' do
+        let!(:existing_payload_handler) {
+          FactoryGirl.create(
+              :metasploit_cache_payload_handler,
+              general_handler_type: general_handler_type,
+              handler_type: handler_type
+          )
+        }
+
+        it 'changes destination.handler to existing Metasploit::Cache::Payload::Handler' do
+          expect {
+            synchronize
+          }.to change(destination, :handler).to(existing_payload_handler)
+        end
+      end
+
+      context 'without existing Metasploit::Cache::Payload::Handler' do
+        it 'changes destination.handler' do
+          expect {
+            synchronize
+          }.to change(destination, :handler)
+        end
+
+        context 'destination.handler' do
+          subject(:destination_handler) {
+            destination.handler
+          }
+
+          #
+          # Callbacks
+          #
+
+          before(:each) do
+            synchronize
+          end
+
+          it { is_expected.to be_new_record }
+
+          it 'has source.handler_klass.general_handler_type for #general_handler_type' do
+            expect(destination_handler.general_handler_type).to eq(source.handler_klass.general_handler_type)
+          end
+
+          it 'has source.handler_klass.handler_type for #handler_type' do
+            expect(destination_handler.handler_type).to eq(source.handler_klass.handler_type)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/cache/payload/handable/ephemeral/handler_spec.rb
+++ b/spec/lib/metasploit/cache/payload/handable/ephemeral/handler_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Metasploit::Cache::Payload::Handable::Ephemeral::Handler do
 
     context 'with persisted record' do
       let(:destination) {
-        FactoryGirl.create(:metasploit_cache_payload_single_instance)
+        FactoryGirl.create(:full_metasploit_cache_payload_single_instance)
       }
 
       it 'maps Metasploit::Cache::Payload::Handler#general_handler_type to :general_handler_type' do
@@ -67,7 +67,7 @@ RSpec.describe Metasploit::Cache::Payload::Handable::Ephemeral::Handler do
 
     context 'with same attributes' do
       let(:destination) {
-        FactoryGirl.create(:metasploit_cache_payload_single_instance)
+        FactoryGirl.create(:full_metasploit_cache_payload_single_instance)
       }
 
       let(:source) {

--- a/spec/lib/metasploit/cache/payload/handler/ephemeral_spec.rb
+++ b/spec/lib/metasploit/cache/payload/handler/ephemeral_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Metasploit::Cache::Payload::Handler::Ephemeral do
+  context 'CONSTANTS' do
+    context 'ATTRIBUTE_NAMES' do
+      subject(:attribute_names) {
+        described_class::ATTRIBUTE_NAMES
+      }
+
+      it { is_expected.to include :general_handler_type }
+      it { is_expected.to include :handler_type }
+    end
+  end
+
+  context 'attributes' do
+    subject(:attributes) {
+      described_class.attributes(source)
+    }
+
+    let(:general_handler_type) {
+      FactoryGirl.generate :metasploit_cache_payload_handler_general_handler_type
+    }
+
+    let(:handler_type) {
+      FactoryGirl.generate :metasploit_cache_payload_handler_handler_type
+    }
+
+    context 'with Metasploit::Cache::Payload::Handler' do
+      let(:source) {
+        Metasploit::Cache::Payload::Handler.new(
+            general_handler_type: general_handler_type,
+            handler_type: handler_type
+        )
+      }
+
+      it 'maps #general_handler_type to :general_handler_type' do
+        expect(attributes[:general_handler_type]).to eq(general_handler_type)
+      end
+
+      it 'maps #handler_type to :handler_type' do
+        expect(attributes[:handler_type]).to eq(handler_type)
+      end
+    end
+
+    context 'with payload Metasploit Module handler_klass' do
+      let(:source) {
+        double(
+            'payload Metasploit Module handler_klass',
+            general_handler_type: general_handler_type,
+            handler_type: handler_type
+        )
+      }
+
+      it 'maps #general_handler_type to :general_handler_type' do
+        expect(attributes[:general_handler_type]).to eq(general_handler_type)
+      end
+
+      it 'maps #handler_type to :handler_type' do
+        expect(attributes[:handler_type]).to eq(handler_type)
+      end
+    end
+  end
+end


### PR DESCRIPTION
MSP-12448

# Changelog
* Enhancements
  * `Metasploit::Cache::Payload::Single::Instance::Ephemeral#persist` will persist to the `Metasploit::Cache::Payload::Single::Instance#description`, `#name`, `#privileged`, `#architecturable_architectures`, `#contributions`, `#licensable_licenses`, and `#platformable_platforms`.
  * The `:full_metasploit_cache_payload_single_instance` factory will build all associations and use the `Metasploit::Cache::Payload::single::Instance::PayloadSingleClass::AncestorCell` to render an ancestor for the single payload Metapsploit Module instance.
* Bug Fixes
  * Add `dependent: :destroy` so `Metasploit::Cache::Payload::Single::Instance#licensable_licenses` are cleaned up correctly.
  *  Add `inverse_of: :licensable` so that `build_licensable_license` builds a valid `Metasploit::Cache::Licensable::Licenses`.
* Incompatible Changes
  * The `:metasploit_cache_payload_single_instance` factory no longer builds the associations, instead use `:metasploit_cache_payload_single_instance` with the association traits (`:metasploit_cache_architecturable_architecturable_architectures`, `:metasploit_cache_contributable_contributions`, `:metasploit_cache_licensable_licensable_licenses`, `:metasploit_cache_payload_handable_handler`, `:metasploit_cache_platformable_platformable_platforms`) or the `:full_metasploit_cache_payload_single_instance` factory, which will use all the traits.

# Pre-verification Steps
- [x] Merge #69 

# Verification Steps

## Postgresql
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without sqlite3`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 100% coverage

### Documentation Coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are `@param` on scopes due to yard-activerecord bug.
- [ ] VERIFY no undocumented objects

## Sqlite3
- [ ] `rm Gemfile.lock`
- [ ] `bundle install --without postgresql`
- [ ] `rake db:drop db:create db:migrate`

### Test coverage
- [ ] `rake cucumber spec coverage`
- [ ] VERIFY no failures
- [ ] VERIFY 100% coverage

### Documentation coverage
- [ ] `rake yard:stats`
- [ ] VERIFY only `[warn]`ings are for `@param` tags for scopes that `yard-activerecord` doesn't support.
- [ ] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broken on master.

## Version
- [ ] Edit `lib/metasploit/cache/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`